### PR TITLE
feat(reports): Compliance PR 1/3 — schema + backend foundations

### DIFF
--- a/apps/backend-go/handlers/discipleship_alerts.go
+++ b/apps/backend-go/handlers/discipleship_alerts.go
@@ -85,17 +85,30 @@ func (h *DiscipleshipAlertsHandler) GetAlerts(c echo.Context) error {
 			args = append(args, userID)
 		case 2:
 			argCount++
-			query += fmt.Sprintf(" AND a.related_group_id IN (SELECT id FROM discipleship_groups WHERE supervisor_id = $%d AND church_id = $1)", argCount)
+			query += fmt.Sprintf(" AND (a.related_group_id IN (SELECT id FROM discipleship_groups WHERE supervisor_id = $%d AND church_id = $1)", argCount)
+			args = append(args, userID)
+			argCount++
+			query += fmt.Sprintf(" OR a.addressed_to = $%d)", argCount)
 			args = append(args, userID)
 		case 3:
 			if userZoneID != nil && *userZoneID != "" {
 				argCount++
-				query += fmt.Sprintf(" AND a.zone_id = $%d", argCount)
+				query += fmt.Sprintf(" AND (a.zone_id = $%d", argCount)
 				args = append(args, *userZoneID)
+				argCount++
+				query += fmt.Sprintf(" OR a.addressed_to = $%d)", argCount)
+				args = append(args, userID)
 			} else {
-				query += " AND 1=0"
+				argCount++
+				query += fmt.Sprintf(" AND a.addressed_to = $%d", argCount)
+				args = append(args, userID)
 			}
 		case 4, 5:
+			// Coordinador/Pastoral: see all alerts in their church scope.
+			// Also surface alerts explicitly addressed to them (e.g. escalations).
+			argCount++
+			query += fmt.Sprintf(" AND (1=1 OR a.addressed_to = $%d)", argCount)
+			args = append(args, userID)
 		}
 	}
 

--- a/apps/backend-go/handlers/discipleship_reports.go
+++ b/apps/backend-go/handlers/discipleship_reports.go
@@ -332,6 +332,98 @@ func autoUpdateGoalProgressFromReport(db *config.Database, reporterID, reportID 
 	}
 }
 
