### PR TITLE
feat(multitenant): Phase 3a — handler scoping users, zones, invitations (PR 4/9)

### DIFF
--- a/apps/backend-go/handlers/db_helper.go
+++ b/apps/backend-go/handlers/db_helper.go
@@ -17,7 +17,8 @@ func getDBOrError(c echo.Context) (*config.Database, error) {
 	return db, nil
 }
 
-// validateDB es un helper que valida la conexión DB y retorna error JSON si falla
+// validateDB es un helper que valida la conexión DB y retorna error JSON si falla.
+// Kept for Phase 3b/3c handlers that have not yet been migrated to validateTx.
 func validateDB(c echo.Context) (*config.Database, error) {
 	db, err := getDBOrError(c)
 	if err != nil {
@@ -27,5 +28,27 @@ func validateDB(c echo.Context) (*config.Database, error) {
 		return nil, err
 	}
 	return db, nil
+}
+
+// validateTx returns the request-scoped Querier for the current tenant context.
+//
+// Phase 3+: config.Tx(c) returns the *sql.Tx stashed by TenantTx middleware
+// (which already executed set_config('app.current_church_id', …, true) inside
+// the transaction).  Falls back to the global pool when no transaction is
+// present (unauthenticated paths or Phase 0 pass-through).
+//
+// Handlers migrated to validateTx must also add AND church_id = $N to every
+// query that touches a tenant-scoped table.  The Querier interface is satisfied
+// by both *sql.DB and *sql.Tx so call sites are identical.
+func validateTx(c echo.Context) (config.Querier, error) {
+	db := config.GetDB()
+	if db == nil || db.DB == nil {
+		err := fmt.Errorf("database connection not available")
+		c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": err.Error(),
+		})
+		return nil, err
+	}
+	return config.Tx(c), nil
 }
 

--- a/apps/backend-go/handlers/invite.go
+++ b/apps/backend-go/handlers/invite.go
@@ -34,16 +34,17 @@ func (h *InviteHandler) InviteUser(c echo.Context) error {
 	}
 
 	inviteBy := c.Get("user_id").(string)
+	churchID, _ := c.Get("church_id").(string)
 
-	db := config.GetDB()
+	q := config.Tx(c)
 
 	var existingInvite string
 
 	checkQuery := `
-		SELECT id FROM user_invitations 
-		WHERE email = $1 AND status IN ('pending', 'accepted')`
+		SELECT id FROM user_invitations
+		WHERE email = $1 AND church_id = $2 AND status IN ('pending', 'accepted')`
 
-	err := db.DB.QueryRow(checkQuery, req.Email).Scan(&existingInvite)
+	err := q.QueryRow(checkQuery, req.Email, churchID).Scan(&existingInvite)
 	if err == nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{
 			"error": "User already has an active invite",
@@ -51,14 +52,14 @@ func (h *InviteHandler) InviteUser(c echo.Context) error {
 	}
 
 	insertQuery := `
-		INSERT INTO user_invitations (email, first_name, last_name, phone, id_number, assigned_role, invited_by, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + INTERVAL '7 days')
+		INSERT INTO user_invitations (email, first_name, last_name, phone, id_number, assigned_role, invited_by, church_id, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW() + INTERVAL '7 days')
 		RETURNING id, expires_at`
 
 	var invitationID string
 	var expiresAt time.Time
 
-	err = db.DB.QueryRow(insertQuery, req.Email, req.FirstName, req.LastName, req.Phone, req.IdNumber, req.Role, inviteBy).Scan(&invitationID, &expiresAt)
+	err = q.QueryRow(insertQuery, req.Email, req.FirstName, req.LastName, req.Phone, req.IdNumber, req.Role, inviteBy, churchID).Scan(&invitationID, &expiresAt)
 	if err != nil {
 		fmt.Printf("Error creating invite: %v", insertQuery)
 		fmt.Println("Error creating invite:", err)
@@ -68,11 +69,11 @@ func (h *InviteHandler) InviteUser(c echo.Context) error {
 	}
 
 	userData := map[string]interface{}{
-		"first_name":    req.FirstName,
-		"last_name":     req.LastName,
-		"phone":         req.Phone,
-		"id_number":     req.IdNumber,
-		"role":          req.Role,
+		"first_name": req.FirstName,
+		"last_name":  req.LastName,
+		"phone":      req.Phone,
+		"id_number":  req.IdNumber,
+		"role":       req.Role,
 	}
 
 	// Usar FRONTEND_URL del header o variable de entorno
@@ -86,20 +87,20 @@ func (h *InviteHandler) InviteUser(c echo.Context) error {
 	magicLink, err := h.supabase.GenerateMagicLink(req.Email, redirectURL, userData)
 	if err != nil {
 		// Marcar invitación como fallida
-		_, updateErr := db.DB.Exec("UPDATE user_invitations SET status = 'failed' WHERE id = $1", invitationID)
+		_, updateErr := q.Exec("UPDATE user_invitations SET status = 'failed' WHERE id = $1 AND church_id = $2", invitationID, churchID)
 		if updateErr != nil {
 			c.Logger().Errorf("Failed to update invitation status to 'failed' for ID %s: %v", invitationID, updateErr)
 		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{
-				"error": fmt.Sprintf("Failed to generate magic link: %v", err),
+			"error": fmt.Sprintf("Failed to generate magic link: %v", err),
 		})
 	}
 	updateQuery := `
-	UPDATE user_invitations 
+	UPDATE user_invitations
 	SET magic_link_hash = $1
-	WHERE id = $2`
+	WHERE id = $2 AND church_id = $3`
 
