### PR TITLE
fix(lint): remove unused imports and variables flagged by CI

### DIFF
--- a/src/components/mobile/screens/LeaderOverview.tsx
+++ b/src/components/mobile/screens/LeaderOverview.tsx
@@ -2,7 +2,6 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { DiscipleshipGroup } from '@/types/discipleship.types';
 import { useAuth } from '@/contexts/AuthContext';
-import { cn } from '@/lib/utils';
 import { Activity, BarChart3, ChevronRight, Users } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { MobileListItem } from '../MobileListItem';

--- a/src/pages/MobilePreviewPage.tsx
+++ b/src/pages/MobilePreviewPage.tsx
@@ -1,16 +1,4 @@
-import {
-  Activity,
-  AlertCircle,
-  BarChart3,
-  Bell,
-  DollarSign,
-  MapPin,
-  Package,
-  Plus,
-  ShoppingCart,
-  UserPlus,
-  Users,
-} from 'lucide-react';
+import { BarChart3, Bell, DollarSign, MapPin, UserPlus, Users } from 'lucide-react';
 import { MobileDashboardScreen } from '@/components/mobile/screens/DashboardScreen';
 import { MobileDiscipleshipOverview } from '@/components/mobile/screens/DiscipleshipScreen';
 import { MobileScreen } from '@/components/mobile/MobileScreen';

--- a/src/pages/dashboard/DiscipleshipPage.tsx
+++ b/src/pages/dashboard/DiscipleshipPage.tsx
@@ -442,7 +442,7 @@ const DiscipleshipPage = () => {
       ...(canViewMap ? [{ value: 'map', label: 'Mapa' }] : []),
     ];
 
-    const { state: pullState, progress: pullProgress, isRefreshing } = pullToRefresh;
+    const { state: pullState, isRefreshing } = pullToRefresh;
 
     return (
       <MobileScreen


### PR DESCRIPTION
Remove unused cn import from LeaderOverview.
Remove unused lucide icons from MobilePreviewPage. Remove unused pullProgress from DiscipleshipPage destructuring.