+// GetZoneRollup sums level-1 leader reports in the caller's zone for the given
+// period (period_start..period_end). Used by the supervision report modal to
+// pre-fill zone totals.
+//
+// GET /api/v1/discipleship/zone-rollup?period_start=YYYY-MM-DD&period_end=YYYY-MM-DD
+//
+// Response:
+//
+//	{
+//	  zone_total_discipleships: int,
+//	  zone_total_evangelism:    int,
+//	  contributing_leaders:     int,   -- distinct reporters with a submitted/approved report
+//	  unmapped_leaders:         int,   -- level-1 hierarchy users with NULL zone_id
+//	  caller_unmapped:          bool   -- true when the caller has no zone_id
+//	}
+func (h *DiscipleshipReportsHandler) GetZoneRollup(c echo.Context) error {
+	churchID, ok := c.Get("church_id").(string)
+	if !ok || churchID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing church context"})
+	}
+
+	q, err := validateTx(c)
+	if err != nil {
+		return err
+	}
+
+	userID := c.Get("user_id").(string)
+	ps := c.QueryParam("period_start")
+	pe := c.QueryParam("period_end")
+	if ps == "" || pe == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "period_start and period_end are required (YYYY-MM-DD)",
+		})
+	}
+
+	// Resolve caller's zone_id from their discipleship_hierarchy row (church-scoped).
+	var zoneID sql.NullString
+	q.QueryRow(
+		`SELECT zone_id FROM discipleship_hierarchy WHERE user_id = $1 AND church_id = $2`,
+		userID, churchID,
+	).Scan(&zoneID)
+
+	if !zoneID.Valid || zoneID.String == "" {
+		// Caller has no zone — return zeroes and flag so the UI can warn.
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"zone_total_discipleships": 0,
+			"zone_total_evangelism":    0,
+			"contributing_leaders":     0,
+			"unmapped_leaders":         0,
+			"caller_unmapped":          true,
+		})
+	}
+
+	var disc, evang, contributing int
+	q.QueryRow(`
+		SELECT
+		  COALESCE(SUM((r.report_data->>'group_discipleships')::int), 0),
+		  COALESCE(SUM(
+		     COALESCE((r.report_data->>'group_evangelism')::int, 0) +
+		     COALESCE((r.report_data->>'leader_evangelism')::int, 0)
+		  ), 0),
+		  COUNT(DISTINCT r.reporter_id)
+		FROM discipleship_reports r
+		JOIN discipleship_hierarchy h
+		  ON h.user_id = r.reporter_id AND h.church_id = r.church_id
+		WHERE r.church_id = $1
+		  AND r.report_level = 1
+		  AND r.status IN ('submitted', 'approved')
+		  AND r.period_start >= $2
+		  AND r.period_end <= $3
+		  AND h.zone_id = $4
+	`, churchID, ps, pe, zoneID.String).Scan(&disc, &evang, &contributing)
+
+	// Unmapped leaders: level-1 users in this church with no zone_id assigned.
+	var unmapped int
+	q.QueryRow(`
+		SELECT COUNT(*)
+		FROM discipleship_hierarchy h
+		WHERE h.church_id = $1
+		  AND h.hierarchy_level = 1
+		  AND (h.zone_id IS NULL OR h.zone_id::text = '')
+	`, churchID).Scan(&unmapped)
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"zone_total_discipleships": disc,
+		"zone_total_evangelism":    evang,
+		"contributing_leaders":     contributing,
+		"unmapped_leaders":         unmapped,
+		"caller_unmapped":          false,
+	})
+}
+
 // ApproveReport aprueba un reporte
 func (h *DiscipleshipReportsHandler) ApproveReport(c echo.Context) error {
 	reportID := c.Param("id")

--- a/apps/backend-go/handlers/report_compliance.go
+++ b/apps/backend-go/handlers/report_compliance.go
@@ -1,0 +1,175 @@
+package handlers
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ReportComplianceHandler serves the /discipleship/compliance/* endpoints.
+type ReportComplianceHandler struct{}
+
+func NewReportComplianceHandler() *ReportComplianceHandler {
+	return &ReportComplianceHandler{}
+}
+
+// isoWeekLabel formats a time.Time as an ISO-8601 week string "YYYY-Www".
+// Uses Go stdlib time.ISOWeek() which implements the ISO-8601 Jan4 method,
+// matching the frontend getIsoWeek() utility in src/lib/iso-week.ts.
+func isoWeekLabel(t time.Time) string {
+	y, w := t.ISOWeek()
+	return fmt.Sprintf("%04d-W%02d", y, w)
+}
+
+// GetMyCompliance returns the compliance row for the requesting user for a given
+// ISO week. Defaults to the current ISO week when ?iso_week= is not provided.
+//
+// GET /api/v1/discipleship/compliance/me?iso_week=YYYY-Www
+//
+// Response (row found):
+//
+//	{ iso_week, status, missed_count, report_id, due_date }
+//
+// Response (no row):
+//
+//	{ iso_week, status: "pending", missed_count: 0 }
+func (h *ReportComplianceHandler) GetMyCompliance(c echo.Context) error {
+	churchID, ok := c.Get("church_id").(string)
+	if !ok || churchID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing church context"})
+	}
+	userID, ok := c.Get("user_id").(string)
+	if !ok || userID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing user context"})
+	}
+
+	q, err := validateTx(c)
+	if err != nil {
+		return err
+	}
+
+	week := c.QueryParam("iso_week")
+	if week == "" {
+		week = isoWeekLabel(time.Now())
+	}
+
+	var status string
+	var missedCount int
+	var reportID sql.NullString
+	var dueDate sql.NullString
+
+	err = q.QueryRow(`
+		SELECT status, missed_count, report_id::text, due_date::text
+		FROM report_compliance
+		WHERE church_id = $1 AND user_id = $2 AND iso_week = $3
+	`, churchID, userID, week).Scan(&status, &missedCount, &reportID, &dueDate)
+
+	if err == sql.ErrNoRows {
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"iso_week":     week,
+			"status":       "pending",
+			"missed_count": 0,
+		})
+	}
+	if err != nil {
+		c.Logger().Error("GetMyCompliance query error:", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Error al obtener cumplimiento",
+		})
+	}
+
+	resp := map[string]interface{}{
+		"iso_week":     week,
+		"status":       status,
+		"missed_count": missedCount,
+	}
+	if reportID.Valid {
+		resp["report_id"] = reportID.String
+	}
+	if dueDate.Valid {
+		resp["due_date"] = dueDate.String
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// GetSubordinatesCompliance returns per-user per-week compliance rows for all
+// direct subordinates of the requesting user in the discipleship hierarchy.
+//
+// GET /api/v1/discipleship/compliance/subordinates?weeks=8
+//
+// Default look-back window: 8 weeks.
+// Returns rows: { user_id, user_name, iso_week, period_start, status, missed_count }
+func (h *ReportComplianceHandler) GetSubordinatesCompliance(c echo.Context) error {
+	churchID, ok := c.Get("church_id").(string)
+	if !ok || churchID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing church context"})
+	}
+	userID, ok := c.Get("user_id").(string)
+	if !ok || userID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing user context"})
+	}
+
+	q, err := validateTx(c)
+	if err != nil {
+		return err
+	}
+
+	weeks := 8
+	if w := c.QueryParam("weeks"); w != "" {
+		if parsed, err := strconv.Atoi(w); err == nil && parsed > 0 {
+			weeks = parsed
+		}
+	}
+
+	rows, err := q.Query(`
+		SELECT
+			u.id                                          AS user_id,
+			COALESCE(u.first_name || ' ' || u.last_name, u.email) AS user_name,
+			rc.iso_week,
+			rc.period_start::text,
+			rc.status,
+			rc.missed_count
+		FROM discipleship_hierarchy h
+		JOIN users u ON u.id = h.user_id AND u.church_id = $1
+		JOIN report_compliance rc ON rc.user_id = h.user_id AND rc.church_id = $1
+		WHERE h.church_id = $1
+		  AND h.supervisor_id = $2
+		  AND rc.period_start >= (CURRENT_DATE - ($3 || ' weeks')::interval)::date
+		ORDER BY rc.period_start DESC, user_name ASC
+	`, churchID, userID, strconv.Itoa(weeks))
+
+	if err != nil {
+		c.Logger().Error("GetSubordinatesCompliance query error:", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Error al obtener cumplimiento de subordinados",
+		})
+	}
+	defer rows.Close()
+
+	type row struct {
+		UserID      string `json:"user_id"`
+		UserName    string `json:"user_name"`
+		IsoWeek     string `json:"iso_week"`
+		PeriodStart string `json:"period_start"`
+		Status      string `json:"status"`
+		MissedCount int    `json:"missed_count"`
+	}
+
+	var result []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.UserID, &r.UserName, &r.IsoWeek, &r.PeriodStart, &r.Status, &r.MissedCount); err != nil {
+			continue
+		}
+		result = append(result, r)
+	}
+
+	if result == nil {
+		result = []row{}
+	}
+	return c.JSON(http.StatusOK, result)
+}

--- a/apps/backend-go/models/discipleship.go
+++ b/apps/backend-go/models/discipleship.go
@@ -138,6 +138,7 @@ type DiscipleshipAlert struct {
 	Priority       int        `json:"priority"`
 	RelatedGroupID *string    `json:"related_group_id"`
 	RelatedUserID  *string    `json:"related_user_id"`
+	AddressedTo    *string    `json:"addressed_to,omitempty" db:"addressed_to"`
 	ZoneID         *string    `json:"zone_id" db:"zone_id"`
 	ZoneName       *string    `json:"zone_name" db:"zone_name"` // Obtenido de JOIN, mantener para compatibilidad
 	ActionRequired bool       `json:"action_required"`
@@ -302,6 +303,37 @@ type AddGroupMemberRequest struct {
 type UpdateGroupMemberRequest struct {
 	RoleInGroup *string `json:"role_in_group,omitempty"`
 	IsActive    *bool   `json:"is_active,omitempty"`
+}
+
+// =====================================================
+// CUMPLIMIENTO DE REPORTES (report_compliance)
+// =====================================================
+
+type ReportCompliance struct {
+	ID               string     `json:"id" db:"id"`
+	ChurchID         string     `json:"church_id" db:"church_id"`
+	UserID           string     `json:"user_id" db:"user_id"`
+	IsoWeek          string     `json:"iso_week" db:"iso_week"`
+	PeriodStart      string     `json:"period_start" db:"period_start"`
+	PeriodEnd        string     `json:"period_end" db:"period_end"`
+	DueDate          string     `json:"due_date" db:"due_date"`
+	Status           string     `json:"status" db:"status"`
+	ReportID         *string    `json:"report_id,omitempty" db:"report_id"`
+	MissedCount      int        `json:"missed_count" db:"missed_count"`
+	EscalationSent   bool       `json:"escalation_sent" db:"escalation_sent"`
+	NotifiedFailer   bool       `json:"notified_failer" db:"notified_failer"`
+	CreatedAt        time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at" db:"updated_at"`
+}
+
+// SubordinateComplianceRow is the shape returned by GetSubordinatesCompliance.
+type SubordinateComplianceRow struct {
+	UserID      string `json:"user_id"`
+	UserName    string `json:"user_name"`
+	IsoWeek     string `json:"iso_week"`
+	PeriodStart string `json:"period_start"`
+	Status      string `json:"status"`
+	MissedCount int    `json:"missed_count"`
 }
 
 // =====================================================

--- a/apps/backend-go/routes/routes.go
+++ b/apps/backend-go/routes/routes.go
@@ -132,6 +132,7 @@ func SetupRoutes(e *echo.Echo) {
 	reportsHandler := handlers.NewDiscipleshipReportsHandler()
 	alertsHandler := handlers.NewDiscipleshipAlertsHandler()
 	schedulerHandler := handlers.NewSchedulerHandler()
+	complianceHandler := handlers.NewReportComplianceHandler()
 	discipleship := protected.Group("/discipleship")
 	discipleship.Use(middleware.RequireModule(utils.ModuleDiscipleship)) // Enforce Discipleship Module
 	{
@@ -217,6 +218,13 @@ func SetupRoutes(e *echo.Echo) {
 		discipleship.GET("/dashboard-stats", discipleshipHandler.GetDashboardStatsByLevel)
 		discipleship.GET("/leaders/:id/stats", discipleshipHandler.GetLeaderGroupStats)
 		discipleship.GET("/supervisors/:id/subordinates", discipleshipHandler.GetSupervisorSubordinates)
+
+		// Zone rollup (PR1) — pre-fills supervision report modal totals
+		discipleship.GET("/zone-rollup", reportsHandler.GetZoneRollup)
+
+		// Compliance (PR1) — per-user per-ISO-week compliance tracking
+		discipleship.GET("/compliance/me", complianceHandler.GetMyCompliance)
+		discipleship.GET("/compliance/subordinates", complianceHandler.GetSubordinatesCompliance)
 	}
 
 	// Notifications routes (any authenticated user)

--- a/supabase/migrations/20260626000001_fix_alert_type_check.sql
+++ b/supabase/migrations/20260626000001_fix_alert_type_check.sql
@@ -1,0 +1,28 @@
+-- =============================================================================
+-- Migration: 20260626000001_fix_alert_type_check.sql
+-- Fix discipleship_alerts.alert_type CHECK constraint to include all live
+-- values used in code PLUS new compliance types: missed_report,
+-- escalated_non_compliance.
+--
+-- Audited alert_type strings from code:
+--   scheduler.go:134          no_reports
+--   discipleship_alerts.go    no_reports, low_attendance, spiritual_decline,
+--                             no_growth, consistency_milestone,
+--                             evangelism_champion, solid_group
+--   Legacy generic (original) critical, warning, info, success
+--   New (PR1+PR2)             missed_report, escalated_non_compliance
+-- =============================================================================
+
+DO $$ BEGIN
+  ALTER TABLE public.discipleship_alerts
+    DROP CONSTRAINT IF EXISTS discipleship_alerts_alert_type_check;
+
+  ALTER TABLE public.discipleship_alerts
+    ADD CONSTRAINT discipleship_alerts_alert_type_check
+    CHECK (alert_type IN (
+      'critical', 'warning', 'info', 'success',
+      'no_reports', 'low_attendance', 'spiritual_decline', 'no_growth',
+      'consistency_milestone', 'evangelism_champion', 'solid_group',
+      'missed_report', 'escalated_non_compliance'
+    ));
+END $$;

--- a/supabase/migrations/20260626000002_fix_report_status_check.sql
+++ b/supabase/migrations/20260626000002_fix_report_status_check.sql
@@ -1,0 +1,17 @@
+-- =============================================================================
+-- Migration: 20260626000002_fix_report_status_check.sql
+-- Fix discipleship_reports.status CHECK constraint to include
+-- 'revision_required', which is used in discipleship_reports.go:441
+-- (RejectReport handler) but was missing from the original constraint.
+-- =============================================================================
+
+DO $$ BEGIN
+  ALTER TABLE public.discipleship_reports
+    DROP CONSTRAINT IF EXISTS discipleship_reports_status_check;
+
+  ALTER TABLE public.discipleship_reports
+    ADD CONSTRAINT discipleship_reports_status_check
+    CHECK (status IN (
+      'draft', 'submitted', 'approved', 'needs_attention', 'revision_required'
+    ));
+END $$;

--- a/supabase/migrations/20260626000003_alert_addressed_to.sql
+++ b/supabase/migrations/20260626000003_alert_addressed_to.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Migration: 20260626000003_alert_addressed_to.sql
+-- Add addressed_to column to discipleship_alerts so compliance alerts can
+-- be addressed to a specific user (the failer or the supervisor to escalate to).
+--
+-- No FK to users(id) — consistent with existing related_user_id which also
+-- has no FK. This keeps the schema lightweight and avoids cascade issues.
+-- =============================================================================
+
+ALTER TABLE public.discipleship_alerts
+  ADD COLUMN IF NOT EXISTS addressed_to uuid;
+
+CREATE INDEX IF NOT EXISTS idx_disc_alerts_addressed_to
+  ON public.discipleship_alerts (church_id, addressed_to)
+  WHERE addressed_to IS NOT NULL;

--- a/supabase/migrations/20260626000004_create_report_compliance.sql
+++ b/supabase/migrations/20260626000004_create_report_compliance.sql
@@ -1,0 +1,73 @@
+-- =============================================================================
+-- Migration: 20260626000004_create_report_compliance.sql
+-- Create the report_compliance table for per-user per-ISO-week compliance
+-- tracking. Scheduler (PR2) upserts rows here each Saturday at 23:00.
+-- Request-path endpoints read and update via TenantTx (RLS enforced).
+-- Scheduler uses the superuser postgres pool and carries explicit church_id
+-- on every write, so RLS is a safety net, not the primary gate for it.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.report_compliance (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  church_id         uuid        NOT NULL REFERENCES public.churches(id),
+  user_id           uuid        NOT NULL,
+  iso_week          text        NOT NULL,             -- 'YYYY-Www' — ISO-8601
+  period_start      date        NOT NULL,             -- Monday of the ISO week
+  period_end        date        NOT NULL,             -- Saturday of the ISO week
+  due_date          date        NOT NULL,             -- Saturday (== period_end); explicit for future grace logic
+  status            text        NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'on_time', 'late', 'missed')),
+  report_id         uuid,                             -- nullable; set when a report is submitted
+  missed_count      int         NOT NULL DEFAULT 0,   -- recomputed = COUNT(status='missed') for this user
+  escalation_sent   boolean     NOT NULL DEFAULT false,
+  notified_failer   boolean     NOT NULL DEFAULT false,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (church_id, user_id, iso_week)
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+-- Fast per-user compliance history lookup
+CREATE INDEX IF NOT EXISTS idx_report_compliance_user
+  ON public.report_compliance (church_id, user_id);
+
+-- Fast per-week sweep query (scan all users in a church for a given week)
+CREATE INDEX IF NOT EXISTS idx_report_compliance_week
+  ON public.report_compliance (church_id, iso_week);
+
+-- Partial index: only missed rows — used by COUNT(status='missed') recompute
+-- and the supervisor "who failed" panel
+CREATE INDEX IF NOT EXISTS idx_report_compliance_missed
+  ON public.report_compliance (church_id, user_id)
+  WHERE status = 'missed';
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.report_compliance ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.report_compliance FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  DROP POLICY IF EXISTS tenant_isolation ON public.report_compliance;
+  CREATE POLICY tenant_isolation ON public.report_compliance
+    USING (
+      church_id = current_setting('app.current_church_id', true)::uuid
+    )
+    WITH CHECK (
+      church_id = current_setting('app.current_church_id', true)::uuid
+    );
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Grants
+-- ---------------------------------------------------------------------------
+
+-- jetro_app is the application role used by request-path handlers.
+-- The scheduler connects as postgres (superuser, BYPASSRLS) and does not
+-- need a separate grant.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.report_compliance TO jetro_app;


### PR DESCRIPTION
## Reportes inteligentes + control de cumplimiento — PR 1 of 3

**Backend + migraciones, sin UI.** Fundaciones para el control de cumplimiento de reportes semanales.

### Migraciones
- **Fix schema drift** `discipleship_alerts.alert_type` CHECK — ahora permite el set real que el código ya inserta (`no_reports`, `low_attendance`, etc.) + los nuevos `missed_report` y `escalated_non_compliance`
- **Fix schema drift** `discipleship_reports.status` CHECK — incluye `revision_required` (que `RejectReport` ya escribía)
- **`discipleship_alerts.addressed_to`** uuid nullable + índice parcial — para rutear alertas escaladas al supervisor
- **`report_compliance`** tabla nueva — tracking por persona/semana (status pending|on_time|late|missed, missed_count, escalation_sent, notified_failer), con RLS + GRANT a jetro_app

### Endpoints nuevos (church-scoped vía TenantTx)
- `GET /discipleship/zone-rollup?period_start=&period_end=` — suma las métricas de los líderes de la zona para esa semana (no acumulado)
- `GET /discipleship/compliance/me` — estado de cumplimiento del usuario
- `GET /discipleship/compliance/subordinates` — panel "quién falló" para el supervisor

### Otros
- `GetAlerts` extendido: supervisores ven alertas con `addressed_to = ellos`

### Safety
- `go build` + `go vet` limpios
- Migraciones idempotentes, aplicadas a la DB local OK
- Todas las queries church-scoped

### Chain
PR 1/3 → PR 2 (scheduler sábado + escalación) → PR 3 (frontend: week picker + rollup + panel)