### PR TITLE
feat(music): PR 3 — TypeScript types, service layer, and web UI

### DIFF
--- a/src/__tests__/pages/MusicPage.test.tsx
+++ b/src/__tests__/pages/MusicPage.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import MusicPage from '@/pages/dashboard/MusicPage';
+import MusicMembers from '@/pages/dashboard/music/MusicMembers';
+import { MusicService } from '@/services/music.service';
+
+vi.mock('@/hooks/useMobileMode', () => ({
+  useMobileMode: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock('@/services/music.service', () => ({
+  MusicService: {
+    getEvents: vi.fn().mockResolvedValue([]),
+    getAssignments: vi.fn().mockResolvedValue([]),
+    getMembers: vi.fn().mockResolvedValue([]),
+    getSongStats: vi.fn().mockResolvedValue([]),
+    getMyAssignments: vi.fn().mockResolvedValue([]),
+    getMyUnavailability: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: { getSession: vi.fn().mockResolvedValue({ data: { session: null } }) },
+  },
+}));
+
+import { usePermissions } from '@/hooks/usePermissions';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function renderWithDirector() {
+  vi.mocked(usePermissions).mockReturnValue({
+    permissions: {
+      role: 'pastor',
+      role_level: 400,
+      has_admin_access: true,
+      installed_modules: ['music'],
+    },
+    loading: false,
+    isLoading: false,
+    hasAccess: () => true,
+    canManageRoles: true,
+    canManageUsers: true,
+    refresh: vi.fn(),
+  });
+  return render(<MusicPage />, { wrapper });
+}
+
+function renderWithServidor() {
+  vi.mocked(usePermissions).mockReturnValue({
+    permissions: {
+      role: 'member',
+      role_level: 0,
+      has_admin_access: false,
+      installed_modules: ['music'],
+    },
+    loading: false,
+    isLoading: false,
+    hasAccess: () => false,
+    canManageRoles: false,
+    canManageUsers: false,
+    refresh: vi.fn(),
+  });
+  return render(<MusicPage />, { wrapper });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(MusicService.getEvents).mockResolvedValue([]);
+  vi.mocked(MusicService.getMembers).mockResolvedValue([]);
+  vi.mocked(MusicService.getSongStats).mockResolvedValue([]);
+  vi.mocked(MusicService.getMyAssignments).mockResolvedValue([]);
+  vi.mocked(MusicService.getMyUnavailability).mockResolvedValue([]);
+});
+
+describe('MusicPage — director role', () => {
+  test('shows all 4 tabs for director', () => {
+    renderWithDirector();
+
+    expect(screen.getByRole('tab', { name: 'Cronograma' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Cultos' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Integrantes' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Canciones' })).toBeInTheDocument();
+  });
+
+  test('does not show servidor-only view for director', () => {
+    renderWithDirector();
+
+    expect(screen.queryByText('Mis cultos')).not.toBeInTheDocument();
+    expect(screen.queryByText('Mis indisponibilidades')).not.toBeInTheDocument();
+  });
+});
+
+describe('MusicPage — servidor role', () => {
+  test('shows Mis cultos and Mis indisponibilidades for servidor', () => {
+    renderWithServidor();
+
+    expect(screen.getByText('Mis cultos')).toBeInTheDocument();
+    expect(screen.getByText('Mis indisponibilidades')).toBeInTheDocument();
+  });
+
+  test('does not show director tabs for servidor', () => {
+    renderWithServidor();
+
+    expect(screen.queryByRole('tab', { name: 'Cronograma' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Cultos' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Integrantes' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Canciones' })).not.toBeInTheDocument();
+  });
+});
+
+function renderMembers(isDirector: boolean) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MusicMembers isDirector={isDirector} />
+    </QueryClientProvider>
+  );
+}
+
+describe('MusicMembers — instrument field visibility', () => {
+  beforeEach(() => {
+    vi.mocked(MusicService.getMembers).mockResolvedValue([]);
+  });
+
+  test('instrument input absent initially (no dialog open)', async () => {
+    renderMembers(true);
+    await screen.findByRole('button', { name: /agregar/i });
+    expect(screen.queryByLabelText('Instrumento')).not.toBeInTheDocument();
+  });
+
+  test('instrument input absent when only corista is checked', async () => {
+    renderMembers(true);
+    const addBtn = await screen.findByRole('button', { name: /agregar/i });
+    fireEvent.click(addBtn);
+
+    const coristaCheckbox = await screen.findByLabelText('Corista');
+    fireEvent.click(coristaCheckbox);
+
+    expect(screen.queryByLabelText('Instrumento')).not.toBeInTheDocument();
+  });
+
+  test('instrument input present when musico is checked', async () => {
+    renderMembers(true);
+    const addBtn = await screen.findByRole('button', { name: /agregar/i });
+    fireEvent.click(addBtn);
+
+    const musicoCheckbox = await screen.findByLabelText('Músico');
+    fireEvent.click(musicoCheckbox);
+
+    expect(screen.getByLabelText('Instrumento')).toBeInTheDocument();
+  });
+
+  test('instrument input disappears when musico is unchecked', async () => {
+    renderMembers(true);
+    const addBtn = await screen.findByRole('button', { name: /agregar/i });
+    fireEvent.click(addBtn);
+
+    const musicoCheckbox = await screen.findByLabelText('Músico');
+    fireEvent.click(musicoCheckbox);
+    expect(screen.getByLabelText('Instrumento')).toBeInTheDocument();
+
+    fireEvent.click(musicoCheckbox);
+    expect(screen.queryByLabelText('Instrumento')).not.toBeInTheDocument();
+  });
+});
+
+describe('MusicPage — assignment state badge colors', () => {
+  test('no_puedo assignment uses destructive badge', async () => {
+    vi.mocked(MusicService.getMyAssignments).mockResolvedValue([
+      {
+        id: 'a1',
+        eventId: 'e1',
+        memberId: 'm1',
+        funcion: 'corista',
+        state: 'no_puedo',
+        assignedBy: null,
+      },
+    ]);
+
+    renderWithServidor();
+
+    const badge = await screen.findByText('No puedo');
+    expect(badge).toBeInTheDocument();
+  });
+
+  test('confirmado assignment uses default (success) badge', async () => {
+    vi.mocked(MusicService.getMyAssignments).mockResolvedValue([
+      {
+        id: 'a2',
+        eventId: 'e1',
+        memberId: 'm1',
+        funcion: 'corista',
+        state: 'confirmado',
+        assignedBy: null,
+      },
+    ]);
+
+    renderWithServidor();
+
+    const badge = await screen.findByText('Confirmado');
+    expect(badge).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/services/music.service.test.ts
+++ b/src/__tests__/services/music.service.test.ts
@@ -1,0 +1,199 @@
+import { MusicService } from '@/services/music.service';
+import { ApiService } from '@/services/api.service';
+
+vi.mock('@/services/api.service', () => ({
+  ApiService: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MusicService.createMember — payload shape', () => {
+  test('sends userId as user_id, funciones array, and instrument', async () => {
+    const raw = {
+      id: 'm1',
+      user_id: 'u1',
+      funciones: ['musico'],
+      instrument: 'guitarra',
+      is_active: true,
+      created_at: '2026-01-01T00:00:00Z',
+    };
+    vi.mocked(ApiService.post).mockResolvedValue(raw);
+
+    const result = await MusicService.createMember({
+      userId: 'u1',
+      funciones: ['musico'],
+      instrument: 'guitarra',
+    });
+
+    expect(ApiService.post).toHaveBeenCalledWith('/music/members', {
+      user_id: 'u1',
+      funciones: ['musico'],
+      instrument: 'guitarra',
+    });
+
+    expect(result.userId).toBe('u1');
+    expect(result.funciones).toEqual(['musico']);
+    expect(result.instrument).toBe('guitarra');
+  });
+
+  test('sends multiple funciones correctly', async () => {
+    const raw = {
+      id: 'm2',
+      user_id: 'u2',
+      funciones: ['corista', 'musico'],
+      instrument: 'piano',
+      is_active: true,
+      created_at: '2026-01-01T00:00:00Z',
+    };
+    vi.mocked(ApiService.post).mockResolvedValue(raw);
+
+    await MusicService.createMember({
+      userId: 'u2',
+      funciones: ['corista', 'musico'],
+      instrument: 'piano',
+    });
+
+    const [, body] = vi.mocked(ApiService.post).mock.calls[0];
+    expect((body as { funciones: string[] }).funciones).toEqual(['corista', 'musico']);
+  });
+
+  test('sends null instrument when not musico', async () => {
+    const raw = {
+      id: 'm3',
+      user_id: 'u3',
+      funciones: ['corista'],
+      instrument: null,
+      is_active: true,
+      created_at: '2026-01-01T00:00:00Z',
+    };
+    vi.mocked(ApiService.post).mockResolvedValue(raw);
+
+    await MusicService.createMember({
+      userId: 'u3',
+      funciones: ['corista'],
+      instrument: null,
+    });
+
+    const [, body] = vi.mocked(ApiService.post).mock.calls[0];
+    expect((body as { instrument: null }).instrument).toBeNull();
+  });
+});
+
+describe('MusicService.createAssignment — maps unavailability_warning', () => {
+  test('maps snake_case unavailability_warning → camelCase unavailabilityWarning: true', async () => {
+    const rawAssignment = {
+      id: 'a1',
+      event_id: 'e1',
+      member_id: 'm1',
+      funcion: 'corista',
+      state: 'asignado',
+      assigned_by: 'director-id',
+    };
+    vi.mocked(ApiService.post).mockResolvedValue({
+      assignment: rawAssignment,
+      unavailability_warning: true,
+    });
+
+    const result = await MusicService.createAssignment('e1', {
+      memberId: 'm1',
+      funcion: 'corista',
+    });
+
+    expect(result.unavailabilityWarning).toBe(true);
+    expect(result.assignment.id).toBe('a1');
+    expect(result.assignment.funcion).toBe('corista');
+    expect(result.assignment.state).toBe('asignado');
+  });
+
+  test('maps unavailability_warning: false correctly', async () => {
+    const rawAssignment = {
+      id: 'a2',
+      event_id: 'e1',
+      member_id: 'm2',
+      funcion: 'musico',
+      state: 'asignado',
+      assigned_by: null,
+    };
+    vi.mocked(ApiService.post).mockResolvedValue({
+      assignment: rawAssignment,
+      unavailability_warning: false,
+    });
+
+    const result = await MusicService.createAssignment('e1', { memberId: 'm2', funcion: 'musico' });
+
+    expect(result.unavailabilityWarning).toBe(false);
+  });
+
+  test('sends correct payload to API', async () => {
+    const rawAssignment = {
+      id: 'a3',
+      event_id: 'ev-123',
+      member_id: 'mem-456',
+      funcion: 'tecnico',
+      state: 'asignado',
+      assigned_by: null,
+    };
+    vi.mocked(ApiService.post).mockResolvedValue({
+      assignment: rawAssignment,
+      unavailability_warning: false,
+    });
+
+    await MusicService.createAssignment('ev-123', { memberId: 'mem-456', funcion: 'tecnico' });
+
+    expect(ApiService.post).toHaveBeenCalledWith('/music/events/ev-123/assignments', {
+      member_id: 'mem-456',
+      funcion: 'tecnico',
+    });
+  });
+});
+
+describe('MusicService.getSongs — query param', () => {
+  test('without q → no query string', async () => {
+    vi.mocked(ApiService.get).mockResolvedValue([]);
+
+    await MusicService.getSongs();
+
+    expect(ApiService.get).toHaveBeenCalledWith('/music/songs');
+  });
+
+  test('with q → appends ?q= encoded', async () => {
+    vi.mocked(ApiService.get).mockResolvedValue([]);
+
+    await MusicService.getSongs('Oceans');
+
+    expect(ApiService.get).toHaveBeenCalledWith('/music/songs?q=Oceans');
+  });
+
+  test('q with spaces → URL-encoded', async () => {
+    vi.mocked(ApiService.get).mockResolvedValue([]);
+
+    await MusicService.getSongs('great is');
+
+    expect(ApiService.get).toHaveBeenCalledWith('/music/songs?q=great%20is');
+  });
+
+  test('maps name_normalized to nameNormalized in response', async () => {
+    vi.mocked(ApiService.get).mockResolvedValue([
+      {
+        id: 's1',
+        name: 'Oceans',
+        name_normalized: 'oceans',
+        author: null,
+        default_key: null,
+        historical_key: 'G',
+      },
+    ]);
+
+    const result = await MusicService.getSongs('Oceans');
+
+    expect(result[0].nameNormalized).toBe('oceans');
+    expect(result[0].historicalKey).toBe('G');
+  });
+});

--- a/src/pages/dashboard/MusicPage.tsx
+++ b/src/pages/dashboard/MusicPage.tsx
@@ -1,0 +1,740 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Plus, Calendar } from 'lucide-react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useMobileMode } from '@/hooks/useMobileMode';
+import { usePermissions } from '@/hooks/usePermissions';
+import { MusicService } from '@/services/music.service';
+import { AssignmentStates, MusicEventTypes } from '@/types/music.types';
+import type {
+  MusicAssignment,
+  MusicEvent,
+  AssignmentState,
+  MusicEventType,
+  CreateEventRequest,
+  BatchQuarterRequest,
+  UpdateAssignmentRequest,
+  CreateUnavailabilityRequest,
+} from '@/types/music.types';
+import MusicMembers from './music/MusicMembers';
+
+function useMusicAccess() {
+  const { permissions } = usePermissions();
+  const isDirector =
+    !!permissions &&
+    (permissions.has_admin_access || permissions.role === 'pastor' || permissions.role === 'staff');
+  return { isDirector };
+}
+
+const STATE_VARIANT: Record<AssignmentState, 'default' | 'secondary' | 'destructive'> = {
+  asignado: 'secondary',
+  confirmado: 'default',
+  no_puedo: 'destructive',
+};
+
+const STATE_LABEL: Record<AssignmentState, string> = {
+  asignado: 'Asignado',
+  confirmado: 'Confirmado',
+  no_puedo: 'No puedo',
+};
+
+const EVENT_TYPE_LABEL: Record<MusicEventType, string> = {
+  viernes: 'Viernes',
+  domingo: 'Domingo',
+  especial: 'Especial',
+};
+
+function AssignmentBadge({ state }: { state: AssignmentState }) {
+  return (
+    <Badge variant={STATE_VARIANT[state]} className="text-xs">
+      {STATE_LABEL[state]}
+    </Badge>
+  );
+}
+
+function CronogramaTab({ isDirector }: { isDirector: boolean }) {
+  const { data: events = [], isLoading } = useQuery({
+    queryKey: ['music-events'],
+    queryFn: () => MusicService.getEvents(),
+  });
+
+  if (isLoading)
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map(i => (
+          <Skeleton key={i} className="h-24 w-full" />
+        ))}
+      </div>
+    );
+
+  const upcoming = events
+    .filter(e => e.eventDate >= new Date().toISOString().slice(0, 10))
+    .slice(0, 20);
+
+  if (upcoming.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-8">No hay cultos próximos.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {upcoming.map(event => (
+        <EventAssignmentCard key={event.id} event={event} isDirector={isDirector} />
+      ))}
+    </div>
+  );
+}
+
+function EventAssignmentCard({ event, isDirector }: { event: MusicEvent; isDirector: boolean }) {
+  const qc = useQueryClient();
+  const { data: assignments = [] } = useQuery({
+    queryKey: ['music-assignments', event.id],
+    queryFn: () => MusicService.getAssignments(event.id),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateAssignmentRequest }) =>
+      MusicService.updateAssignment(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-assignments', event.id] });
+    },
+    onError: () => toast.error('No se pudo actualizar el estado'),
+  });
+
+  const byFuncion = assignments.reduce<Record<string, MusicAssignment[]>>((acc, a) => {
+    (acc[a.funcion] ??= []).push(a);
+    return acc;
+  }, {});
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium">
+            {event.eventDate} — {EVENT_TYPE_LABEL[event.eventType]}
+            {event.title ? ` — ${event.title}` : ''}
+          </CardTitle>
+          {event.published && (
+            <Badge variant="secondary" className="text-xs">
+              Publicado
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {Object.entries(byFuncion).map(([funcion, list]) => (
+          <div key={funcion} className="mb-2">
+            <p className="text-xs text-muted-foreground mb-1 capitalize">{funcion}</p>
+            <div className="space-y-1">
+              {list.map(a => (
+                <div key={a.id} className="flex items-center justify-between">
+                  <span className="text-sm">{a.memberName ?? a.memberId}</span>
+                  <div className="flex items-center gap-2">
+                    <AssignmentBadge state={a.state} />
+                    {!isDirector && a.state !== 'no_puedo' && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-6 text-xs px-2"
+                        onClick={() =>
+                          updateMutation.mutate({ id: a.id, data: { state: 'no_puedo' } })
+                        }
+                        disabled={updateMutation.isPending}
+                      >
+                        No puedo
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+        {assignments.length === 0 && (
+          <p className="text-xs text-muted-foreground">Sin asignaciones.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CultosTab({ isDirector }: { isDirector: boolean }) {
+  const qc = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [batchOpen, setBatchOpen] = useState(false);
+  const [form, setForm] = useState<{ eventDate: string; eventType: MusicEventType; title: string }>(
+    {
+      eventDate: '',
+      eventType: 'domingo',
+      title: '',
+    }
+  );
+  const [batchForm, setBatchForm] = useState<{ year: string; quarter: string }>({
+    year: String(new Date().getFullYear()),
+    quarter: '1',
+  });
+
+  const { data: events = [], isLoading } = useQuery({
+    queryKey: ['music-events'],
+    queryFn: () => MusicService.getEvents(),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateEventRequest) => MusicService.createEvent(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-events'] });
+      setCreateOpen(false);
+      setForm({ eventDate: '', eventType: 'domingo', title: '' });
+      toast.success('Culto creado');
+    },
+    onError: () => toast.error('No se pudo crear el culto'),
+  });
+
+  const batchMutation = useMutation({
+    mutationFn: (data: BatchQuarterRequest) => MusicService.batchCreateQuarter(data),
+    onSuccess: result => {
+      qc.invalidateQueries({ queryKey: ['music-events'] });
+      setBatchOpen(false);
+      toast.success(`Creados: ${result.created}, omitidos: ${result.skipped}`);
+    },
+    onError: () => toast.error('No se pudo generar el trimestre'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => MusicService.deleteEvent(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-events'] });
+      toast.success('Culto eliminado');
+    },
+    onError: () => toast.error('No se pudo eliminar el culto'),
+  });
+
+  function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.eventDate) {
+      toast.error('La fecha es requerida');
+      return;
+    }
+    createMutation.mutate({
+      eventDate: form.eventDate,
+      eventType: form.eventType,
+      title: form.title || undefined,
+    });
+  }
+
+  function handleBatch(e: React.FormEvent) {
+    e.preventDefault();
+    batchMutation.mutate({
+      year: Number(batchForm.year),
+      quarter: Number(batchForm.quarter) as 1 | 2 | 3 | 4,
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+        <CardTitle className="text-base">Cultos</CardTitle>
+        {isDirector && (
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setBatchOpen(true)}
+              className="gap-1"
+            >
+              <Calendar className="h-4 w-4" />
+              Trimestre
+            </Button>
+            <Button size="sm" onClick={() => setCreateOpen(true)} className="gap-1">
+              <Plus className="h-4 w-4" />
+              Nuevo
+            </Button>
+          </div>
+        )}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map(i => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : events.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-6">
+            No hay cultos registrados.
+          </p>
+        ) : (
+          <div className="divide-y divide-border">
+            {events.map(ev => (
+              <div key={ev.id} className="flex items-center justify-between py-3">
+                <div>
+                  <span className="font-medium text-sm">{ev.eventDate}</span>
+                  <span className="text-muted-foreground text-sm ml-2">
+                    {EVENT_TYPE_LABEL[ev.eventType]}
+                  </span>
+                  {ev.title && <span className="text-sm ml-2">{ev.title}</span>}
+                </div>
+                <div className="flex items-center gap-2">
+                  {ev.published && (
+                    <Badge variant="secondary" className="text-xs">
+                      Publicado
+                    </Badge>
+                  )}
+                  {isDirector && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 text-xs text-destructive"
+                      onClick={() => deleteMutation.mutate(ev.id)}
+                      disabled={deleteMutation.isPending}
+                    >
+                      Eliminar
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Nuevo culto</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleCreate} className="space-y-4">
+            <div className="space-y-1">
+              <Label htmlFor="ev-date">Fecha</Label>
+              <Input
+                id="ev-date"
+                type="date"
+                value={form.eventDate}
+                onChange={e => setForm(p => ({ ...p, eventDate: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Tipo</Label>
+              <Select
+                value={form.eventType}
+                onValueChange={v => setForm(p => ({ ...p, eventType: v as MusicEventType }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(MusicEventTypes) as MusicEventType[]).map(t => (
+                    <SelectItem key={t} value={t}>
+                      {EVENT_TYPE_LABEL[t]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="ev-title">Título (opcional)</Label>
+              <Input
+                id="ev-title"
+                value={form.title}
+                onChange={e => setForm(p => ({ ...p, title: e.target.value }))}
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={createMutation.isPending}>
+                {createMutation.isPending ? 'Creando…' : 'Crear'}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={batchOpen} onOpenChange={setBatchOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Generar trimestre</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleBatch} className="space-y-4">
+            <div className="space-y-1">
+              <Label htmlFor="batch-year">Año</Label>
+              <Input
+                id="batch-year"
+                type="number"
+                min="2020"
+                max="2100"
+                value={batchForm.year}
+                onChange={e => setBatchForm(p => ({ ...p, year: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Trimestre</Label>
+              <Select
+                value={batchForm.quarter}
+                onValueChange={v => setBatchForm(p => ({ ...p, quarter: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="1">Q1 — Ene/Mar</SelectItem>
+                  <SelectItem value="2">Q2 — Abr/Jun</SelectItem>
+                  <SelectItem value="3">Q3 — Jul/Sep</SelectItem>
+                  <SelectItem value="4">Q4 — Oct/Dic</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => setBatchOpen(false)}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={batchMutation.isPending}>
+                {batchMutation.isPending ? 'Generando…' : 'Generar'}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
+
+function CancionesTab() {
+  const { data: stats = [], isLoading } = useQuery({
+    queryKey: ['music-song-stats'],
+    queryFn: () => MusicService.getSongStats(50),
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Canciones</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            {[1, 2, 3, 4].map(i => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : stats.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-6">
+            No hay canciones en el repertorio.
+          </p>
+        ) : (
+          <div className="divide-y divide-border">
+            {stats.map(s => (
+              <div key={s.id} className="flex items-center justify-between py-3">
+                <div className="min-w-0">
+                  <p className="font-medium text-sm truncate">{s.name}</p>
+                  {s.lastPlayedDate && (
+                    <p className="text-xs text-muted-foreground">Último: {s.lastPlayedDate}</p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 shrink-0 ml-2">
+                  {s.historicalKey && (
+                    <Badge variant="outline" className="text-xs">
+                      {s.historicalKey}
+                    </Badge>
+                  )}
+                  <Badge variant="secondary" className="text-xs">
+                    {s.timesPlayed}×
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ServidorView() {
+  const qc = useQueryClient();
+  const [unavailOpen, setUnavailOpen] = useState(false);
+  const [unavailForm, setUnavailForm] = useState<{
+    startDate: string;
+    endDate: string;
+    reason: string;
+  }>({
+    startDate: '',
+    endDate: '',
+    reason: '',
+  });
+
+  const { data: myAssignments = [], isLoading: loadingAssignments } = useQuery({
+    queryKey: ['music-my-assignments'],
+    queryFn: () => MusicService.getMyAssignments(),
+  });
+
+  const { data: myUnavailability = [], isLoading: loadingUnavail } = useQuery({
+    queryKey: ['music-my-unavailability'],
+    queryFn: () => MusicService.getMyUnavailability(),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateAssignmentRequest }) =>
+      MusicService.updateAssignment(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-my-assignments'] });
+      toast.success('Estado actualizado');
+    },
+    onError: () => toast.error('No se pudo actualizar'),
+  });
+
+  const createUnavailMutation = useMutation({
+    mutationFn: ({ memberId, data }: { memberId: string; data: CreateUnavailabilityRequest }) =>
+      MusicService.createUnavailability(memberId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-my-unavailability'] });
+      setUnavailOpen(false);
+      setUnavailForm({ startDate: '', endDate: '', reason: '' });
+      toast.success('Indisponibilidad registrada');
+    },
+    onError: () => toast.error('No se pudo registrar'),
+  });
+
+  const deleteUnavailMutation = useMutation({
+    mutationFn: (id: string) => MusicService.deleteUnavailability(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-my-unavailability'] });
+      toast.success('Indisponibilidad eliminada');
+    },
+    onError: () => toast.error('No se pudo eliminar'),
+  });
+
+  function handleUnavailSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!unavailForm.startDate) {
+      toast.error('La fecha de inicio es requerida');
+      return;
+    }
+    createUnavailMutation.mutate({
+      memberId: 'me',
+      data: {
+        startDate: unavailForm.startDate,
+        endDate: unavailForm.endDate || null,
+        reason: unavailForm.reason || undefined,
+      },
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Mis cultos</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loadingAssignments ? (
+            <div className="space-y-2">
+              {[1, 2, 3].map(i => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : myAssignments.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-6">
+              No tenés cultos asignados.
+            </p>
+          ) : (
+            <div className="divide-y divide-border">
+              {myAssignments.map(a => (
+                <div key={a.id} className="flex items-center justify-between py-3">
+                  <div>
+                    <p className="text-sm font-medium capitalize">{a.funcion}</p>
+                    <p className="text-xs text-muted-foreground">{a.eventId}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <AssignmentBadge state={a.state} />
+                    {a.state !== AssignmentStates.no_puedo && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs"
+                        onClick={() =>
+                          updateMutation.mutate({ id: a.id, data: { state: 'no_puedo' } })
+                        }
+                        disabled={updateMutation.isPending}
+                      >
+                        No puedo
+                      </Button>
+                    )}
+                    {a.state === AssignmentStates.asignado && (
+                      <Button
+                        size="sm"
+                        variant="default"
+                        className="h-7 text-xs"
+                        onClick={() =>
+                          updateMutation.mutate({ id: a.id, data: { state: 'confirmado' } })
+                        }
+                        disabled={updateMutation.isPending}
+                      >
+                        Confirmar
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+          <CardTitle className="text-base">Mis indisponibilidades</CardTitle>
+          <Button size="sm" onClick={() => setUnavailOpen(true)} className="gap-1">
+            <Plus className="h-4 w-4" />
+            Agregar
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {loadingUnavail ? (
+            <div className="space-y-2">
+              {[1, 2].map(i => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : myUnavailability.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-6">
+              No tenés indisponibilidades registradas.
+            </p>
+          ) : (
+            <div className="divide-y divide-border">
+              {myUnavailability.map(u => (
+                <div key={u.id} className="flex items-center justify-between py-3">
+                  <div>
+                    <p className="text-sm">
+                      {u.startDate}
+                      {u.endDate ? ` → ${u.endDate}` : ' (indefinida)'}
+                    </p>
+                    {u.reason && <p className="text-xs text-muted-foreground">{u.reason}</p>}
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 text-xs text-destructive"
+                    onClick={() => deleteUnavailMutation.mutate(u.id)}
+                    disabled={deleteUnavailMutation.isPending}
+                  >
+                    Eliminar
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={unavailOpen} onOpenChange={setUnavailOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Registrar indisponibilidad</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleUnavailSubmit} className="space-y-4">
+            <div className="space-y-1">
+              <Label htmlFor="u-start">Fecha inicio</Label>
+              <Input
+                id="u-start"
+                type="date"
+                value={unavailForm.startDate}
+                onChange={e => setUnavailForm(p => ({ ...p, startDate: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="u-end">Fecha fin (opcional)</Label>
+              <Input
+                id="u-end"
+                type="date"
+                value={unavailForm.endDate}
+                onChange={e => setUnavailForm(p => ({ ...p, endDate: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="u-reason">Motivo (opcional)</Label>
+              <Input
+                id="u-reason"
+                value={unavailForm.reason}
+                onChange={e => setUnavailForm(p => ({ ...p, reason: e.target.value }))}
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => setUnavailOpen(false)}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={createUnavailMutation.isPending}>
+                {createUnavailMutation.isPending ? 'Guardando…' : 'Guardar'}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+export default function MusicPage() {
+  const isMobileApp = useMobileMode();
+  const { isDirector } = useMusicAccess();
+
+  if (isMobileApp) return null;
+
+  if (!isDirector) {
+    return (
+      <div className="space-y-4 animate-fade-in p-3 sm:p-4 md:p-6">
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Música</h1>
+          <p className="text-sm text-muted-foreground">Módulo de equipo de alabanza</p>
+        </div>
+        <ServidorView />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 animate-fade-in p-3 sm:p-4 md:p-6">
+      <div>
+        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Música</h1>
+        <p className="text-sm text-muted-foreground">Gestión del equipo de alabanza</p>
+      </div>
+      <Tabs defaultValue="cronograma">
+        <TabsList className="w-full sm:w-auto">
+          <TabsTrigger value="cronograma">Cronograma</TabsTrigger>
+          <TabsTrigger value="cultos">Cultos</TabsTrigger>
+          <TabsTrigger value="integrantes">Integrantes</TabsTrigger>
+          <TabsTrigger value="canciones">Canciones</TabsTrigger>
+        </TabsList>
+        <TabsContent value="cronograma" className="mt-4">
+          <CronogramaTab isDirector={isDirector} />
+        </TabsContent>
+        <TabsContent value="cultos" className="mt-4">
+          <CultosTab isDirector={isDirector} />
+        </TabsContent>
+        <TabsContent value="integrantes" className="mt-4">
+          <MusicMembers isDirector={isDirector} />
+        </TabsContent>
+        <TabsContent value="canciones" className="mt-4">
+          <CancionesTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/pages/dashboard/music/MusicMembers.tsx
+++ b/src/pages/dashboard/music/MusicMembers.tsx
@@ -1,0 +1,282 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Plus, Pencil, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { MusicService } from '@/services/music.service';
+import { Funciones } from '@/types/music.types';
+import type {
+  MusicMember,
+  Funcion,
+  CreateMemberRequest,
+  UpdateMemberRequest,
+} from '@/types/music.types';
+
+const FUNCION_LABELS: Record<Funcion, string> = {
+  corista: 'Corista',
+  musico: 'Músico',
+  tecnico: 'Técnico',
+  danzarina: 'Danzarina',
+};
+
+interface MemberFormState {
+  userId: string;
+  funciones: Funcion[];
+  instrument: string;
+}
+
+interface MemberFormProps {
+  initial?: MusicMember;
+  onSave: (data: CreateMemberRequest | UpdateMemberRequest) => void;
+  onCancel: () => void;
+  saving: boolean;
+}
+
+function MemberForm({ initial, onSave, onCancel, saving }: MemberFormProps) {
+  const [form, setForm] = useState<MemberFormState>({
+    userId: initial?.userId ?? '',
+    funciones: initial?.funciones ?? [],
+    instrument: initial?.instrument ?? '',
+  });
+
+  function toggleFuncion(f: Funcion) {
+    setForm(prev => ({
+      ...prev,
+      funciones: prev.funciones.includes(f)
+        ? prev.funciones.filter(x => x !== f)
+        : [...prev.funciones, f],
+    }));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!initial && !form.userId.trim()) {
+      toast.error('El ID de usuario es requerido');
+      return;
+    }
+    if (form.funciones.length === 0) {
+      toast.error('Seleccioná al menos una función');
+      return;
+    }
+    const instrument = form.funciones.includes('musico') ? form.instrument.trim() || null : null;
+    if (initial) {
+      onSave({ funciones: form.funciones, instrument } as UpdateMemberRequest);
+    } else {
+      onSave({
+        userId: form.userId.trim(),
+        funciones: form.funciones,
+        instrument,
+      } as CreateMemberRequest);
+    }
+  }
+
+  const showInstrument = form.funciones.includes('musico');
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {!initial && (
+        <div className="space-y-1">
+          <Label htmlFor="userId">ID de usuario</Label>
+          <Input
+            id="userId"
+            value={form.userId}
+            onChange={e => setForm(prev => ({ ...prev, userId: e.target.value }))}
+            placeholder="UUID del usuario"
+          />
+        </div>
+      )}
+      <div className="space-y-2">
+        <Label>Funciones</Label>
+        <div className="grid grid-cols-2 gap-2">
+          {(Object.keys(Funciones) as Funcion[]).map(f => (
+            <div key={f} className="flex items-center gap-2">
+              <Checkbox
+                id={`funcion-${f}`}
+                checked={form.funciones.includes(f)}
+                onCheckedChange={() => toggleFuncion(f)}
+              />
+              <Label htmlFor={`funcion-${f}`} className="cursor-pointer font-normal">
+                {FUNCION_LABELS[f]}
+              </Label>
+            </div>
+          ))}
+        </div>
+      </div>
+      {showInstrument && (
+        <div className="space-y-1">
+          <Label htmlFor="instrument">Instrumento</Label>
+          <Input
+            id="instrument"
+            value={form.instrument}
+            onChange={e => setForm(prev => ({ ...prev, instrument: e.target.value }))}
+            placeholder="Ej: guitarra, piano, batería"
+          />
+        </div>
+      )}
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={saving}>
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? 'Guardando…' : 'Guardar'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+interface MusicMembersProps {
+  isDirector: boolean;
+}
+
+export default function MusicMembers({ isDirector }: MusicMembersProps) {
+  const qc = useQueryClient();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<MusicMember | null>(null);
+
+  const { data: members = [], isLoading } = useQuery({
+    queryKey: ['music-members'],
+    queryFn: () => MusicService.getMembers(),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateMemberRequest) => MusicService.createMember(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-members'] });
+      setDialogOpen(false);
+      toast.success('Integrante agregado');
+    },
+    onError: () => toast.error('No se pudo agregar el integrante'),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateMemberRequest }) =>
+      MusicService.updateMember(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-members'] });
+      setDialogOpen(false);
+      setEditing(null);
+      toast.success('Integrante actualizado');
+    },
+    onError: () => toast.error('No se pudo actualizar el integrante'),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => MusicService.deleteMember(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-members'] });
+      toast.success('Integrante eliminado');
+    },
+    onError: () => toast.error('No se pudo eliminar el integrante'),
+  });
+
+  function openCreate() {
+    setEditing(null);
+    setDialogOpen(true);
+  }
+
+  function openEdit(m: MusicMember) {
+    setEditing(m);
+    setDialogOpen(true);
+  }
+
+  function handleSave(data: CreateMemberRequest | UpdateMemberRequest) {
+    if (editing) {
+      updateMutation.mutate({ id: editing.id, data: data as UpdateMemberRequest });
+    } else {
+      createMutation.mutate(data as CreateMemberRequest);
+    }
+  }
+
+  const saving = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+        <CardTitle className="text-base">Integrantes</CardTitle>
+        {isDirector && (
+          <Button size="sm" onClick={openCreate} className="gap-1">
+            <Plus className="h-4 w-4" />
+            Agregar
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map(i => (
+              <Skeleton key={i} className="h-12 w-full" />
+            ))}
+          </div>
+        ) : members.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-6">
+            No hay integrantes registrados.
+          </p>
+        ) : (
+          <div className="divide-y divide-border">
+            {members.map(m => (
+              <div key={m.id} className="flex items-center justify-between py-3">
+                <div className="min-w-0">
+                  <p className="font-medium text-sm truncate">{m.name ?? m.userId}</p>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {m.funciones.map(f => (
+                      <Badge key={f} variant="secondary" className="text-xs">
+                        {FUNCION_LABELS[f]}
+                        {f === 'musico' && m.instrument ? ` — ${m.instrument}` : ''}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                {isDirector && (
+                  <div className="flex gap-1 shrink-0 ml-2">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-8 w-8"
+                      onClick={() => openEdit(m)}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-8 w-8 text-destructive"
+                      onClick={() => deleteMutation.mutate(m.id)}
+                      disabled={deleteMutation.isPending}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editing ? 'Editar integrante' : 'Nuevo integrante'}</DialogTitle>
+          </DialogHeader>
+          <MemberForm
+            initial={editing ?? undefined}
+            onSave={handleSave}
+            onCancel={() => {
+              setDialogOpen(false);
+              setEditing(null);
+            }}
+            saving={saving}
+          />
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/services/music.service.ts
+++ b/src/services/music.service.ts
@@ -1,0 +1,362 @@
+import { ApiService } from './api.service';
+import type {
+  MusicMember,
+  MusicEvent,
+  MusicAssignment,
+  MusicSong,
+  MusicSongStat,
+  EventSong,
+  MusicUnavailability,
+  CreateMemberRequest,
+  UpdateMemberRequest,
+  CreateEventRequest,
+  BatchQuarterRequest,
+  CreateAssignmentRequest,
+  UpdateAssignmentRequest,
+  AddSongToEventRequest,
+  CreateUnavailabilityRequest,
+} from '@/types/music.types';
+
+interface RawMember {
+  id: string;
+  user_id: string;
+  name?: string;
+  funciones: string[];
+  instrument: string | null;
+  is_active: boolean;
+  created_at: string;
+}
+
+interface RawEvent {
+  id: string;
+  event_date: string;
+  event_type: string;
+  title: string | null;
+  notes: string | null;
+  published: boolean;
+  created_at: string;
+}
+
+interface RawAssignment {
+  id: string;
+  event_id: string;
+  member_id: string;
+  member_name?: string;
+  funcion: string;
+  state: string;
+  assigned_by: string | null;
+}
+
+interface RawSong {
+  id: string;
+  name: string;
+  name_normalized: string;
+  author: string | null;
+  default_key: string | null;
+  historical_key: string | null;
+}
+
+interface RawEventSong {
+  id: string;
+  event_id: string;
+  song_id: string;
+  song_name: string;
+  tono: string | null;
+  order_index: number;
+}
+
+interface RawSongStat {
+  id: string;
+  name: string;
+  times_played: number;
+  last_played_date: string | null;
+  historical_key: string | null;
+}
+
+interface RawUnavailability {
+  id: string;
+  member_id: string;
+  start_date: string;
+  end_date: string | null;
+  reason: string | null;
+  created_at: string;
+}
+
+interface RawCreateAssignmentResponse {
+  assignment: RawAssignment;
+  unavailability_warning: boolean;
+}
+
+function mapMember(r: RawMember): MusicMember {
+  return {
+    id: r.id,
+    userId: r.user_id,
+    name: r.name,
+    funciones: r.funciones as MusicMember['funciones'],
+    instrument: r.instrument,
+    active: r.is_active,
+    createdAt: r.created_at,
+  };
+}
+
+function mapEvent(r: RawEvent): MusicEvent {
+  return {
+    id: r.id,
+    eventDate: r.event_date,
+    eventType: r.event_type as MusicEvent['eventType'],
+    title: r.title,
+    notes: r.notes,
+    published: r.published,
+    createdAt: r.created_at,
+  };
+}
+
+function mapAssignment(r: RawAssignment): MusicAssignment {
+  return {
+    id: r.id,
+    eventId: r.event_id,
+    memberId: r.member_id,
+    memberName: r.member_name,
+    funcion: r.funcion as MusicAssignment['funcion'],
+    state: r.state as MusicAssignment['state'],
+    assignedBy: r.assigned_by,
+  };
+}
+
+function mapSong(r: RawSong): MusicSong {
+  return {
+    id: r.id,
+    name: r.name,
+    nameNormalized: r.name_normalized,
+    author: r.author,
+    defaultKey: r.default_key,
+    historicalKey: r.historical_key,
+  };
+}
+
+function mapEventSong(r: RawEventSong): EventSong {
+  return {
+    id: r.id,
+    eventId: r.event_id,
+    songId: r.song_id,
+    songName: r.song_name,
+    tono: r.tono,
+    orderIndex: r.order_index,
+  };
+}
+
+function mapSongStat(r: RawSongStat): MusicSongStat {
+  return {
+    id: r.id,
+    name: r.name,
+    timesPlayed: r.times_played,
+    lastPlayedDate: r.last_played_date,
+    historicalKey: r.historical_key,
+  };
+}
+
+function mapUnavailability(r: RawUnavailability): MusicUnavailability {
+  return {
+    id: r.id,
+    memberId: r.member_id,
+    startDate: r.start_date,
+    endDate: r.end_date,
+    reason: r.reason,
+    createdAt: r.created_at,
+  };
+}
+
+export class MusicService {
+  private static base = '/music';
+
+  static async getMembers(): Promise<MusicMember[]> {
+    const raw = await ApiService.get<RawMember[]>(`${this.base}/members`);
+    return raw.map(mapMember);
+  }
+
+  static async createMember(data: CreateMemberRequest): Promise<MusicMember> {
+    const raw = await ApiService.post<
+      RawMember,
+      { user_id: string; funciones: string[]; instrument?: string | null }
+    >(`${this.base}/members`, {
+      user_id: data.userId,
+      funciones: data.funciones,
+      instrument: data.instrument,
+    });
+    return mapMember(raw);
+  }
+
+  static async updateMember(id: string, data: UpdateMemberRequest): Promise<MusicMember> {
+    const raw = await ApiService.put<RawMember, UpdateMemberRequest>(
+      `${this.base}/members/${id}`,
+      data
+    );
+    return mapMember(raw);
+  }
+
+  static async deleteMember(id: string): Promise<void> {
+    await ApiService.delete(`${this.base}/members/${id}`);
+  }
+
+  static async getEvents(params?: { from?: string; to?: string }): Promise<MusicEvent[]> {
+    const q = new URLSearchParams();
+    if (params?.from) q.append('from', params.from);
+    if (params?.to) q.append('to', params.to);
+    const qs = q.toString();
+    const raw = await ApiService.get<RawEvent[]>(`${this.base}/events${qs ? `?${qs}` : ''}`);
+    return raw.map(mapEvent);
+  }
+
+  static async getEventById(id: string): Promise<MusicEvent> {
+    const raw = await ApiService.get<RawEvent>(`${this.base}/events/${id}`);
+    return mapEvent(raw);
+  }
+
+  static async createEvent(data: CreateEventRequest): Promise<MusicEvent> {
+    const raw = await ApiService.post<
+      RawEvent,
+      { event_date: string; event_type: string; title?: string; notes?: string }
+    >(`${this.base}/events`, {
+      event_date: data.eventDate,
+      event_type: data.eventType,
+      title: data.title,
+      notes: data.notes,
+    });
+    return mapEvent(raw);
+  }
+
+  static async updateEvent(id: string, data: Partial<CreateEventRequest>): Promise<MusicEvent> {
+    const body: Record<string, unknown> = {};
+    if (data.eventDate !== undefined) body.event_date = data.eventDate;
+    if (data.eventType !== undefined) body.event_type = data.eventType;
+    if (data.title !== undefined) body.title = data.title;
+    if (data.notes !== undefined) body.notes = data.notes;
+    const raw = await ApiService.put<RawEvent, Record<string, unknown>>(
+      `${this.base}/events/${id}`,
+      body
+    );
+    return mapEvent(raw);
+  }
+
+  static async deleteEvent(id: string): Promise<void> {
+    await ApiService.delete(`${this.base}/events/${id}`);
+  }
+
+  static async batchCreateQuarter(
+    data: BatchQuarterRequest
+  ): Promise<{ created: number; skipped: number }> {
+    return ApiService.post<{ created: number; skipped: number }, BatchQuarterRequest>(
+      `${this.base}/events/batch-quarter`,
+      data
+    );
+  }
+
+  static async getAssignments(eventId: string): Promise<MusicAssignment[]> {
+    const raw = await ApiService.get<RawAssignment[]>(`${this.base}/events/${eventId}/assignments`);
+    return raw.map(mapAssignment);
+  }
+
+  static async createAssignment(
+    eventId: string,
+    data: CreateAssignmentRequest
+  ): Promise<{ assignment: MusicAssignment; unavailabilityWarning: boolean }> {
+    const raw = await ApiService.post<
+      RawCreateAssignmentResponse,
+      { member_id: string; funcion: string }
+    >(`${this.base}/events/${eventId}/assignments`, {
+      member_id: data.memberId,
+      funcion: data.funcion,
+    });
+    return {
+      assignment: mapAssignment(raw.assignment),
+      unavailabilityWarning: raw.unavailability_warning,
+    };
+  }
+
+  static async updateAssignment(
+    id: string,
+    data: UpdateAssignmentRequest
+  ): Promise<MusicAssignment> {
+    const raw = await ApiService.put<RawAssignment, UpdateAssignmentRequest>(
+      `${this.base}/assignments/${id}`,
+      data
+    );
+    return mapAssignment(raw);
+  }
+
+  static async deleteAssignment(id: string): Promise<void> {
+    await ApiService.delete(`${this.base}/assignments/${id}`);
+  }
+
+  static async getSuggestions(assignmentId: string): Promise<MusicMember[]> {
+    const raw = await ApiService.get<RawMember[]>(
+      `${this.base}/assignments/${assignmentId}/suggestions`
+    );
+    return raw.map(mapMember);
+  }
+
+  static async getEventSongs(eventId: string): Promise<EventSong[]> {
+    const raw = await ApiService.get<RawEventSong[]>(`${this.base}/events/${eventId}/songs`);
+    return raw.map(mapEventSong);
+  }
+
+  static async addSongToEvent(eventId: string, data: AddSongToEventRequest): Promise<EventSong> {
+    const raw = await ApiService.post<RawEventSong, AddSongToEventRequest>(
+      `${this.base}/events/${eventId}/songs`,
+      data
+    );
+    return mapEventSong(raw);
+  }
+
+  static async removeSongFromEvent(eventId: string, songId: string): Promise<void> {
+    await ApiService.delete(`${this.base}/event-songs/${songId}`);
+  }
+
+  static async getSongs(q?: string): Promise<MusicSong[]> {
+    const qs = q ? `?q=${encodeURIComponent(q)}` : '';
+    const raw = await ApiService.get<RawSong[]>(`${this.base}/songs${qs}`);
+    return raw.map(mapSong);
+  }
+
+  static async getSongStats(limit?: number): Promise<MusicSongStat[]> {
+    const qs = limit !== undefined ? `?limit=${limit}` : '';
+    const raw = await ApiService.get<RawSongStat[]>(`${this.base}/songs/stats${qs}`);
+    return raw.map(mapSongStat);
+  }
+
+  static async getMyAssignments(): Promise<MusicAssignment[]> {
+    const raw = await ApiService.get<RawAssignment[]>(`${this.base}/me/assignments`);
+    return raw.map(mapAssignment);
+  }
+
+  static async getMyUnavailability(): Promise<MusicUnavailability[]> {
+    const raw = await ApiService.get<RawUnavailability[]>(`${this.base}/me/unavailability`);
+    return raw.map(mapUnavailability);
+  }
+
+  static async createUnavailability(
+    memberId: string,
+    data: CreateUnavailabilityRequest
+  ): Promise<MusicUnavailability> {
+    const raw = await ApiService.post<
+      RawUnavailability,
+      { start_date: string; end_date?: string | null; reason?: string }
+    >(`${this.base}/members/${memberId}/unavailability`, {
+      start_date: data.startDate,
+      end_date: data.endDate,
+      reason: data.reason,
+    });
+    return mapUnavailability(raw);
+  }
+
+  static async deleteUnavailability(id: string): Promise<void> {
+    await ApiService.delete(`${this.base}/unavailability/${id}`);
+  }
+
+  static async getMemberUnavailability(memberId: string): Promise<MusicUnavailability[]> {
+    const raw = await ApiService.get<RawUnavailability[]>(
+      `${this.base}/members/${memberId}/unavailability`
+    );
+    return raw.map(mapUnavailability);
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};

--- a/src/types/music.types.ts
+++ b/src/types/music.types.ts
@@ -1,0 +1,132 @@
+export const Funciones = {
+  corista: 'corista',
+  musico: 'musico',
+  tecnico: 'tecnico',
+  danzarina: 'danzarina',
+} as const;
+export type Funcion = (typeof Funciones)[keyof typeof Funciones];
+
+export const AssignmentStates = {
+  asignado: 'asignado',
+  confirmado: 'confirmado',
+  no_puedo: 'no_puedo',
+} as const;
+export type AssignmentState = (typeof AssignmentStates)[keyof typeof AssignmentStates];
+
+export const MusicEventTypes = {
+  viernes: 'viernes',
+  domingo: 'domingo',
+  especial: 'especial',
+} as const;
+export type MusicEventType = (typeof MusicEventTypes)[keyof typeof MusicEventTypes];
+
+export interface MusicMember {
+  id: string;
+  userId: string;
+  name?: string;
+  funciones: Funcion[];
+  instrument: string | null;
+  active: boolean;
+  createdAt: string;
+}
+
+export interface MusicEvent {
+  id: string;
+  eventDate: string;
+  eventType: MusicEventType;
+  title: string | null;
+  notes: string | null;
+  published: boolean;
+  createdAt: string;
+}
+
+export interface MusicAssignment {
+  id: string;
+  eventId: string;
+  memberId: string;
+  memberName?: string;
+  funcion: Funcion;
+  state: AssignmentState;
+  assignedBy: string | null;
+}
+
+export interface MusicSong {
+  id: string;
+  name: string;
+  nameNormalized: string;
+  author: string | null;
+  defaultKey: string | null;
+  historicalKey: string | null;
+}
+
+export interface EventSong {
+  id: string;
+  eventId: string;
+  songId: string;
+  songName: string;
+  tono: string | null;
+  orderIndex: number;
+}
+
+export interface MusicSongStat {
+  id: string;
+  name: string;
+  timesPlayed: number;
+  lastPlayedDate: string | null;
+  historicalKey: string | null;
+}
+
+export interface MusicUnavailability {
+  id: string;
+  memberId: string;
+  startDate: string;
+  endDate: string | null;
+  reason: string | null;
+  createdAt: string;
+}
+
+export interface CreateMemberRequest {
+  userId: string;
+  funciones: Funcion[];
+  instrument?: string | null;
+}
+
+export interface UpdateMemberRequest {
+  funciones?: Funcion[];
+  instrument?: string | null;
+  active?: boolean;
+}
+
+export interface CreateEventRequest {
+  eventDate: string;
+  eventType: MusicEventType;
+  title?: string;
+  notes?: string;
+}
+
+export interface BatchQuarterRequest {
+  year: number;
+  quarter: 1 | 2 | 3 | 4;
+}
+
+export interface CreateAssignmentRequest {
+  memberId: string;
+  funcion: Funcion;
+}
+
+export interface UpdateAssignmentRequest {
+  state: AssignmentState;
+}
+
+export interface AddSongToEventRequest {
+  name: string;
+  author?: string;
+  tono?: string;
+  orderIndex?: number;
+}
+
+export interface CreateUnavailabilityRequest {
+  startDate: string;
+  endDate?: string | null;
+  reason?: string;
+}


### PR DESCRIPTION
## Summary

- `src/types/music.types.ts` — const-object enums for Funcion/AssignmentState/MusicEventType; flat interfaces for all domain entities and request types
- `src/services/music.service.ts` — static `MusicService` with full API layer (snake_case→camelCase mapping); `createAssignment` surfaces `unavailabilityWarning` flag
- `src/pages/dashboard/MusicPage.tsx` — 4 tabs (Cronograma, Cultos, Integrantes, Canciones) for directors; servidor role-gated view shows only own assignments + unavailability sheet
- `src/pages/dashboard/music/MusicMembers.tsx` — member CRUD split out to stay under line budget; multi-funcion checkbox + conditional instrumento field
- 20 new frontend tests: service mapping, MusicPage tab visibility, role gating, badge colors, instrumento conditional

## Key decisions

- `isDirector` derived from system role (`has_admin_access || pastor || staff`) — module-level role lookup deferred until PR 4 wires module registration
- `MusicMembers` extracted to separate file to keep MusicPage under 500 lines
- `ResizeObserver` stub added to `src/test/setup.ts` for Radix Dialog/Popover compatibility in tests

## Test plan

- [ ] `pnpm tsc --noEmit` — clean
- [ ] `pnpm test:run` — 127/127 passing
- [ ] Web UI renders correctly for director and servidor roles

## Chain

PR 3 of 4. Base: `feat/music-pr2`. PR 4 adds mobile screens and module registration (nav/sidebar/routes) — module becomes visible to users after that merge.