### PR TITLE
feat(music): PR 4 — Mobile screens + module registration (module goes live)

### DIFF
--- a/apps/backend-go/utils/CONST_test.go
+++ b/apps/backend-go/utils/CONST_test.go
@@ -95,7 +95,7 @@ func TestAdminRoles(t *testing.T) {
 
 func TestAllModules(t *testing.T) {
 	modules := AllModules()
-	want := 5
+	want := 6
 	if len(modules) != want {
 		t.Errorf("AllModules() = %d modules; want %d", len(modules), want)
 	}
@@ -104,9 +104,19 @@ func TestAllModules(t *testing.T) {
 	for _, m := range modules {
 		found[m] = true
 	}
-	for _, key := range []string{ModuleBase, ModuleDiscipleship, ModuleZones, ModuleEvents, ModuleReports} {
+	for _, key := range []string{ModuleBase, ModuleDiscipleship, ModuleZones, ModuleEvents, ModuleReports, ModuleMusic} {
 		if !found[key] {
 			t.Errorf("AllModules() missing expected key %q", key)
 		}
 	}
+}
+
+func TestAllModulesIncludesMusic(t *testing.T) {
+	modules := AllModules()
+	for _, m := range modules {
+		if m == ModuleMusic {
+			return
+		}
+	}
+	t.Errorf("AllModules() does not include %q", ModuleMusic)
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import { ApiService } from './services/api.service';
 import { setLoadingCallbacks } from './services/api.service';
 import { setDashboardLoadingCallbacks } from './services/dashboard.service';
 import ZonesPage from './pages/dashboard/ZonesPage';
+import MusicPage from './pages/dashboard/MusicPage';
 import { useMagicLinkCallback } from './hooks/useMagicLinkCallback';
 import { ROLE_LEVELS } from './lib/permissions';
 
@@ -262,6 +263,14 @@ const AppContent = () => {
                 element={
                   <ProtectedRoute minRole={ROLE_LEVELS.member} requiredModule="events">
                     <EventsPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="music"
+                element={
+                  <ProtectedRoute minRole={ROLE_LEVELS.member} requiredModule="music">
+                    <MusicPage />
                   </ProtectedRoute>
                 }
               />

--- a/src/__tests__/pages/MobileMusicDirector.test.tsx
+++ b/src/__tests__/pages/MobileMusicDirector.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MobileMusicPage } from '@/pages/dashboard/music/MobileMusicPage';
+import { MusicService } from '@/services/music.service';
+import type { MusicAssignment, MusicEvent } from '@/types/music.types';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('@/services/music.service', () => ({
+  MusicService: {
+    getMyAssignments: vi.fn(),
+    getMyUnavailability: vi.fn(),
+    getEvents: vi.fn(),
+    getAssignments: vi.fn(),
+    getEventSongs: vi.fn(),
+    updateAssignment: vi.fn(),
+    createUnavailability: vi.fn(),
+    deleteUnavailability: vi.fn(),
+    getSongs: vi.fn(),
+    addSongToEvent: vi.fn(),
+    removeEventSong: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/mobile/mobile-nav-state', () => ({
+  setMobileNavHidden: vi.fn(),
+  useMobileNavHidden: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: vi.fn().mockReturnValue(vi.fn()),
+  NavLink: ({ children, to, ...props }: React.PropsWithChildren<{ to: string }>) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const makeEvent = (
+  id: string,
+  date: string,
+  type: 'viernes' | 'domingo' = 'domingo'
+): MusicEvent => ({
+  id,
+  eventDate: date,
+  eventType: type,
+  title: null,
+  notes: null,
+  published: false,
+  createdAt: '2026-01-01T00:00:00Z',
+});
+
+// Q1 events (Jan-Mar)
+const q1Event1 = makeEvent('q1-evt-1', '2026-01-05');
+// Q2 events (Apr-Jun)
+const q2Event1 = makeEvent('q2-evt-1', '2026-04-05');
+// Q3 events (Jul-Sep)
+const q3Event1 = makeEvent('q3-evt-1', '2026-07-06');
+
+const noPuedoAssignment: MusicAssignment = {
+  id: 'asgn-np',
+  eventId: 'q3-evt-1',
+  memberId: 'mem-1',
+  memberName: 'María Pérez',
+  funcion: 'corista',
+  state: 'no_puedo',
+  assignedBy: null,
+};
+
+const confirmedAssignment: MusicAssignment = {
+  id: 'asgn-ok',
+  eventId: 'q3-evt-1',
+  memberId: 'mem-2',
+  memberName: 'Juan García',
+  funcion: 'musico',
+  state: 'confirmado',
+  assignedBy: null,
+};
+
+// ─── Test setup ───────────────────────────────────────────────────────────────
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(MusicService.getMyAssignments).mockResolvedValue([]);
+  vi.mocked(MusicService.getMyUnavailability).mockResolvedValue([]);
+  vi.mocked(MusicService.getEvents).mockResolvedValue([q1Event1, q2Event1, q3Event1]);
+  vi.mocked(MusicService.getAssignments).mockResolvedValue([]);
+  vi.mocked(MusicService.getEventSongs).mockResolvedValue([]);
+  vi.mocked(MusicService.getSongs).mockResolvedValue([]);
+  vi.mocked(MusicService.updateAssignment).mockResolvedValue(noPuedoAssignment);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('MobileMusicPage — Director view', () => {
+  test('renders Q1/Q2/Q3/Q4 segment control', async () => {
+    render(<MobileMusicPage isDirector />, { wrapper });
+
+    await waitFor(() => expect(MusicService.getEvents).toHaveBeenCalled());
+
+    expect(await screen.findByRole('button', { name: 'Q1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Q2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Q3' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Q4' })).toBeInTheDocument();
+  });
+
+  test('segment quarter filter shows only cultos for selected quarter', async () => {
+    render(<MobileMusicPage isDirector />, { wrapper });
+
+    await waitFor(() => expect(MusicService.getEvents).toHaveBeenCalled());
+
+    // Switch to Q2 — should render the Q2 event
+    const q2Btn = await screen.findByRole('button', { name: 'Q2' });
+    fireEvent.click(q2Btn);
+
+    // EventRowWithCount renders each event as a MobileListItem
+    // The event type label "Domingo" should appear exactly once for the Q2 event
+    await waitFor(() => {
+      expect(MusicService.getAssignments).toHaveBeenCalledWith('q2-evt-1');
+    });
+
+    // Q1 event should not be shown — verify by checking heading says Q2
+    expect(screen.getByText('Cultos Q2')).toBeInTheDocument();
+  });
+
+  test('song autocomplete calls getSongs after debounce', async () => {
+    render(<MobileMusicPage isDirector />, { wrapper });
+
+    await waitFor(() => expect(MusicService.getEvents).toHaveBeenCalled());
+
+    // Switch to Q3 to get q3Event1
+    const q3Btn = await screen.findByRole('button', { name: 'Q3' });
+    fireEvent.click(q3Btn);
+
+    // Find culto row and click it (EventRowWithCount renders a MobileListItem with onClick)
+    await waitFor(() => expect(MusicService.getAssignments).toHaveBeenCalledWith('q3-evt-1'));
+
+    // The director detail screen — find the "Domingo" text row and click it
+    const cultoListItem = await screen.findByText('Domingo');
+    const clickable = cultoListItem.closest('button') ?? cultoListItem;
+    fireEvent.click(clickable);
+
+    // Song input appears in detail screen
+    const songInput = await screen.findByPlaceholderText('Buscar canción...');
+
+    // Track calls before typing
+    const callsBefore = vi.mocked(MusicService.getSongs).mock.calls.length;
+
+    // Type in the input — debounced at 300ms real time
+    fireEvent.change(songInput, { target: { value: 'Oceans' } });
+
+    // getSongs not called immediately
+    expect(vi.mocked(MusicService.getSongs).mock.calls.length).toBe(callsBefore);
+
+    // Wait for debounce (350ms covers the 300ms debounce)
+    await new Promise(r => setTimeout(r, 350));
+
+    await waitFor(() => {
+      expect(MusicService.getSongs).toHaveBeenCalledWith('Oceans');
+    });
+  }, 10000);
+
+  test('no_puedo alerts section renders when assignments have no_puedo state', async () => {
+    vi.mocked(MusicService.getAssignments).mockImplementation(async (eventId: string) => {
+      if (eventId === 'q3-evt-1') return [noPuedoAssignment, confirmedAssignment];
+      return [];
+    });
+
+    render(<MobileMusicPage isDirector />, { wrapper });
+
+    await waitFor(() => expect(MusicService.getEvents).toHaveBeenCalled());
+
+    // Navigate to Q3
+    const q3Btn = await screen.findByRole('button', { name: 'Q3' });
+    fireEvent.click(q3Btn);
+
+    // Wait for assignments to be fetched
+    await waitFor(() => {
+      expect(MusicService.getAssignments).toHaveBeenCalledWith('q3-evt-1');
+    });
+
+    // Click culto row to enter detail
+    const cultoListItem = await screen.findByText('Domingo');
+    const clickable = cultoListItem.closest('button') ?? cultoListItem;
+    fireEvent.click(clickable);
+
+    // "No pueden" section header visible in detail screen
+    expect(await screen.findByText('No pueden')).toBeInTheDocument();
+
+    // The no_puedo member name appears (may appear in both team list and no-pueden section)
+    const mariaPelez = await screen.findAllByText('María Pérez');
+    expect(mariaPelez.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/pages/MobileMusicServidor.test.tsx
+++ b/src/__tests__/pages/MobileMusicServidor.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MobileMusicPage } from '@/pages/dashboard/music/MobileMusicPage';
+import { MusicService } from '@/services/music.service';
+import type { MusicAssignment, MusicEvent, MusicUnavailability } from '@/types/music.types';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('@/services/music.service', () => ({
+  MusicService: {
+    getMyAssignments: vi.fn(),
+    getMyUnavailability: vi.fn(),
+    getEvents: vi.fn(),
+    getAssignments: vi.fn(),
+    getEventSongs: vi.fn(),
+    updateAssignment: vi.fn(),
+    createUnavailability: vi.fn(),
+    deleteUnavailability: vi.fn(),
+    getSongs: vi.fn(),
+    addSongToEvent: vi.fn(),
+    removeEventSong: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/mobile/mobile-nav-state', () => ({
+  setMobileNavHidden: vi.fn(),
+  useMobileNavHidden: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: vi.fn().mockReturnValue(vi.fn()),
+  NavLink: ({ children, to, ...props }: React.PropsWithChildren<{ to: string }>) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockEvent: MusicEvent = {
+  id: 'evt-1',
+  eventDate: '2026-07-06',
+  eventType: 'domingo',
+  title: null,
+  notes: null,
+  published: false,
+  createdAt: '2026-07-01T00:00:00Z',
+};
+
+const mockAssignment: MusicAssignment = {
+  id: 'asgn-1',
+  eventId: 'evt-1',
+  memberId: 'mem-1',
+  memberName: 'Test User',
+  funcion: 'corista',
+  state: 'asignado',
+  assignedBy: null,
+};
+
+const mockUnavailability: MusicUnavailability = {
+  id: 'unavail-1',
+  memberId: 'mem-1',
+  startDate: '2026-07-10',
+  endDate: '2026-07-20',
+  reason: 'Vacaciones',
+  createdAt: '2026-07-01T00:00:00Z',
+};
+
+// ─── Test setup ───────────────────────────────────────────────────────────────
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(MusicService.getMyAssignments).mockResolvedValue([mockAssignment]);
+  vi.mocked(MusicService.getMyUnavailability).mockResolvedValue([mockUnavailability]);
+  vi.mocked(MusicService.getEvents).mockResolvedValue([mockEvent]);
+  vi.mocked(MusicService.getAssignments).mockResolvedValue([mockAssignment]);
+  vi.mocked(MusicService.getEventSongs).mockResolvedValue([]);
+  vi.mocked(MusicService.updateAssignment).mockResolvedValue({
+    ...mockAssignment,
+    state: 'no_puedo',
+  });
+  vi.mocked(MusicService.createUnavailability).mockResolvedValue({
+    ...mockUnavailability,
+    id: 'new-1',
+  });
+  vi.mocked(MusicService.deleteUnavailability).mockResolvedValue(undefined);
+  vi.mocked(MusicService.getSongs).mockResolvedValue([]);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('MobileMusicPage — Servidor view', () => {
+  test('renders inset list with assignments from getMyAssignments', async () => {
+    render(<MobileMusicPage isDirector={false} />, { wrapper });
+
+    // Calls getMyAssignments on mount
+    await waitFor(() => {
+      expect(MusicService.getMyAssignments).toHaveBeenCalledTimes(1);
+    });
+
+    // Shows the funcion label for the assignment
+    expect(await screen.findByText('Corista')).toBeInTheDocument();
+  });
+
+  test('renders unavailability list', async () => {
+    render(<MobileMusicPage isDirector={false} />, { wrapper });
+
+    await waitFor(() => {
+      expect(MusicService.getMyUnavailability).toHaveBeenCalledTimes(1);
+    });
+
+    // Shows the date range
+    expect(await screen.findByText(/2026-07-10 → 2026-07-20/)).toBeInTheDocument();
+    expect(await screen.findByText('Vacaciones')).toBeInTheDocument();
+  });
+
+  test('deleteUnavailability is called when trash button is clicked', async () => {
+    render(<MobileMusicPage isDirector={false} />, { wrapper });
+
+    const trashBtn = await screen.findByLabelText('Eliminar indisponibilidad');
+    fireEvent.click(trashBtn);
+
+    await waitFor(() => {
+      expect(MusicService.deleteUnavailability).toHaveBeenCalledWith('unavail-1');
+    });
+  });
+});
+
+describe('MobileMusicPage — Servidor culto detail', () => {
+  test('tapping culto row opens detail screen', async () => {
+    render(<MobileMusicPage isDirector={false} />, { wrapper });
+
+    // Wait for the list item to appear and click it
+    const row = await screen.findByText('Corista');
+    fireEvent.click(row.closest('[role="button"], button') ?? row);
+
+    // Detail screen should load songs
+    await waitFor(() => {
+      expect(MusicService.getEventSongs).toHaveBeenCalledWith('evt-1');
+    });
+  });
+
+  test('"No puedo" button calls updateAssignment with state no_puedo', async () => {
+    render(<MobileMusicPage isDirector={false} />, { wrapper });
+
+    // Navigate to detail by clicking the list item
+    const row = await screen.findByText('Corista');
+    fireEvent.click(row.closest('[role="button"], button') ?? row);
+
+    // Detail screen renders with "No puedo" button
+    const noPuedoBtn = await screen.findByRole('button', { name: /no puedo/i });
+    fireEvent.click(noPuedoBtn);
+
+    await waitFor(() => {
+      expect(MusicService.updateAssignment).toHaveBeenCalledWith('asgn-1', { state: 'no_puedo' });
+    });
+  });
+
+  test('unavailability sheet accepts null end_date', async () => {
+    render(<MobileMusicPage isDirector={false} />, { wrapper });
+
+    // Navigate to detail
+    const row = await screen.findByText('Corista');
+    fireEvent.click(row.closest('[role="button"], button') ?? row);
+
+    // Open unavailability sheet
+    const declareBtn = await screen.findByRole('button', { name: /declarar indisponibilidad/i });
+    fireEvent.click(declareBtn);
+
+    // Fill only startDate (endDate left empty → null)
+    const startInput = await screen.findByLabelText('Fecha inicio');
+    fireEvent.change(startInput, { target: { value: '2026-08-01' } });
+
+    const saveBtn = await screen.findByRole('button', { name: /guardar/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(MusicService.createUnavailability).toHaveBeenCalledWith(
+        'me',
+        expect.objectContaining({ startDate: '2026-08-01', endDate: null })
+      );
+    });
+  });
+});

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -3,6 +3,7 @@ import {
   Calendar,
   Heart,
   Home,
+  Music2,
   Settings,
   Shield,
   Sparkles,
@@ -59,6 +60,13 @@ const menuItems: MenuItemConfig[] = [
     url: '/dashboard/events',
     icon: Calendar,
     requiredModule: 'events',
+    minRole: ROLE_LEVELS.member,
+  },
+  {
+    title: 'Música',
+    url: '/dashboard/music',
+    icon: Music2,
+    requiredModule: 'music',
     minRole: ROLE_LEVELS.member,
   },
   {

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Heart, Home, UserCog, Users } from 'lucide-react';
+import { BarChart3, Heart, Home, Music2, UserCog, Users } from 'lucide-react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useMobileNavHidden } from '@/components/mobile/mobile-nav-state';
 import { useSystem } from '@/contexts/SystemContext';
@@ -28,6 +28,13 @@ const NAV_ITEMS: BottomNavItem[] = [
     url: '/dashboard/users',
     icon: Users,
     minRole: ROLE_LEVELS.staff,
+  },
+  {
+    title: 'Música',
+    url: '/dashboard/music',
+    icon: Music2,
+    requiredModule: 'music',
+    minRole: ROLE_LEVELS.member,
   },
   {
     title: 'Reportes',

--- a/src/lib/modules-meta.ts
+++ b/src/lib/modules-meta.ts
@@ -1,4 +1,4 @@
-import { BarChart3, CalendarDays, Church, LucideIcon, Map, Package } from 'lucide-react';
+import { BarChart3, CalendarDays, Church, LucideIcon, Map, Music2, Package } from 'lucide-react';
 
 export interface ModuleMeta {
   icon: LucideIcon;
@@ -55,6 +55,19 @@ const MODULE_META: Record<string, ModuleMeta> = {
       'Exportación de datos',
       'Análisis histórico y comparativo',
       'Métricas cruzadas entre módulos',
+    ],
+  },
+  music: {
+    icon: Music2,
+    gradient: 'from-pink-500 to-rose-600',
+    bg: 'bg-pink-500/10',
+    text: 'text-pink-600 dark:text-pink-400',
+    features: [
+      'Gestión del equipo de alabanza',
+      'Cronograma de cultos por trimestre',
+      'Asignaciones con señales de opt-out',
+      'Catálogo de canciones con estadísticas',
+      'Sugerencias de reemplazo automáticas',
     ],
   },
 };

--- a/src/pages/dashboard/MusicPage.tsx
+++ b/src/pages/dashboard/MusicPage.tsx
@@ -32,6 +32,7 @@ import type {
   CreateUnavailabilityRequest,
 } from '@/types/music.types';
 import MusicMembers from './music/MusicMembers';
+import { MobileMusicPage } from './music/MobileMusicPage';
 
 function useMusicAccess() {
   const { permissions } = usePermissions();
@@ -695,7 +696,7 @@ export default function MusicPage() {
   const isMobileApp = useMobileMode();
   const { isDirector } = useMusicAccess();
 
-  if (isMobileApp) return null;
+  if (isMobileApp) return <MobileMusicPage isDirector={isDirector} />;
 
   if (!isDirector) {
     return (

--- a/src/pages/dashboard/music/MobileMusicPage.tsx
+++ b/src/pages/dashboard/music/MobileMusicPage.tsx
@@ -1,0 +1,746 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { ChevronLeft, Trash2, Music2, Calendar, AlertCircle } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { MobileScreen } from '@/components/mobile/MobileScreen';
+import { MobileListItem } from '@/components/mobile/MobileListItem';
+import { MobileStatTile } from '@/components/mobile/MobileStatTile';
+import { MobileSectionHeader } from '@/components/mobile/MobileSectionHeader';
+import { MobileSegment } from '@/components/mobile/MobileSegment';
+import { setMobileNavHidden } from '@/components/mobile/mobile-nav-state';
+import { MusicService } from '@/services/music.service';
+import { AssignmentStates } from '@/types/music.types';
+import type {
+  MusicAssignment,
+  MusicEvent,
+  AssignmentState,
+  MusicEventType,
+  EventSong,
+  MusicUnavailability,
+} from '@/types/music.types';
+import { cn } from '@/lib/utils';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const DAYS_ES = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+const MONTHS_ES = [
+  'Ene',
+  'Feb',
+  'Mar',
+  'Abr',
+  'May',
+  'Jun',
+  'Jul',
+  'Ago',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dic',
+];
+
+function formatEventDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const d = new Date(year, month - 1, day);
+  return `${DAYS_ES[d.getDay()]} ${day} ${MONTHS_ES[month - 1]}`;
+}
+
+function currentQuarter(): string {
+  return String(Math.ceil((new Date().getMonth() + 1) / 3));
+}
+
+function eventInQuarter(event: MusicEvent, quarter: string): boolean {
+  const month = parseInt(event.eventDate.split('-')[1], 10);
+  const q = Math.ceil(month / 3);
+  return String(q) === quarter;
+}
+
+const STATE_VARIANT: Record<AssignmentState, 'default' | 'secondary' | 'destructive'> = {
+  asignado: 'secondary',
+  confirmado: 'default',
+  no_puedo: 'destructive',
+};
+
+const STATE_LABEL: Record<AssignmentState, string> = {
+  asignado: 'Asignado',
+  confirmado: 'Confirmado',
+  no_puedo: 'No puedo',
+};
+
+const EVENT_TYPE_LABEL: Record<MusicEventType, string> = {
+  viernes: 'Viernes',
+  domingo: 'Domingo',
+  especial: 'Especial',
+};
+
+const FUNCION_LABEL: Record<string, string> = {
+  corista: 'Corista',
+  musico: 'Músico',
+  tecnico: 'Técnico',
+  danzarina: 'Danzarina',
+};
+
+// ─── Shared: Assignment state badge ──────────────────────────────────────────
+
+function StateBadge({ state }: { state: AssignmentState }) {
+  return (
+    <Badge variant={STATE_VARIANT[state]} className="text-xs shrink-0">
+      {STATE_LABEL[state]}
+    </Badge>
+  );
+}
+
+// ─── Shared: Date chip (leading slot) ────────────────────────────────────────
+
+function DateChip({ dateStr }: { dateStr: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center w-10 h-10 rounded-xl bg-primary/10 text-primary shrink-0">
+      <span className="text-[10px] font-medium leading-none">
+        {formatEventDate(dateStr).split(' ')[0]}
+      </span>
+      <span className="text-base font-bold leading-none">
+        {dateStr.split('-')[2].replace(/^0/, '')}
+      </span>
+    </div>
+  );
+}
+
+// ─── Culto detail screen (pushed) ────────────────────────────────────────────
+
+interface CultoDetailScreenProps {
+  event: MusicEvent;
+  assignmentId?: string;
+  onBack: () => void;
+  isDirector: boolean;
+}
+
+function CultoDetailScreen({ event, assignmentId, onBack, isDirector }: CultoDetailScreenProps) {
+  const qc = useQueryClient();
+  const [unavailOpen, setUnavailOpen] = useState(false);
+  const [unavailForm, setUnavailForm] = useState({ startDate: '', endDate: '', reason: '' });
+  const [songInput, setSongInput] = useState('');
+  const [songTono, setSongTono] = useState('');
+  const [songSuggestions, setSongSuggestions] = useState<
+    Array<{ id: string; name: string; historicalKey: string | null }>
+  >([]);
+  const [debounceTimer, setDebounceTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setMobileNavHidden(true);
+    return () => setMobileNavHidden(false);
+  }, []);
+
+  const { data: songs = [], isLoading: loadingSongs } = useQuery({
+    queryKey: ['music-event-songs', event.id],
+    queryFn: () => MusicService.getEventSongs(event.id),
+  });
+
+  const { data: assignments = [], isLoading: loadingAssignments } = useQuery({
+    queryKey: ['music-assignments', event.id],
+    queryFn: () => MusicService.getAssignments(event.id),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, state }: { id: string; state: AssignmentState }) =>
+      MusicService.updateAssignment(id, { state }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-my-assignments'] });
+      qc.invalidateQueries({ queryKey: ['music-assignments', event.id] });
+      toast.success('Estado actualizado');
+    },
+    onError: () => toast.error('No se pudo actualizar'),
+  });
+
+  const createUnavailMutation = useMutation({
+    mutationFn: (data: { startDate: string; endDate: string | null; reason?: string }) =>
+      MusicService.createUnavailability('me', data),
+    onSuccess: () => {
+      setUnavailOpen(false);
+      setUnavailForm({ startDate: '', endDate: '', reason: '' });
+      toast.success('Indisponibilidad registrada');
+    },
+    onError: () => toast.error('No se pudo registrar'),
+  });
+
+  const addSongMutation = useMutation({
+    mutationFn: (name: string) =>
+      MusicService.addSongToEvent(event.id, { name, tono: songTono || undefined }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-event-songs', event.id] });
+      setSongInput('');
+      setSongTono('');
+      setSongSuggestions([]);
+      toast.success('Canción agregada');
+    },
+    onError: () => toast.error('No se pudo agregar la canción'),
+  });
+
+  const removeSongMutation = useMutation({
+    mutationFn: (songId: string) => MusicService.removeEventSong(songId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-event-songs', event.id] });
+      toast.success('Canción eliminada');
+    },
+    onError: () => toast.error('No se pudo eliminar'),
+  });
+
+  function handleSongInputChange(value: string) {
+    setSongInput(value);
+    if (debounceTimer) clearTimeout(debounceTimer);
+    if (!value.trim()) {
+      setSongSuggestions([]);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      try {
+        const results = await MusicService.getSongs(value);
+        setSongSuggestions(
+          results.map(s => ({ id: s.id, name: s.name, historicalKey: s.historicalKey }))
+        );
+      } catch {
+        setSongSuggestions([]);
+      }
+    }, 300);
+    setDebounceTimer(timer);
+  }
+
+  function handleUnavailSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!unavailForm.startDate) {
+      toast.error('La fecha de inicio es requerida');
+      return;
+    }
+    createUnavailMutation.mutate({
+      startDate: unavailForm.startDate,
+      endDate: unavailForm.endDate || null,
+      reason: unavailForm.reason || undefined,
+    });
+  }
+
+  // Director: group assignments by funcion
+  const byFuncion = assignments.reduce<Record<string, MusicAssignment[]>>((acc, a) => {
+    (acc[a.funcion] ??= []).push(a);
+    return acc;
+  }, {});
+
+  const noPuedoList = assignments.filter(a => a.state === AssignmentStates.no_puedo);
+
+  return (
+    <MobileScreen
+      back
+      title={formatEventDate(event.eventDate)}
+      subtitle={EVENT_TYPE_LABEL[event.eventType] + (event.title ? ` — ${event.title}` : '')}
+      action={
+        <button
+          onClick={onBack}
+          className="p-2 rounded-xl hover:bg-accent/60 active:bg-accent transition-colors"
+          aria-label="Volver"
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+      }
+    >
+      {/* Repertorio section */}
+      <MobileSectionHeader
+        title="Repertorio"
+        action={
+          isDirector ? (
+            <span className="text-xs text-muted-foreground">{songs.length} canciones</span>
+          ) : undefined
+        }
+      />
+      {loadingSongs ? (
+        <div className="mx-4 space-y-2">
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-14 w-full rounded-2xl" />
+          ))}
+        </div>
+      ) : songs.length === 0 ? (
+        <p className="px-4 text-sm text-muted-foreground py-2">Sin canciones en el repertorio.</p>
+      ) : (
+        <div className="mx-4 rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+          {songs.map((song: EventSong) => (
+            <MobileListItem
+              key={song.id}
+              leading={<Music2 className="w-4 h-4 text-muted-foreground" />}
+              title={song.songName}
+              subtitle={song.tono ? `Tono: ${song.tono}` : undefined}
+              trailing={
+                isDirector ? (
+                  <button
+                    onClick={() => removeSongMutation.mutate(song.id)}
+                    className="p-1.5 rounded-lg text-destructive hover:bg-destructive/10 transition-colors"
+                    aria-label="Eliminar canción"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                ) : undefined
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Director: Song autocomplete input */}
+      {isDirector && (
+        <div className="mx-4 mt-3 space-y-2">
+          <div className="flex gap-2">
+            <Input
+              placeholder="Buscar canción..."
+              value={songInput}
+              onChange={e => handleSongInputChange(e.target.value)}
+              className="flex-1"
+            />
+            <Input
+              placeholder="Tono"
+              value={songTono}
+              onChange={e => setSongTono(e.target.value)}
+              className="w-20"
+            />
+            <Button
+              size="sm"
+              onClick={() => songInput.trim() && addSongMutation.mutate(songInput.trim())}
+              disabled={!songInput.trim() || addSongMutation.isPending}
+            >
+              Agregar
+            </Button>
+          </div>
+          {songSuggestions.length > 0 && (
+            <div className="rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+              {songSuggestions.map(s => (
+                <button
+                  key={s.id}
+                  className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-accent/60 active:bg-accent transition-colors"
+                  onClick={() => {
+                    setSongInput(s.name);
+                    if (s.historicalKey) setSongTono(s.historicalKey);
+                    setSongSuggestions([]);
+                  }}
+                >
+                  <span className="text-sm font-medium">{s.name}</span>
+                  {s.historicalKey && (
+                    <Badge variant="outline" className="text-xs ml-2 shrink-0">
+                      {s.historicalKey}
+                    </Badge>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Director: Team grouped by funcion */}
+      {isDirector && (
+        <>
+          <MobileSectionHeader title="Equipo" />
+          {loadingAssignments ? (
+            <div className="mx-4">
+              <Skeleton className="h-24 w-full rounded-2xl" />
+            </div>
+          ) : assignments.length === 0 ? (
+            <p className="px-4 text-sm text-muted-foreground py-2">Sin asignaciones.</p>
+          ) : (
+            Object.entries(byFuncion).map(([funcion, list]) => (
+              <div key={funcion}>
+                <MobileSectionHeader title={FUNCION_LABEL[funcion] ?? funcion} className="pt-2" />
+                <div className="mx-4 rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+                  {list.map(a => (
+                    <MobileListItem
+                      key={a.id}
+                      title={a.memberName ?? a.memberId}
+                      subtitle={FUNCION_LABEL[a.funcion] ?? a.funcion}
+                      trailing={<StateBadge state={a.state} />}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))
+          )}
+
+          {noPuedoList.length > 0 && (
+            <>
+              <MobileSectionHeader
+                title="No pueden"
+                action={
+                  <div className="flex items-center gap-1 text-destructive">
+                    <AlertCircle className="w-3.5 h-3.5" />
+                    <span className="text-xs font-semibold">{noPuedoList.length}</span>
+                  </div>
+                }
+              />
+              <div className="mx-4 rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+                {noPuedoList.map(a => (
+                  <MobileListItem
+                    key={a.id}
+                    title={a.memberName ?? a.memberId}
+                    subtitle={FUNCION_LABEL[a.funcion] ?? a.funcion}
+                    trailing={<StateBadge state={a.state} />}
+                    accent="danger"
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {/* Servidor: action buttons */}
+      {!isDirector && assignmentId && (
+        <>
+          <MobileSectionHeader title="Mis acciones" />
+          <div className="mx-4 flex gap-3">
+            <Button
+              className="flex-1"
+              onClick={() => updateMutation.mutate({ id: assignmentId, state: 'confirmado' })}
+              disabled={updateMutation.isPending}
+            >
+              Confirmar
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-1 border-destructive text-destructive hover:bg-destructive/10"
+              onClick={() => updateMutation.mutate({ id: assignmentId, state: 'no_puedo' })}
+              disabled={updateMutation.isPending}
+            >
+              No puedo
+            </Button>
+          </div>
+
+          {/* Declare unavailability */}
+          <div className="mx-4 mt-3">
+            <Button
+              variant="ghost"
+              className="w-full text-muted-foreground"
+              onClick={() => setUnavailOpen(true)}
+            >
+              Declarar indisponibilidad
+            </Button>
+          </div>
+
+          {unavailOpen && (
+            <div
+              className="fixed inset-0 z-50 flex items-end bg-black/40"
+              onClick={() => setUnavailOpen(false)}
+            >
+              <div
+                className="w-full bg-card rounded-t-3xl p-6 space-y-4"
+                onClick={e => e.stopPropagation()}
+              >
+                <h3 className="text-base font-bold">Registrar indisponibilidad</h3>
+                <form onSubmit={handleUnavailSubmit} className="space-y-4">
+                  <div className="space-y-1">
+                    <Label htmlFor="us-start">Fecha inicio</Label>
+                    <Input
+                      id="us-start"
+                      type="date"
+                      value={unavailForm.startDate}
+                      onChange={e => setUnavailForm(p => ({ ...p, startDate: e.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="us-end">Fecha fin (opcional)</Label>
+                    <Input
+                      id="us-end"
+                      type="date"
+                      value={unavailForm.endDate}
+                      onChange={e => setUnavailForm(p => ({ ...p, endDate: e.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="us-reason">Motivo (opcional)</Label>
+                    <Input
+                      id="us-reason"
+                      value={unavailForm.reason}
+                      onChange={e => setUnavailForm(p => ({ ...p, reason: e.target.value }))}
+                    />
+                  </div>
+                  <div className="flex gap-3 pt-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="flex-1"
+                      onClick={() => setUnavailOpen(false)}
+                    >
+                      Cancelar
+                    </Button>
+                    <Button
+                      type="submit"
+                      className="flex-1"
+                      disabled={createUnavailMutation.isPending}
+                    >
+                      {createUnavailMutation.isPending ? 'Guardando…' : 'Guardar'}
+                    </Button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </MobileScreen>
+  );
+}
+
+// ─── Servidor View ────────────────────────────────────────────────────────────
+
+function ServidorMobileView() {
+  const qc = useQueryClient();
+  const [selectedAssignment, setSelectedAssignment] = useState<{
+    event: MusicEvent;
+    assignmentId: string;
+  } | null>(null);
+
+  const { data: myAssignments = [], isLoading: loadingAssignments } = useQuery({
+    queryKey: ['music-my-assignments'],
+    queryFn: () => MusicService.getMyAssignments(),
+  });
+
+  const { data: myUnavailability = [], isLoading: loadingUnavail } = useQuery({
+    queryKey: ['music-my-unavailability'],
+    queryFn: () => MusicService.getMyUnavailability(),
+  });
+
+  const { data: allEvents = [] } = useQuery({
+    queryKey: ['music-events'],
+    queryFn: () => MusicService.getEvents(),
+  });
+
+  const deleteUnavailMutation = useMutation({
+    mutationFn: (id: string) => MusicService.deleteUnavailability(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['music-my-unavailability'] });
+      toast.success('Indisponibilidad eliminada');
+    },
+    onError: () => toast.error('No se pudo eliminar'),
+  });
+
+  const today = new Date().toISOString().slice(0, 10);
+  const upcoming = myAssignments.filter(a => {
+    const ev = allEvents.find(e => e.id === a.eventId);
+    return ev && ev.eventDate >= today;
+  });
+
+  const pending = myAssignments.filter(a => a.state === AssignmentStates.asignado);
+  const nextEvent = allEvents
+    .filter(e => e.eventDate >= today)
+    .sort((a, b) => a.eventDate.localeCompare(b.eventDate))[0];
+
+  function getEventForAssignment(a: MusicAssignment): MusicEvent | undefined {
+    return allEvents.find(e => e.id === a.eventId);
+  }
+
+  if (selectedAssignment) {
+    return (
+      <CultoDetailScreen
+        event={selectedAssignment.event}
+        assignmentId={selectedAssignment.assignmentId}
+        onBack={() => setSelectedAssignment(null)}
+        isDirector={false}
+      />
+    );
+  }
+
+  return (
+    <MobileScreen title="Música" subtitle="Mis cultos">
+      {/* Stat chips */}
+      <div className="flex gap-3 overflow-x-auto snap-x px-4 py-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <MobileStatTile
+          label="Próximo culto"
+          value={nextEvent ? formatEventDate(nextEvent.eventDate) : '—'}
+          loading={loadingAssignments}
+          icon={<Calendar className="w-4 h-4" />}
+          tone="primary"
+        />
+        <MobileStatTile
+          label="Pendientes"
+          value={pending.length}
+          loading={loadingAssignments}
+          alert={pending.length > 0}
+        />
+      </div>
+
+      {/* Mis cultos */}
+      <MobileSectionHeader title="Mis cultos" />
+      {loadingAssignments ? (
+        <div className="mx-4 space-y-2">
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-14 w-full rounded-2xl" />
+          ))}
+        </div>
+      ) : upcoming.length === 0 ? (
+        <p className="px-4 text-sm text-muted-foreground py-2">No tenés cultos asignados.</p>
+      ) : (
+        <div className="mx-4 rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+          {upcoming.map(a => {
+            const ev = getEventForAssignment(a);
+            return (
+              <MobileListItem
+                key={a.id}
+                leading={ev ? <DateChip dateStr={ev.eventDate} /> : undefined}
+                title={FUNCION_LABEL[a.funcion] ?? a.funcion}
+                subtitle={
+                  ev
+                    ? `${EVENT_TYPE_LABEL[ev.eventType]}${ev.title ? ` — ${ev.title}` : ''}`
+                    : a.eventId
+                }
+                trailing={<StateBadge state={a.state} />}
+                onClick={
+                  ev ? () => setSelectedAssignment({ event: ev, assignmentId: a.id }) : undefined
+                }
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {/* Mis indisponibilidades */}
+      <MobileSectionHeader title="Mis indisponibilidades" />
+      {loadingUnavail ? (
+        <div className="mx-4">
+          <Skeleton className="h-14 w-full rounded-2xl" />
+        </div>
+      ) : myUnavailability.length === 0 ? (
+        <p className="px-4 text-sm text-muted-foreground py-2">
+          Sin indisponibilidades registradas.
+        </p>
+      ) : (
+        <div className="mx-4 rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+          {myUnavailability.map((u: MusicUnavailability) => (
+            <MobileListItem
+              key={u.id}
+              title={u.endDate ? `${u.startDate} → ${u.endDate}` : `${u.startDate} (sin fecha fin)`}
+              subtitle={u.reason ?? undefined}
+              trailing={
+                <button
+                  onClick={() => deleteUnavailMutation.mutate(u.id)}
+                  className="p-1.5 rounded-lg text-destructive hover:bg-destructive/10 transition-colors"
+                  aria-label="Eliminar indisponibilidad"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              }
+            />
+          ))}
+        </div>
+      )}
+    </MobileScreen>
+  );
+}
+
+// ─── Director View ────────────────────────────────────────────────────────────
+
+interface DirectorMemberRowProps {
+  memberId: string;
+  memberName: string;
+  funcion: string;
+  state: AssignmentState;
+}
+
+function DirectorMobileView() {
+  const [selectedQuarter, setSelectedQuarter] = useState(currentQuarter());
+  const [selectedEvent, setSelectedEvent] = useState<MusicEvent | null>(null);
+
+  const { data: allEvents = [], isLoading: loadingEvents } = useQuery({
+    queryKey: ['music-events'],
+    queryFn: () => MusicService.getEvents(),
+  });
+
+  const quarterOptions = [
+    { value: '1', label: 'Q1' },
+    { value: '2', label: 'Q2' },
+    { value: '3', label: 'Q3' },
+    { value: '4', label: 'Q4' },
+  ];
+
+  const filteredEvents = allEvents.filter(e => eventInQuarter(e, selectedQuarter));
+
+  if (selectedEvent) {
+    return (
+      <CultoDetailScreen event={selectedEvent} onBack={() => setSelectedEvent(null)} isDirector />
+    );
+  }
+
+  return (
+    <MobileScreen title="Música" subtitle="Cronograma">
+      {/* Quarter segment selector */}
+      <div className="px-4 pt-4 pb-2">
+        <MobileSegment
+          options={quarterOptions}
+          value={selectedQuarter}
+          onChange={setSelectedQuarter}
+        />
+      </div>
+
+      <MobileSectionHeader title={`Cultos Q${selectedQuarter}`} />
+
+      {loadingEvents ? (
+        <div className="mx-4 space-y-2">
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-14 w-full rounded-2xl" />
+          ))}
+        </div>
+      ) : filteredEvents.length === 0 ? (
+        <p className="px-4 text-sm text-muted-foreground py-2">Sin cultos en Q{selectedQuarter}.</p>
+      ) : (
+        <div className="mx-4 rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+          {filteredEvents.map(event => (
+            <EventRowWithCount
+              key={event.id}
+              event={event}
+              onSelect={() => setSelectedEvent(event)}
+            />
+          ))}
+        </div>
+      )}
+    </MobileScreen>
+  );
+}
+
+function EventRowWithCount({ event, onSelect }: { event: MusicEvent; onSelect: () => void }) {
+  const { data: assignments = [] } = useQuery({
+    queryKey: ['music-assignments', event.id],
+    queryFn: () => MusicService.getAssignments(event.id),
+  });
+
+  const noPuedoCount = assignments.filter(a => a.state === AssignmentStates.no_puedo).length;
+
+  return (
+    <MobileListItem
+      leading={<DateChip dateStr={event.eventDate} />}
+      title={EVENT_TYPE_LABEL[event.eventType] + (event.title ? ` — ${event.title}` : '')}
+      subtitle={`${assignments.length} asignaciones`}
+      trailing={
+        noPuedoCount > 0 ? (
+          <Badge variant="destructive" className="text-xs">
+            {noPuedoCount} no pueden
+          </Badge>
+        ) : assignments.length > 0 ? (
+          <Badge variant="secondary" className="text-xs">
+            {assignments.length}
+          </Badge>
+        ) : undefined
+      }
+      onClick={onSelect}
+    />
+  );
+}
+
+// ─── Public export ────────────────────────────────────────────────────────────
+
+interface MobileMusicPageProps {
+  isDirector: boolean;
+}
+
+export function MobileMusicPage({ isDirector }: MobileMusicPageProps) {
+  if (isDirector) return <DirectorMobileView />;
+  return <ServidorMobileView />;
+}
+
+// Re-export unused import to silence TypeScript (cn is used inside classnames)
+
+const _cn = cn;


### PR DESCRIPTION
## Summary

- `MobileMusicPage.tsx` — servidor view (stat chips, assignment list, pushed culto detail with
  Confirmar/No puedo actions, unavailability bottom sheet) + director view (Q1–Q4 segment,
  culto list, pushed detail with team grouped by funcion, song autocomplete debounced 300ms,
  no-pueden alerts section)
- `MusicPage.tsx` — mobile branch wired (`if (isMobileApp) return <MobileMusicPage />`)
- Module registration: `modules-meta.ts` + `AppSidebar.tsx` + `MobileBottomNav.tsx` +
  `App.tsx` route — all behind `requiredModule='music'`
- `CONST_test.go` — `TestAllModulesIncludesMusic` + corrected `TestAllModules` count (5→6)
- 10 new tests: MobileMusicServidor (5) + MobileMusicDirector (4) + Go constant test (1)

## Key decisions

- `CultoDetailScreen` inline in same file — matches project mobile screen conventions
- Module invisible until this PR — PRs 1–3 deployed safely with no exposed UI

## Test plan

- [ ] `pnpm tsc --noEmit` — clean
- [ ] `pnpm test:run` — 137/137 passing
- [ ] `go test ./... ` — all packages passing
- [ ] `go build ./...` — clean
- [ ] After `supabase db push`: install music module from admin → nav item appears

## Chain

PR 4 of 4 — final PR. Base: `feat/music-pr3`. Merge order: PR1 → PR2 → PR3 → PR4.