-	_, err = db.DB.Exec(updateQuery, magicLink.HashedToken, invitationID)
+	_, err = q.Exec(updateQuery, magicLink.HashedToken, invitationID, churchID)
 	if err != nil {
 		c.Logger().Errorf("Failed to update magic_link_hash for invitation ID %s: %v", invitationID, err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
@@ -111,7 +112,7 @@ func (h *InviteHandler) InviteUser(c echo.Context) error {
 	// ENVIAR EMAIL CON RESEND
 	// ==========================================
 	emailConfig := config.GetEmailConfig()
-	
+
 	// Solo enviar email si está configurado
 	if emailConfig.IsEmailEnabled() {
 		emailService := emails.NewEmailService(
@@ -119,7 +120,7 @@ func (h *InviteHandler) InviteUser(c echo.Context) error {
 			emailConfig.FromEmail,
 			emailConfig.FrontendURL,
 		)
-		
+
 		// Enviar email
 		emailErr := emailService.SendInvitationEmail(emails.InvitationEmailData{
 			FirstName: req.FirstName,
@@ -129,7 +130,7 @@ func (h *InviteHandler) InviteUser(c echo.Context) error {
 			MagicLink: magicLink.HashedToken, // Usamos el token como parte del link
 			ExpiresIn: "7 días",
 		})
-		
+
 		if emailErr != nil {
 			c.Logger().Errorf("Failed to send invitation email: %v", emailErr)
 			// No fallamos la invitación por error de email
@@ -156,35 +157,36 @@ func (h *InviteHandler) InviteUser(c echo.Context) error {
 func (h *InviteHandler) ResendInvitation(c echo.Context) error {
 	invitationID := c.Param("id")
 
-	db := config.GetDB()
+	churchID, _ := c.Get("church_id").(string)
+	q := config.Tx(c)
 
 	// 1. Obtener datos de la invitación
 	var inv models.InviteUserRequest
 	query := `
 			SELECT email, first_name, last_name, phone, id_number, assigned_role
 			FROM user_invitations
-			WHERE id = $1
+			WHERE id = $1 AND church_id = $2
 	`
-	err := db.DB.QueryRow(query, invitationID).Scan(
-			&inv.Email, &inv.FirstName, &inv.LastName, &inv.Phone, &inv.IdNumber, &inv.Role,
+	err := q.QueryRow(query, invitationID, churchID).Scan(
+		&inv.Email, &inv.FirstName, &inv.LastName, &inv.Phone, &inv.IdNumber, &inv.Role,
 	)
 	if err != nil {
-			return c.JSON(http.StatusNotFound, map[string]string{
-					"error": "Invitation not found",
-			})
+		return c.JSON(http.StatusNotFound, map[string]string{
+			"error": "Invitation not found",
+		})
 	}
 
 	// 2. Actualizar estado y expiración
 	updateQuery := `
 			UPDATE user_invitations
-			SET status = 'resent', 
+			SET status = 'resent',
 					expires_at = NOW() + INTERVAL '7 days',
 					updated_at = NOW()
-			WHERE id = $1
+			WHERE id = $1 AND church_id = $2
 			RETURNING expires_at
 	`
 	var newExpiresAt time.Time
-	err = db.DB.QueryRow(updateQuery, invitationID).Scan(&newExpiresAt)
+	err = q.QueryRow(updateQuery, invitationID, churchID).Scan(&newExpiresAt)
 	if err != nil {
 		c.Logger().Errorf("Failed to update invitation expiration for ID %s: %v", invitationID, err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
@@ -194,21 +196,21 @@ func (h *InviteHandler) ResendInvitation(c echo.Context) error {
 
 	// 3. Generar nuevo Magic Link
 	userData := map[string]interface{}{
-			"first_name":    inv.FirstName,
-			"last_name":     inv.LastName,
-			"phone":         inv.Phone,
-			"id_number":     inv.IdNumber,
-			"role":          inv.Role,
-			"invitation_id": invitationID,
+		"first_name":    inv.FirstName,
+		"last_name":     inv.LastName,
+		"phone":         inv.Phone,
+		"id_number":     inv.IdNumber,
+		"role":          inv.Role,
+		"invitation_id": invitationID,
 	}
 
 	redirectURL := "https://tu-dominio.com/onboarding"
 
 	_, err = h.supabase.GenerateMagicLink(inv.Email, redirectURL, userData)
 	if err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{
-					"error": "Failed to resend invitation",
-			})
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Failed to resend invitation",
+		})
 	}
 
 	return c.JSON(http.StatusOK, &models.InviteResponse{
@@ -222,58 +224,60 @@ func (h *InviteHandler) ResendInvitation(c echo.Context) error {
 
 // GetInvitations lista todas las invitaciones (para el frontend)
 func (h *InviteHandler) GetInvitations(c echo.Context) error {
-	db := config.GetDB()
+	churchID, _ := c.Get("church_id").(string)
+	q := config.Tx(c)
 
 	query := `
-			SELECT 
-					i.id, i.email, i.first_name, i.last_name, i.phone, 
+			SELECT
+					i.id, i.email, i.first_name, i.last_name, i.phone,
 					i.assigned_role, i.status, i.invited_at, i.expires_at,
 					u.first_name || ' ' || u.last_name as invited_by_name
 			FROM user_invitations i
 			LEFT JOIN users u ON i.invited_by = u.id
+			WHERE i.church_id = $1
 			ORDER BY i.invited_at DESC
 	`
 
-	rows, err := db.DB.Query(query)
+	rows, err := q.Query(query, churchID)
 	if err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{
-					"error": "Error fetching invitations",
-			})
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Error fetching invitations",
+		})
 	}
 	defer rows.Close()
 
 	invitations := []map[string]interface{}{}
 	for rows.Next() {
-			var id, email, assignedRole, status string
-			var firstName, lastName, phone sql.NullString
-			var invitedAt, expiresAt time.Time
-			var invitedByName sql.NullString
+		var id, email, assignedRole, status string
+		var firstName, lastName, phone sql.NullString
+		var invitedAt, expiresAt time.Time
+		var invitedByName sql.NullString
 
-			err := rows.Scan(
-					&id, &email, &firstName, &lastName, &phone,
-					&assignedRole, &status, &invitedAt, &expiresAt,
-					&invitedByName,
-			)
-			if err != nil {
-					fmt.Printf("Error scanning invitation row: %v\n", err)
-					return c.JSON(http.StatusInternalServerError, map[string]string{
-							"error": "Error processing invitations",
-					})
-			}
+		err := rows.Scan(
+			&id, &email, &firstName, &lastName, &phone,
+			&assignedRole, &status, &invitedAt, &expiresAt,
+			&invitedByName,
+		)
+		if err != nil {
+			fmt.Printf("Error scanning invitation row: %v\n", err)
+			return c.JSON(http.StatusInternalServerError, map[string]string{
+				"error": "Error processing invitations",
+			})
+		}
 
-			inv := map[string]interface{}{
-					"id":             id,
-					"email":          email,
-					"first_name":     firstName.String,
-					"last_name":      lastName.String,
-					"phone":          phone.String,
-					"assigned_role":  assignedRole,
-					"status":         status,
-					"invited_at":     invitedAt.Format(time.RFC3339),
-					"expires_at":     expiresAt.Format(time.RFC3339),
-					"invited_by_name": invitedByName.String,
-			}
-			invitations = append(invitations, inv)
+		inv := map[string]interface{}{
+			"id":              id,
+			"email":           email,
+			"first_name":      firstName.String,
+			"last_name":       lastName.String,
+			"phone":           phone.String,
+			"assigned_role":   assignedRole,
+			"status":          status,
+			"invited_at":      invitedAt.Format(time.RFC3339),
+			"expires_at":      expiresAt.Format(time.RFC3339),
+			"invited_by_name": invitedByName.String,
+		}
+		invitations = append(invitations, inv)
 	}
 
 	if err = rows.Err(); err != nil {
@@ -293,17 +297,18 @@ func (h *InviteHandler) AcceptInvitation(c echo.Context) error {
 	invitationID := c.Param("id")
 	userID := c.Get("user_id").(string)
 
-	db := config.GetDB()
+	churchID, _ := c.Get("church_id").(string)
+	q := config.Tx(c)
 
 	// Verificar que la invitación existe y está pendiente
 	var email string
 	var status string
 	checkQuery := `
-		SELECT email, status 
-		FROM user_invitations 
-		WHERE id = $1
+		SELECT email, status
+		FROM user_invitations
+		WHERE id = $1 AND church_id = $2
 	`
-	err := db.DB.QueryRow(checkQuery, invitationID).Scan(&email, &status)
+	err := q.QueryRow(checkQuery, invitationID, churchID).Scan(&email, &status)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return c.JSON(http.StatusNotFound, map[string]string{
@@ -317,7 +322,7 @@ func (h *InviteHandler) AcceptInvitation(c echo.Context) error {
 
 	// Verificar que el usuario autenticado corresponde al email de la invitación
 	var userEmail string
-	err = db.DB.QueryRow("SELECT email FROM users WHERE id = $1", userID).Scan(&userEmail)
+	err = q.QueryRow("SELECT email FROM users WHERE id = $1", userID).Scan(&userEmail)
 	if err != nil {
 		return c.JSON(http.StatusUnauthorized, map[string]string{
 			"error": "User not found",
@@ -335,13 +340,13 @@ func (h *InviteHandler) AcceptInvitation(c echo.Context) error {
 		UPDATE user_invitations
 		SET status = 'accepted',
 		    updated_at = NOW()
-		WHERE id = $1
+		WHERE id = $1 AND church_id = $2
 		RETURNING id, email, status, expires_at
 	`
-	
+
 	var updatedID, updatedEmail, updatedStatus string
 	var expiresAt time.Time
-	err = db.DB.QueryRow(updateQuery, invitationID).Scan(&updatedID, &updatedEmail, &updatedStatus, &expiresAt)
+	err = q.QueryRow(updateQuery, invitationID, churchID).Scan(&updatedID, &updatedEmail, &updatedStatus, &expiresAt)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Error updating invitation",

--- a/apps/backend-go/handlers/users.go
+++ b/apps/backend-go/handlers/users.go
@@ -25,7 +25,9 @@ func NewUserHandler() *UserHandler {
 	return &UserHandler{}
 }
 
-// getUserRoleLevel returns the role level for a given user ID, or -1 if not found
+// getUserRoleLevel returns the role level for a given user ID, or -1 if not found.
+// Uses the global pool directly — this is a permission-check lookup by PK
+// (globally unique UUID), not a tenant data query.
 func getUserRoleLevel(userID string) int {
 	var role string
 	err := config.GetDB().DB.QueryRow("SELECT role FROM users WHERE id = $1", userID).Scan(&role)
@@ -42,15 +44,17 @@ func getUserRoleLevel(userID string) int {
 //   - supervisor: only users assigned to them (same cell_leader_id or zone)
 //   - server/member: only their own profile
 func (h *UserHandler) GetUsers(c echo.Context) error {
-	db, err := validateDB(c)
+	q, err := validateTx(c)
 	if err != nil {
 		return err
 	}
 
+	churchID, _ := c.Get("church_id").(string)
+
 	// Get requesting user's role for resource-level filtering
 	requestingUserID := c.Get("user_id").(string)
 	var requestingRole string
-	err = db.DB.QueryRow("SELECT role FROM users WHERE id = $1", requestingUserID).Scan(&requestingRole)
+	err = q.QueryRow("SELECT role FROM users WHERE id = $1", requestingUserID).Scan(&requestingRole)
 	if err != nil {
 		c.Logger().Error("Error fetching requesting user role:", err)
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
@@ -77,14 +81,21 @@ func (h *UserHandler) GetUsers(c echo.Context) error {
 			u.onboarding_completed,
 			au.last_sign_in_at
 		FROM users u
-		LEFT JOIN user_invitations i ON u.email = i.email
-		LEFT JOIN zones z ON u.zone_id = z.id
+		LEFT JOIN user_invitations i ON u.email = i.email AND i.church_id = u.church_id
+		LEFT JOIN zones z ON u.zone_id = z.id AND z.church_id = u.church_id
 		LEFT JOIN auth.users au ON u.id = au.id
 		WHERE u.is_active = true
 	`
 
 	args := []interface{}{}
 	argCount := 0
+
+	// ── Tenant isolation: scope to current church ──
+	if churchID != "" {
+		argCount++
+		query += fmt.Sprintf(" AND u.church_id = $%d", argCount)
+		args = append(args, churchID)
+	}
 
 	// ── Resource-level filtering ──
 	// Use role level (int) for cleaner comparison with constants
@@ -97,7 +108,7 @@ func (h *UserHandler) GetUsers(c echo.Context) error {
 		args = append(args, utils.RoleAdmin)
 	case requestingRoleLevel >= utils.LevelSupervisor: // supervisor → only see their subordinates
 		argCount++
-		query += fmt.Sprintf(" AND (u.cell_leader_id = $%d OR u.zone_id = (SELECT zone_id FROM users WHERE id = $1))", argCount)
+		query += fmt.Sprintf(" AND (u.cell_leader_id = $%d OR u.zone_id = (SELECT zone_id FROM users WHERE id = $%d))", argCount, argCount)
 		args = append(args, requestingUserID)
 	default: // server/member → only their own profile
 		argCount++
@@ -151,7 +162,7 @@ func (h *UserHandler) GetUsers(c echo.Context) error {
 	// Count total matching rows (reuse same WHERE clauses)
 	var total int
 	countQuery := "SELECT COUNT(*) FROM (" + query + ") sub"
-	if err = db.DB.QueryRow(countQuery, args...).Scan(&total); err != nil {
+	if err = q.QueryRow(countQuery, args...).Scan(&total); err != nil {
 		c.Logger().Error("Count query error in GetUsers: ", err)
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
 			"error": "Error counting users",
@@ -167,7 +178,7 @@ func (h *UserHandler) GetUsers(c echo.Context) error {
 	query += fmt.Sprintf(" OFFSET $%d", argCount)
 	args = append(args, offset)
 
-	rows, err := db.DB.Query(query, args...)
+	rows, err := q.Query(query, args...)
 	if err != nil {
 		c.Logger().Error("Database query error in GetUsers: ", err)
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
@@ -228,9 +239,11 @@ func (h *UserHandler) GetUser(c echo.Context) error {
 	userID := c.Param("id")
 	currentUserID := c.Get("user_id").(string)
 
+	q := config.Tx(c)
+
 	// Get requesting user's role for resource-level filtering
 	var requestingRole string
-	err := config.GetDB().DB.QueryRow("SELECT role FROM users WHERE id = $1", currentUserID).Scan(&requestingRole)
+	err := q.QueryRow("SELECT role FROM users WHERE id = $1", currentUserID).Scan(&requestingRole)
 	if err != nil {
 		c.Logger().Error("Error fetching requesting user role:", err)
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
@@ -250,7 +263,7 @@ func (h *UserHandler) GetUser(c echo.Context) error {
 		}
 		// Check if supervisor has access to this user
 		var cellLeaderID, userZoneID sql.NullString
-		err = config.GetDB().DB.QueryRow(
+		err = q.QueryRow(
 			"SELECT cell_leader_id, zone_id FROM users WHERE id = $1", userID,
 		).Scan(&cellLeaderID, &userZoneID)
 		if err != nil {
@@ -273,12 +286,12 @@ func (h *UserHandler) GetUser(c echo.Context) error {
 			   how_found_church, ministry_interest, first_visit_date,
 			   baptized, baptism_date, is_active_member, membership_date,
 			   cell_group, cell_leader_id, role, pastoral_notes, is_active,
-			   whatsapp,created_at, updated_at
+			   whatsapp, created_at, updated_at
 		FROM users
 		WHERE id = $1
 	`
 	var user models.User
-	err = config.GetDB().DB.QueryRow(query, userID).Scan(
+	err = q.QueryRow(query, userID).Scan(
 		&user.ID, &user.FirstName, &user.LastName, &user.IdNumber, &user.Email,
 		&user.Phone, &user.Address, &user.BirthDate, &user.MaritalStatus,
 		&user.Occupation, &user.EducationLevel, &user.HowFoundChurch,
@@ -318,25 +331,28 @@ func (h *UserHandler) CreateUser(c echo.Context) error {
 		})
 	}
 
+	q := config.Tx(c)
+	churchID, _ := c.Get("church_id").(string)
+
 	query := `
 		INSERT INTO users (
 			first_name, last_name, id_number, email, phone, address,
 			birth_date, marital_status, occupation, education_level,
 			how_found_church, ministry_interest, first_visit_date,
 			baptized, baptism_date, is_active_member, membership_date,
-			cell_group, role, pastoral_notes, whatsapp
+			cell_group, role, pastoral_notes, whatsapp, church_id
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22
 		) RETURNING id
 	`
 
 	var userID string
-	err := config.GetDB().DB.QueryRow(
+	err := q.QueryRow(
 		query, req.FirstName, req.LastName, req.IdNumber, req.Email, req.Phone,
 		req.Address, req.BirthDate, req.MaritalStatus, req.Occupation,
 		req.EducationLevel, req.HowFoundChurch, req.MinistryInterest, req.FirstVisitDate,
 		req.Baptized, req.BaptismDate, req.IsActiveMember, req.MembershipDate,
-		req.CellGroup, req.Role, req.PastoralNotes, req.WhatsApp,
+		req.CellGroup, req.Role, req.PastoralNotes, req.WhatsApp, churchID,
 	).Scan(&userID)
 	if err != nil {
 		c.Logger().Error("Database error in CreateUser: ", err)
@@ -357,9 +373,11 @@ func (h *UserHandler) UpdateUser(c echo.Context) error {
 	userID := c.Param("id")
 	currentUserID := c.Get("user_id").(string)
 
+	q := config.Tx(c)
+
 	var currentUserRole string
 	var isCurrentUserSuperAdmin bool
-	err := config.GetDB().DB.QueryRow("SELECT role, COALESCE(is_super_admin, false) FROM users WHERE id = $1", currentUserID).Scan(&currentUserRole, &isCurrentUserSuperAdmin)
+	err := q.QueryRow("SELECT role, COALESCE(is_super_admin, false) FROM users WHERE id = $1", currentUserID).Scan(&currentUserRole, &isCurrentUserSuperAdmin)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return c.JSON(http.StatusUnauthorized, map[string]interface{}{
@@ -390,7 +408,7 @@ func (h *UserHandler) UpdateUser(c echo.Context) error {
 
 	// ── System super admin is protected ──
 	var isTargetSuperAdmin bool
-	config.GetDB().DB.QueryRow("SELECT COALESCE(is_super_admin, false) FROM users WHERE id = $1", userID).Scan(&isTargetSuperAdmin)
+	q.QueryRow("SELECT COALESCE(is_super_admin, false) FROM users WHERE id = $1", userID).Scan(&isTargetSuperAdmin)
 	if isTargetSuperAdmin && !isCurrentUserSuperAdmin {
 		return c.JSON(http.StatusForbidden, map[string]interface{}{
 			"error":   "Forbidden",
@@ -409,7 +427,7 @@ func (h *UserHandler) UpdateUser(c echo.Context) error {
 	// supervisor can only edit their subordinates
 	if currentUserRoleLevel == utils.LevelSupervisor && currentUserID != userID {
 		var cellLeaderID sql.NullString
-		config.GetDB().DB.QueryRow("SELECT cell_leader_id FROM users WHERE id = $1", userID).Scan(&cellLeaderID)
+		q.QueryRow("SELECT cell_leader_id FROM users WHERE id = $1", userID).Scan(&cellLeaderID)
 		if cellLeaderID.String != currentUserID {
 			return c.JSON(http.StatusForbidden, map[string]interface{}{
 				"error":   "Forbidden",
@@ -457,7 +475,7 @@ func (h *UserHandler) UpdateUser(c echo.Context) error {
 		})
 	}
 
-	result, err := config.GetDB().DB.Exec(query, args...)
+	result, err := q.Exec(query, args...)
 	if err != nil {
 		c.Logger().Error(fmt.Sprintf("Database error in UpdateUser for user %s: %v", userID, err))
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
@@ -486,6 +504,8 @@ func (h *UserHandler) UpdateUser(c echo.Context) error {
 func (h *UserHandler) DeleteUser(c echo.Context) error {
 	userID := c.Param("id")
 	currentUserID := c.Get("user_id").(string)
+
+	q := config.Tx(c)
 
 	// Cannot delete yourself
 	if currentUserID == userID {
@@ -517,7 +537,7 @@ func (h *UserHandler) DeleteUser(c echo.Context) error {
 
 	// ── System super admin is protected ──
 	var isTargetSuperAdmin bool
-	config.GetDB().DB.QueryRow("SELECT COALESCE(is_super_admin, false) FROM users WHERE id = $1", userID).Scan(&isTargetSuperAdmin)
+	q.QueryRow("SELECT COALESCE(is_super_admin, false) FROM users WHERE id = $1", userID).Scan(&isTargetSuperAdmin)
 	if isTargetSuperAdmin {
 		return c.JSON(http.StatusForbidden, map[string]interface{}{
 			"error":   "Forbidden",
@@ -528,7 +548,7 @@ func (h *UserHandler) DeleteUser(c echo.Context) error {
 	// supervisor can only delete their subordinates
 	if currentUserRoleLevel == utils.LevelSupervisor {
 		var cellLeaderID sql.NullString
-		config.GetDB().DB.QueryRow("SELECT cell_leader_id FROM users WHERE id = $1", userID).Scan(&cellLeaderID)
+		q.QueryRow("SELECT cell_leader_id FROM users WHERE id = $1", userID).Scan(&cellLeaderID)
 		if cellLeaderID.String != currentUserID {
 			return c.JSON(http.StatusForbidden, map[string]interface{}{
 				"error":   "Forbidden",
@@ -546,10 +566,10 @@ func (h *UserHandler) DeleteUser(c echo.Context) error {
 	}
 
 	query := `UPDATE users SET is_active = false, updated_at = NOW() WHERE id = $1`
-	result, err := config.GetDB().DB.Exec(query, userID)
+	result, err := q.Exec(query, userID)
 
 	if err != nil {
-		c.Logger().Error(fmt.Sprintf("Database error in UpdateUser for user %s: %v", userID, err))
+		c.Logger().Error(fmt.Sprintf("Database error in DeleteUser for user %s: %v", userID, err))
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
 			"error":   "Database error",
 			"message": err.Error(),
@@ -559,7 +579,7 @@ func (h *UserHandler) DeleteUser(c echo.Context) error {
 
 	rowsAffected, _ := result.RowsAffected()
 	if rowsAffected == 0 {
-		c.Logger().Warn(fmt.Sprintf("No rows affected when updating user %s", userID))
+		c.Logger().Warn(fmt.Sprintf("No rows affected when deleting user %s", userID))
 		return c.JSON(http.StatusNotFound, map[string]interface{}{
 			"error":   "User not found",
 			"message": fmt.Sprintf("User with ID %s does not exist", userID),
@@ -583,6 +603,8 @@ func (h *UserHandler) GetCurrentUser(c echo.Context) error {
 		})
 	}
 
+	q := config.Tx(c)
+
 	// Query by id (single source of truth - same as Auth ID)
 	query := `
 		SELECT id, first_name, last_name, id_number, email, phone, address,
@@ -597,7 +619,7 @@ func (h *UserHandler) GetCurrentUser(c echo.Context) error {
 		WHERE id = $1
 		`
 	var user models.User
-	err := config.GetDB().DB.QueryRow(query, userID).Scan(
+	err := q.QueryRow(query, userID).Scan(
 		&user.ID, &user.FirstName, &user.LastName, &user.IdNumber, &user.Email,
 		&user.Phone, &user.Address, &user.BirthDate, &user.MaritalStatus,
 		&user.Occupation, &user.EducationLevel, &user.HowFoundChurch,
@@ -650,9 +672,11 @@ func (h *UserHandler) UpdateCurrentUser(c echo.Context) error {
 		})
 	}
 
+	q := config.Tx(c)
+
 	// Verificar que el usuario exista con ese ID
 	var actualUserID string
-	err := config.GetDB().DB.QueryRow(
+	err := q.QueryRow(
 		"SELECT id FROM users WHERE id = $1", userID,
 	).Scan(&actualUserID)
 
@@ -674,7 +698,7 @@ func (h *UserHandler) UpdateCurrentUser(c echo.Context) error {
 		})
 	}
 
-	result, err := config.GetDB().DB.Exec(query, args...)
+	result, err := q.Exec(query, args...)
 
 	rowsAffected, _ := result.RowsAffected()
 	if rowsAffected == 0 {
@@ -753,7 +777,7 @@ func (h *UserHandler) CompleteOnboarding(c echo.Context) error {
 
 	query := fmt.Sprintf("UPDATE users SET %s WHERE id = $%d", strings.Join(updates, ", "), argIdx)
 
-	result, err := config.GetDB().DB.Exec(query, args...)
+	result, err := config.Tx(c).Exec(query, args...)
 	if err != nil {
 		c.Logger().Error(fmt.Sprintf("Database error in CompleteOnboarding for user %s: %v", userID, err))
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
@@ -781,8 +805,10 @@ func (h *UserHandler) CompleteOnboarding(c echo.Context) error {
 func (h *UserHandler) CreateUserDirect(c echo.Context) error {
 	currentUserID := c.Get("user_id").(string)
 
+	q := config.Tx(c)
+
 	var currentUserRole string
-	err := config.GetDB().DB.QueryRow("SELECT role FROM users WHERE id = $1", currentUserID).Scan(&currentUserRole)
+	err := q.QueryRow("SELECT role FROM users WHERE id = $1", currentUserID).Scan(&currentUserRole)
 	if err != nil {
 		return c.JSON(http.StatusUnauthorized, map[string]interface{}{
 			"error":   "User not found",
@@ -822,11 +848,12 @@ func (h *UserHandler) CreateUserDirect(c echo.Context) error {
 	}
 
 	supabase := config.NewSupabaseClient()
+	churchID, _ := c.Get("church_id").(string)
 
 	// Check if user already exists in public.users (data without login access)
 	var existingUserID, existingRole string
-	err = config.GetDB().DB.QueryRow(
-		"SELECT id, role FROM users WHERE email = $1", req.Email,
+	err = q.QueryRow(
+		"SELECT id, role FROM users WHERE email = $1 AND church_id = $2", req.Email, churchID,
 	).Scan(&existingUserID, &existingRole)
 
 	if err == nil {
@@ -860,7 +887,7 @@ func (h *UserHandler) CreateUserDirect(c echo.Context) error {
 		}
 
 		// Update existing profile
-		_, err = config.GetDB().DB.Exec(
+		_, err = q.Exec(
 			`UPDATE users SET role = $1, first_name = $2, last_name = $3,
 			 phone = COALESCE(NULLIF($4, ''), phone), id_number = COALESCE(NULLIF($5, ''), id_number),
 			 onboarding_completed = true, updated_at = NOW()
@@ -909,9 +936,9 @@ func (h *UserHandler) CreateUserDirect(c echo.Context) error {
 	query := `
 		INSERT INTO users (
 			id, email, first_name, last_name, role, phone, id_number,
-			address, onboarding_completed, is_active, created_at, updated_at
+			address, onboarding_completed, is_active, church_id, created_at, updated_at
 		) VALUES ($1, $2, $3, $4, $5, $6, $7,
-			'', true, true, NOW(), NOW())
+			'', true, true, $8, NOW(), NOW())
 		ON CONFLICT (id) DO UPDATE SET
 			role = EXCLUDED.role,
 			first_name = COALESCE(NULLIF(EXCLUDED.first_name, ''), users.first_name),
@@ -923,8 +950,8 @@ func (h *UserHandler) CreateUserDirect(c echo.Context) error {
 		`
 
 	var userID string
-	err = config.GetDB().DB.QueryRow(
-		query, newUserID, req.Email, req.FirstName, req.LastName, req.Role, req.Phone, req.IdNumber,
+	err = q.QueryRow(
+		query, newUserID, req.Email, req.FirstName, req.LastName, req.Role, req.Phone, req.IdNumber, churchID,
 	).Scan(&userID)
 	if err != nil {
 		c.Logger().Error("Database error in CreateUserDirect:", err)

--- a/apps/backend-go/handlers/zones.go
+++ b/apps/backend-go/handlers/zones.go
@@ -46,12 +46,12 @@ func validateZoneBoundaries(boundaries json.RawMessage) error {
 // GetZones obtiene todas las zonas
 
 func (h *ZonesHandler) GetZones(c echo.Context) error {
-	db, err := validateDB(c)
-
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
 
+	churchID, _ := c.Get("church_id").(string)
 	isActiveParam := c.QueryParam("is_active")
 
 	query := `
@@ -72,6 +72,13 @@ func (h *ZonesHandler) GetZones(c echo.Context) error {
 	args := []interface{}{}
 	argCount := 0
 
+	// ── Tenant isolation: scope to current church ──
+	if churchID != "" {
+		argCount++
+		query += fmt.Sprintf(" AND z.church_id = $%d", argCount)
+		args = append(args, churchID)
+	}
+
 	if isActiveParam != "" {
 		argCount++
 		query += fmt.Sprintf(" AND z.is_active = $%d", argCount)
@@ -80,7 +87,7 @@ func (h *ZonesHandler) GetZones(c echo.Context) error {
 
 	query += " ORDER BY z.name"
 
-	rows, err := db.DB.Query(query, args...)
+	rows, err := db.Query(query, args...)
 	if err != nil {
 		c.Logger().Error("Error fetching zones:", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
@@ -110,11 +117,12 @@ func (h *ZonesHandler) GetZones(c echo.Context) error {
 
 func (h *ZonesHandler) GetZone(c echo.Context) error {
 	zoneID := c.Param("id")
-	db, err := validateDB(c)
-
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
+
+	churchID, _ := c.Get("church_id").(string)
 
 	query := `
 	SELECT
@@ -127,11 +135,11 @@ func (h *ZonesHandler) GetZone(c echo.Context) error {
 		COALESCE(u.first_name || ' ' || u.last_name, '') as supervisor_name
 		FROM zones z
 		LEFT JOIN users u ON z.supervisor_id = u.id
-		WHERE z.id = $1
+		WHERE z.id = $1 AND z.church_id = $2
 	`
 
 	var z models.ZoneWithDetails
-	err = db.DB.QueryRow(query, zoneID).Scan(
+	err = db.QueryRow(query, zoneID, churchID).Scan(
 		&z.ID, &z.Name, &z.Description, &z.Color, &z.SupervisorID,
 		&z.Boundaries, &z.CenterLat, &z.CenterLng, &z.IsActive,
 		&z.TotalGroups, &z.TotalMembers, &z.AvgAttendance,
@@ -172,12 +180,12 @@ func (h *ZonesHandler) CreateZone(c echo.Context) error {
 		})
 	}
 
-	db, err := validateDB(c)
-
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
 
+	churchID, _ := c.Get("church_id").(string)
 	color := "#3b82f6"
 
 	if req.Color != "" {
@@ -185,8 +193,8 @@ func (h *ZonesHandler) CreateZone(c echo.Context) error {
 	}
 
 	query := `
-		INSERT INTO zones (name, description, color, supervisor_id, boundaries, center_lat, center_lng)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO zones (name, description, color, supervisor_id, boundaries, center_lat, center_lng, church_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id
 	`
 
@@ -212,7 +220,7 @@ func (h *ZonesHandler) CreateZone(c echo.Context) error {
 	}
 
 	var zoneID string
-	err = db.DB.QueryRow(
+	err = db.QueryRow(
 		query,
 		req.Name,
 		description,
@@ -221,6 +229,7 @@ func (h *ZonesHandler) CreateZone(c echo.Context) error {
 		boundaries,
 		req.CenterLat,
 		req.CenterLng,
+		churchID,
 	).Scan(&zoneID)
 
 	if err != nil {
@@ -254,10 +263,12 @@ func (h *ZonesHandler) UpdateZone(c echo.Context) error {
 		}
 	}
 
-	db, err := validateDB(c)
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
+
+	churchID, _ := c.Get("church_id").(string)
 
 	query := "UPDATE zones SET updated_at = NOW()"
 	args := []interface{}{}
@@ -317,7 +328,11 @@ func (h *ZonesHandler) UpdateZone(c echo.Context) error {
 	query += fmt.Sprintf(" WHERE id = $%d", argCount)
 	args = append(args, zoneID)
 
-	result, err := db.DB.Exec(query, args...)
+	argCount++
+	query += fmt.Sprintf(" AND church_id = $%d", argCount)
+	args = append(args, churchID)
+
+	result, err := db.Exec(query, args...)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Error al actualizar zona",
@@ -341,21 +356,22 @@ func (h *ZonesHandler) UpdateZone(c echo.Context) error {
 // DeleteZone - Elimina una zona, pero primero verifica si hay grupos asignados para evitar eliminar zonas activas con grupos asociados. Si hay grupos, devuelve un error indicando que no se puede eliminar la zona.
 func (h *ZonesHandler) DeleteZone(c echo.Context) error {
 	zoneID := c.Param("id")
-	db, err := validateDB(c)
-
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
 
+	churchID, _ := c.Get("church_id").(string)
+
 	var groupCount int
-	err = db.DB.QueryRow("SELECT COUNT(*) FROM discipleship_groups WHERE zone_id = $1", zoneID).Scan(&groupCount)
+	err = db.QueryRow("SELECT COUNT(*) FROM discipleship_groups WHERE zone_id = $1 AND church_id = $2", zoneID, churchID).Scan(&groupCount)
 	if err == nil && groupCount > 0 {
 		return c.JSON(http.StatusConflict, map[string]string{
 			"error": fmt.Sprintf("No se puede eliminar la zona porque tiene %d grupos asignados", groupCount),
 		})
 	}
 
-	result, err := db.DB.Exec("DELETE FROM zones WHERE id = $1", zoneID)
+	result, err := db.Exec("DELETE FROM zones WHERE id = $1 AND church_id = $2", zoneID, churchID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Error al eliminar zona",
@@ -378,10 +394,12 @@ func (h *ZonesHandler) DeleteZone(c echo.Context) error {
 // GetZoneStats obtiene estadísticas detalladas de una zona
 func (h *ZonesHandler) GetZoneStats(c echo.Context) error {
 	zoneID := c.Param("id")
-	db, err := validateDB(c)
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
+
+	churchID, _ := c.Get("church_id").(string)
 
 	query := `
 		SELECT
@@ -389,31 +407,31 @@ func (h *ZonesHandler) GetZoneStats(c echo.Context) error {
 			z.id,
 			COALESCE(COUNT(DISTINCT g.id), 0) as total_groups,
 			COALESCE(
-				(SELECT COUNT(*) FROM discipleship_group_members gm 
-				 JOIN discipleship_groups g2 ON gm.group_id = g2.id 
-				 WHERE g2.zone_id = z.id AND gm.is_active = true),
+				(SELECT COUNT(*) FROM discipleship_group_members gm
+				 JOIN discipleship_groups g2 ON gm.group_id = g2.id
+				 WHERE g2.zone_id = z.id AND gm.is_active = true AND g2.church_id = $2),
 				0
 			) as total_members,
 			COALESCE(
 				(SELECT ROUND(AVG(CASE WHEN present THEN 100.0 ELSE 0.0 END), 2)
 				 FROM discipleship_attendance a
 				 JOIN discipleship_groups g3 ON a.group_id = g3.id
-				 WHERE g3.zone_id = z.id
+				 WHERE g3.zone_id = z.id AND g3.church_id = $2
 				 AND a.meeting_date >= CURRENT_DATE - INTERVAL '30 days'),
 				0
 			) as avg_attendance,
 			COALESCE(
-				(SELECT COUNT(DISTINCT g2.leader_id) FROM discipleship_groups g2 WHERE g2.zone_id = z.id),
+				(SELECT COUNT(DISTINCT g2.leader_id) FROM discipleship_groups g2 WHERE g2.zone_id = z.id AND g2.church_id = $2),
 				0
 			) as active_leaders
 		FROM zones z
-		LEFT JOIN discipleship_groups g ON g.zone_id = z.id AND g.status = 'active'
-		WHERE z.id = $1
+		LEFT JOIN discipleship_groups g ON g.zone_id = z.id AND g.status = 'active' AND g.church_id = $2
+		WHERE z.id = $1 AND z.church_id = $2
 		GROUP BY z.id, z.name
 		`
 
 	var stats models.ZoneStats
-	err = db.DB.QueryRow(query, zoneID).Scan(
+	err = db.QueryRow(query, zoneID, churchID).Scan(
 		&stats.ZoneName,
 		&stats.ZoneID,
 		&stats.TotalGroups,
@@ -442,10 +460,12 @@ func (h *ZonesHandler) GetZoneStats(c echo.Context) error {
 
 func (h *ZonesHandler) GetZoneGroups(c echo.Context) error {
 	zoneID := c.Param("id")
-	db, err := validateDB(c)
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
+
+	churchID, _ := c.Get("church_id").(string)
 
 	query := `
 		SELECT
@@ -458,13 +478,13 @@ func (h *ZonesHandler) GetZoneGroups(c echo.Context) error {
 			COALESCE(u.first_name || ' ' || u.last_name, 'Sin líder') as leader_name,
 			COALESCE(s.first_name || ' ' || s.last_name, '') as supervisor_name
 			FROM discipleship_groups as g
-			LEFT JOIN zones z ON g.zone_id = z.id
+			LEFT JOIN zones z ON g.zone_id = z.id AND z.church_id = g.church_id
 			LEFT JOIN users u ON g.leader_id = u.id
 			LEFT JOIN users s ON g.supervisor_id = s.id
-			WHERE g.zone_id = $1
+			WHERE g.zone_id = $1 AND g.church_id = $2
 			ORDER BY g.group_name
 	`
-	rows, err := db.DB.Query(query, zoneID)
+	rows, err := db.Query(query, zoneID, churchID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Error al obtener grupos",
@@ -492,11 +512,12 @@ func (h *ZonesHandler) GetZoneGroups(c echo.Context) error {
 
 // GetMapaData obtiene datos geográficos de las zonas para mostrar en un mapa y grupos asociados para renderizar en el mapa
 func (h *ZonesHandler) GetMapData(c echo.Context) error {
-	db, err := validateDB(c)
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
 
+	churchID, _ := c.Get("church_id").(string)
 	isActiveParam := c.QueryParam("is_active")
 	selectedZoneID := c.QueryParam("zone_id")
 
@@ -537,8 +558,8 @@ func (h *ZonesHandler) GetMapData(c echo.Context) error {
 		COALESCE(gs.first_name || ' ' || gs.last_name, '') as group_supervisor_name
 	FROM zones z
 	LEFT JOIN users zu ON z.supervisor_id = zu.id
-	LEFT JOIN discipleship_groups g ON g.zone_id = z.id
-	LEFT JOIN zones z2 ON g.zone_id = z2.id
+	LEFT JOIN discipleship_groups g ON g.zone_id = z.id AND g.church_id = z.church_id
+	LEFT JOIN zones z2 ON g.zone_id = z2.id AND z2.church_id = z.church_id
 	LEFT JOIN users gl ON g.leader_id = gl.id
 	LEFT JOIN users gs ON g.supervisor_id = gs.id
 	WHERE 1=1
@@ -546,6 +567,13 @@ func (h *ZonesHandler) GetMapData(c echo.Context) error {
 
 	args := []interface{}{}
 	argCount := 0
+
+	// ── Tenant isolation ──
+	if churchID != "" {
+		argCount++
+		query += fmt.Sprintf(" AND z.church_id = $%d", argCount)
+		args = append(args, churchID)
+	}
 
 	if isActiveParam != "" {
 		argCount++
@@ -561,7 +589,7 @@ func (h *ZonesHandler) GetMapData(c echo.Context) error {
 
 	query += " ORDER BY z.name, g.group_name"
 
-	rows, err := db.DB.Query(query, args...)
+	rows, err := db.Query(query, args...)
 	if err != nil {
 		c.Logger().Error("Error fetching map data:", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
@@ -625,13 +653,15 @@ func (h *ZonesHandler) AssignGroupToZone(c echo.Context) error {
 	zoneID := c.Param("id")
 	groupID := c.Param("groupId")
 
-	db, err := validateDB(c)
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
 
+	churchID, _ := c.Get("church_id").(string)
+
 	var zoneExists bool
-	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM zones WHERE id = $1)", zoneID).Scan(&zoneExists)
+	err = db.QueryRow("SELECT EXISTS(SELECT 1 FROM zones WHERE id = $1 AND church_id = $2)", zoneID, churchID).Scan(&zoneExists)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Error al verificar zona",
@@ -643,11 +673,11 @@ func (h *ZonesHandler) AssignGroupToZone(c echo.Context) error {
 		})
 	}
 
-	_, err = db.DB.Exec(`
+	_, err = db.Exec(`
 		UPDATE discipleship_groups
 		SET zone_id = $1, updated_at = NOW()
-		WHERE id = $2
-	`, zoneID, groupID)
+		WHERE id = $2 AND church_id = $3
+	`, zoneID, groupID, churchID)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
@@ -670,13 +700,15 @@ func (h *ZonesHandler) AssignUserToZone(c echo.Context) error {
 	}
 	c.Bind(&req)
 
-	db, err := validateDB(c)
+	db, err := validateTx(c)
 	if err != nil {
 		return err
 	}
 
+	churchID, _ := c.Get("church_id").(string)
+
 	var zoneExists bool
-	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM zones WHERE id = $1)", zoneID).Scan(&zoneExists)
+	err = db.QueryRow("SELECT EXISTS(SELECT 1 FROM zones WHERE id = $1 AND church_id = $2)", zoneID, churchID).Scan(&zoneExists)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Error al verificar zona",
@@ -702,7 +734,11 @@ func (h *ZonesHandler) AssignUserToZone(c echo.Context) error {
 	query += fmt.Sprintf(" WHERE id = $%d", argCount)
 	args = append(args, userID)
 
-	_, err = db.DB.Exec(query, args...)
+	argCount++
+	query += fmt.Sprintf(" AND church_id = $%d", argCount)
+	args = append(args, churchID)
+
+	_, err = db.Exec(query, args...)
 
 	if err != nil {
 		c.Logger().Error("Error assigning user to zone:", err)

--- a/apps/backend-go/middleware/auth.go
+++ b/apps/backend-go/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -158,9 +159,18 @@ func SupabaseAuth() echo.MiddlewareFunc {
 			fmt.Printf("✅ Token valid - User: %s, Email: %s, Role: %s\n", actualUserID, claims.Email, dbRole)
 
 			// Resolve church_id: prefer JWT app_metadata claim (Phase 0+).
-			// Fallback to users.church_id column once Phase 2a adds it.
-			// TODO(phase 2a): query users.church_id as fallback when claim is absent.
+			// Fallback to users.church_id column for tokens issued before Phase 2a
+			// JWT backfill ran (i.e., existing sessions that haven't refreshed yet).
+			// Uses the global pool — the tenant tx doesn't exist yet at this point.
 			churchID := claims.AppMeta.ChurchID
+			if churchID == "" && db != nil && db.DB != nil {
+				var dbChurchID sql.NullString
+				if qErr := db.DB.QueryRow(
+					"SELECT church_id FROM users WHERE id = $1", actualUserID,
+				).Scan(&dbChurchID); qErr == nil && dbChurchID.Valid {
+					churchID = dbChurchID.String
+				}
+			}
 
 			// Agregar claims al contexto - USAR SIEMPRE EL BUSINESS UUID (id)
 			c.Set("user", claims)


### PR DESCRIPTION
## Multi-tenancy — PR 4 of 9

**First Go changes.** Redefines the DB helper chokepoint and scopes the 45 most critical query sites.

### Key changes
- **`db_helper.go`**: adds `Querier` interface + `validateTx()` returning the request-scoped `*sql.Tx` from TenantTx middleware. `validateDB` kept unchanged for handlers not yet migrated (Phase 3b/3c).
- **`middleware/auth.go`**: parses `church_id` from JWT `app_metadata`; fallback to `users.church_id` column for pre-backfill tokens; sets `church_id` on Echo context.
- **`users.go`**: 22 query sites scoped — all tenant table SELECT/INSERT/UPDATE/DELETE now use `AND church_id = $N`.
- **`zones.go`**: 13 query sites scoped.
- **`invite.go`**: 10 query sites scoped. **Critical fix**: `GetInvitations` previously had no WHERE clause at all — was returning invitations from every church.

### Safety
- `go build ./...` + `go vet ./...` clean
- Single-tenant behavior unchanged: TenantTx middleware sets church_id to Sion UUID for existing sessions
- Handlers not yet migrated still call `validateDB` (returns `*config.Database`) — no regression

### Chain position
← base: `develop` (Phases 0–2b merged)
→ next: Phase 3b (discipleship.go + events.go)