### PR TITLE
feat(reports): Compliance PR 2/3 — Saturday scheduler + escalation

### DIFF
--- a/apps/backend-go/handlers/compliance_test.go
+++ b/apps/backend-go/handlers/compliance_test.go
@@ -1,0 +1,420 @@
+package handlers
+
+// compliance_test.go — Integration tests for the compliance sweep and write-through.
+//
+// ALL tests here require a real PostgreSQL database. They are guarded with:
+//   if os.Getenv("TEST_DATABASE_URL") == "" { t.Skip(...) }
+//
+// so `go test ./handlers/...` passes cleanly in CI without a DB.
+// To run locally:
+//   TEST_DATABASE_URL="postgres://postgres:password@localhost:5432/postgres?sslmode=disable" \
+//     go test ./handlers/... -v -run TestCompliance
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// openTestDB opens a *sql.DB from TEST_DATABASE_URL.
+// Returns (nil, skip-message) when the env var is absent.
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set — skipping DB integration test")
+	}
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("db.Ping: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// seedChurch creates a minimal church row and returns its UUID.
+// Cleaned up via t.Cleanup.
+func seedChurch(t *testing.T, db *sql.DB, name string) string {
+	t.Helper()
+	var id string
+	err := db.QueryRow(
+		`INSERT INTO churches (name) VALUES ($1) RETURNING id`, name,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("seedChurch %q: %v", name, err)
+	}
+	t.Cleanup(func() {
+		db.Exec(`DELETE FROM discipleship_alerts   WHERE church_id = $1`, id)
+		db.Exec(`DELETE FROM report_compliance     WHERE church_id = $1`, id)
+		db.Exec(`DELETE FROM discipleship_reports  WHERE church_id = $1`, id)
+		db.Exec(`DELETE FROM discipleship_hierarchy WHERE church_id = $1`, id)
+		db.Exec(`DELETE FROM users                 WHERE church_id = $1`, id)
+		db.Exec(`DELETE FROM churches              WHERE id = $1`, id)
+	})
+	return id
+}
+
+// seedUser creates a minimal active user and returns their UUID.
+func seedUser(t *testing.T, db *sql.DB, churchID string, email string) string {
+	t.Helper()
+	var id string
+	err := db.QueryRow(`
+		INSERT INTO users (email, church_id, role, is_active)
+		VALUES ($1, $2, 'member', true)
+		RETURNING id
+	`, email, churchID).Scan(&id)
+	if err != nil {
+		t.Fatalf("seedUser %q: %v", email, err)
+	}
+	return id
+}
+
+// seedHierarchy inserts a discipleship_hierarchy row.
+func seedHierarchy(t *testing.T, db *sql.DB, churchID, userID, supervisorID string, level int) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO discipleship_hierarchy (church_id, user_id, supervisor_id, hierarchy_level)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT DO NOTHING
+	`, churchID, userID, supervisorID, level)
+	if err != nil {
+		t.Fatalf("seedHierarchy: %v", err)
+	}
+}
+
+// seedNullSupervisorHierarchy inserts a hierarchy row without a supervisor.
+func seedNullSupervisorHierarchy(t *testing.T, db *sql.DB, churchID, userID string, level int) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO discipleship_hierarchy (church_id, user_id, supervisor_id, hierarchy_level)
+		VALUES ($1, $2, NULL, $3)
+		ON CONFLICT DO NOTHING
+	`, churchID, userID, level)
+	if err != nil {
+		t.Fatalf("seedNullSupervisorHierarchy: %v", err)
+	}
+}
+
+// countAlerts returns the count of alerts of the given type for (church, user) combinations.
+func countAlerts(t *testing.T, db *sql.DB, churchID, alertType string) int {
+	t.Helper()
+	var n int
+	db.QueryRow(`
+		SELECT COUNT(*) FROM discipleship_alerts
+		WHERE church_id = $1 AND alert_type = $2
+	`, churchID, alertType).Scan(&n)
+	return n
+}
+
+// complianceStatus returns the status field for (church, user, isoWeek).
+func complianceStatus(t *testing.T, db *sql.DB, churchID, userID, isoWeek string) string {
+	t.Helper()
+	var s string
+	err := db.QueryRow(`
+		SELECT status FROM report_compliance
+		WHERE church_id = $1 AND user_id = $2 AND iso_week = $3
+	`, churchID, userID, isoWeek).Scan(&s)
+	if err == sql.ErrNoRows {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("complianceStatus: %v", err)
+	}
+	return s
+}
+
+// complianceMissedCount returns the missed_count for (church, user, isoWeek).
+func complianceMissedCount(t *testing.T, db *sql.DB, churchID, userID, isoWeek string) int {
+	t.Helper()
+	var n int
+	db.QueryRow(`
+		SELECT missed_count FROM report_compliance
+		WHERE church_id = $1 AND user_id = $2 AND iso_week = $3
+	`, churchID, userID, isoWeek).Scan(&n)
+	return n
+}
+
+// ─── DB integration tests (skipped without TEST_DATABASE_URL) ─────────────────
+
+// TestComplianceMissedToLateTransition — spec R3 scenario "Late submission".
+//
+// Seed a compliance row with status=missed (as the sweep would create).
+// Then simulate CreateReport write-through by running the write-through SQL directly.
+// Assert: status flips to late, missed_count decrements, escalation_sent unchanged.
+func TestComplianceMissedToLateTransition(t *testing.T) {
+	db := openTestDB(t)
+
+	churchID := seedChurch(t, db, "TestChurch_MissedLate")
+	supID := seedUser(t, db, churchID, fmt.Sprintf("sup_%d@test.com", time.Now().UnixNano()))
+	userID := seedUser(t, db, churchID, fmt.Sprintf("user_%d@test.com", time.Now().UnixNano()))
+	seedHierarchy(t, db, churchID, userID, supID, 1)
+
+	week := "2026-W10"
+	monday := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	saturday := monday.AddDate(0, 0, 5)
+
+	// Seed three missed weeks so escalation_sent=true on week W10.
+	for i, w := range []string{"2026-W08", "2026-W09", "2026-W10"} {
+		wMon := monday.AddDate(0, 0, -(2-i)*7)
+		wSat := wMon.AddDate(0, 0, 5)
+		_, err := db.Exec(`
+			INSERT INTO report_compliance
+				(church_id, user_id, iso_week, period_start, period_end, due_date,
+				 status, missed_count, escalation_sent, notified_failer)
+			VALUES ($1, $2, $3, $4, $5, $5, 'missed', 3, true, true)
+		`, churchID, userID, w, wMon, wSat)
+		if err != nil {
+			t.Fatalf("seeding compliance row %s: %v", w, err)
+		}
+	}
+
+	// Now simulate write-through: user submits AFTER Saturday (so status=late).
+	submitStatus := "late"
+	_, err := db.Exec(`
+		INSERT INTO report_compliance
+			(church_id, user_id, iso_week, period_start, period_end, due_date, status, report_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, gen_random_uuid())
+		ON CONFLICT (church_id, user_id, iso_week) DO UPDATE
+		SET
+			status = CASE
+				WHEN report_compliance.status = 'missed'             THEN $7
+				WHEN report_compliance.status IN ('on_time', 'late') THEN report_compliance.status
+				ELSE $7
+			END,
+			report_id  = EXCLUDED.report_id,
+			updated_at = now()
+	`, churchID, userID, week, monday, saturday, saturday, submitStatus)
+	if err != nil {
+		t.Fatalf("write-through upsert: %v", err)
+	}
+
+	// Recompute missed_count.
+	var missed int
+	db.QueryRow(`
+		SELECT COUNT(*) FROM report_compliance
+		WHERE church_id = $1 AND user_id = $2 AND status = 'missed'
+	`, churchID, userID).Scan(&missed)
+	db.Exec(`
+		UPDATE report_compliance SET missed_count = $1, updated_at = now()
+		WHERE church_id = $2 AND user_id = $3
+	`, missed, churchID, userID)
+
+	// Assert: W10 flipped to late.
+	if got := complianceStatus(t, db, churchID, userID, week); got != "late" {
+		t.Errorf("status = %q, want late", got)
+	}
+	// missed_count should now be 2 (W08 and W09 remain missed; W10 → late).
+	if got := complianceMissedCount(t, db, churchID, userID, week); got != 2 {
+		t.Errorf("missed_count = %d, want 2", got)
+	}
+	// escalation_sent on W10 should remain true (historical — no re-fire).
+	var escalated bool
+	db.QueryRow(`
+		SELECT escalation_sent FROM report_compliance
+		WHERE church_id = $1 AND user_id = $2 AND iso_week = $3
+	`, churchID, userID, week).Scan(&escalated)
+	if !escalated {
+		t.Error("escalation_sent should remain true after missed→late flip")
+	}
+}
+
+// TestThreeMissedEscalationAndDedup — spec R4 "Escalation at 3 missed weeks + dedup".
+//
+// Run sweep for 3 distinct weeks with no report. Assert exactly 1 escalated_non_compliance
+// alert. Re-run sweep for the 3rd week. Assert still exactly 1 alert.
+func TestThreeMissedEscalationAndDedup(t *testing.T) {
+	db := openTestDB(t)
+
+	churchID := seedChurch(t, db, "TestChurch_Escalation")
+	supID := seedUser(t, db, churchID, fmt.Sprintf("sup2_%d@test.com", time.Now().UnixNano()))
+	userID := seedUser(t, db, churchID, fmt.Sprintf("user2_%d@test.com", time.Now().UnixNano()))
+	seedHierarchy(t, db, churchID, userID, supID, 1)
+
+	loc := time.UTC
+	// Three consecutive weeks with no report.
+	weeks := []struct {
+		week string
+		mon  time.Time
+	}{
+		{"2025-W01", time.Date(2024, 12, 30, 0, 0, 0, 0, loc)},
+		{"2025-W02", time.Date(2025, 1, 6, 0, 0, 0, 0, loc)},
+		{"2025-W03", time.Date(2025, 1, 13, 0, 0, 0, 0, loc)},
+	}
+
+	for _, w := range weeks {
+		sat := w.mon.AddDate(0, 0, 5)
+		n, err := sweepChurch(db, churchID, w.mon, sat, w.week)
+		if err != nil {
+			t.Fatalf("sweepChurch week %s: %v", w.week, err)
+		}
+		t.Logf("sweepChurch(%s): created %d alerts", w.week, n)
+	}
+
+	// After 3 sweeps: exactly 1 escalated_non_compliance alert.
+	got := countAlerts(t, db, churchID, "escalated_non_compliance")
+	if got != 1 {
+		t.Errorf("escalated_non_compliance count = %d, want 1", got)
+	}
+
+	// Re-run the 3rd week sweep → escalation_sent=true, so no new alert.
+	w3 := weeks[2]
+	sat3 := w3.mon.AddDate(0, 0, 5)
+	sweepChurch(db, churchID, w3.mon, sat3, w3.week)
+
+	got = countAlerts(t, db, churchID, "escalated_non_compliance")
+	if got != 1 {
+		t.Errorf("after re-sweep: escalated_non_compliance count = %d, want 1 (dedup failed)", got)
+	}
+
+	// Also check missed_report nudge dedup: each week should have exactly 1 alert.
+	gotNudges := countAlerts(t, db, churchID, "missed_report")
+	// 3 distinct weeks → 3 nudges, each deduplicated by notified_failer.
+	if gotNudges != 3 {
+		t.Errorf("missed_report count = %d, want 3 (one per week)", gotNudges)
+	}
+}
+
+// TestFailerNudgeDedup — spec R4 "Failer nudge deduplication".
+//
+// Sweep week W once → 1 missed_report alert. Sweep again → still 1.
+func TestFailerNudgeDedup(t *testing.T) {
+	db := openTestDB(t)
+
+	churchID := seedChurch(t, db, "TestChurch_NudgeDedup")
+	supID := seedUser(t, db, churchID, fmt.Sprintf("sup3_%d@test.com", time.Now().UnixNano()))
+	userID := seedUser(t, db, churchID, fmt.Sprintf("user3_%d@test.com", time.Now().UnixNano()))
+	seedHierarchy(t, db, churchID, userID, supID, 1)
+
+	loc := time.UTC
+	monday := time.Date(2025, 2, 3, 0, 0, 0, 0, loc) // 2025-W06
+	saturday := monday.AddDate(0, 0, 5)
+	week := "2025-W06"
+
+	sweepChurch(db, churchID, monday, saturday, week)
+
+	if n := countAlerts(t, db, churchID, "missed_report"); n != 1 {
+		t.Fatalf("first sweep: missed_report count = %d, want 1", n)
+	}
+
+	// Re-sweep → notified_failer=true → no new alert.
+	sweepChurch(db, churchID, monday, saturday, week)
+
+	if n := countAlerts(t, db, churchID, "missed_report"); n != 1 {
+		t.Errorf("re-sweep: missed_report count = %d, want 1 (dedup failed)", n)
+	}
+}
+
+// TestPerChurchIsolation — spec R5 "Per-Church Sweep Isolation".
+//
+// Two churches, each with one failing user. runComplianceSweep should produce
+// compliance rows and alerts scoped exclusively to their own church.
+func TestPerChurchIsolation(t *testing.T) {
+	db := openTestDB(t)
+
+	churchA := seedChurch(t, db, "TestChurchA_Isolation")
+	churchB := seedChurch(t, db, "TestChurchB_Isolation")
+
+	supA := seedUser(t, db, churchA, fmt.Sprintf("supA_%d@test.com", time.Now().UnixNano()))
+	userA := seedUser(t, db, churchA, fmt.Sprintf("userA_%d@test.com", time.Now().UnixNano()))
+	seedHierarchy(t, db, churchA, userA, supA, 1)
+
+	supB := seedUser(t, db, churchB, fmt.Sprintf("supB_%d@test.com", time.Now().UnixNano()))
+	userB := seedUser(t, db, churchB, fmt.Sprintf("userB_%d@test.com", time.Now().UnixNano()))
+	seedHierarchy(t, db, churchB, userB, supB, 1)
+
+	loc := time.UTC
+	// Use a unique past week to avoid colliding with other tests.
+	monday := time.Date(2025, 3, 3, 0, 0, 0, 0, loc) // 2025-W10
+	saturday := monday.AddDate(0, 0, 5)
+	week := "2025-W10"
+
+	// Sweep both churches.
+	sweepChurch(db, churchA, monday, saturday, week)
+	sweepChurch(db, churchB, monday, saturday, week)
+
+	// All compliance rows for churchA must have church_id=A.
+	var crossCount int
+	db.QueryRow(`
+		SELECT COUNT(*) FROM report_compliance
+		WHERE church_id = $1 AND user_id = $2
+	`, churchB, userA).Scan(&crossCount)
+	if crossCount > 0 {
+		t.Errorf("church A user found in church B compliance rows: count=%d", crossCount)
+	}
+
+	db.QueryRow(`
+		SELECT COUNT(*) FROM report_compliance
+		WHERE church_id = $1 AND user_id = $2
+	`, churchA, userB).Scan(&crossCount)
+	if crossCount > 0 {
+		t.Errorf("church B user found in church A compliance rows: count=%d", crossCount)
+	}
+
+	// All alerts for churchA must have church_id=A.
+	db.QueryRow(`
+		SELECT COUNT(*) FROM discipleship_alerts
+		WHERE church_id = $1 AND (related_user_id = $2 OR addressed_to = $2)
+	`, churchB, userA).Scan(&crossCount)
+	if crossCount > 0 {
+		t.Errorf("church A user found in church B alerts: count=%d", crossCount)
+	}
+
+	db.QueryRow(`
+		SELECT COUNT(*) FROM discipleship_alerts
+		WHERE church_id = $1 AND (related_user_id = $2 OR addressed_to = $2)
+	`, churchA, userB).Scan(&crossCount)
+	if crossCount > 0 {
+		t.Errorf("church B user found in church A alerts: count=%d", crossCount)
+	}
+}
+
+// TestIdempotentSweep — spec R3 "Sweep idempotency".
+//
+// Sweep week W twice. Assert: row count unchanged, alert count unchanged,
+// missed_count stable.
+func TestIdempotentSweep(t *testing.T) {
+	db := openTestDB(t)
+
+	churchID := seedChurch(t, db, "TestChurch_Idempotent")
+	supID := seedUser(t, db, churchID, fmt.Sprintf("sup5_%d@test.com", time.Now().UnixNano()))
+	userID := seedUser(t, db, churchID, fmt.Sprintf("user5_%d@test.com", time.Now().UnixNano()))
+	seedHierarchy(t, db, churchID, userID, supID, 1)
+
+	loc := time.UTC
+	monday := time.Date(2025, 4, 7, 0, 0, 0, 0, loc) // 2025-W15
+	saturday := monday.AddDate(0, 0, 5)
+	week := "2025-W15"
+
+	sweepChurch(db, churchID, monday, saturday, week)
+
+	// Snapshot counts after first sweep.
+	var rowCount1, alertCount1, missedCount1 int
+	db.QueryRow(`SELECT COUNT(*) FROM report_compliance WHERE church_id = $1 AND iso_week = $2`, churchID, week).Scan(&rowCount1)
+	db.QueryRow(`SELECT COUNT(*) FROM discipleship_alerts WHERE church_id = $1`, churchID).Scan(&alertCount1)
+	db.QueryRow(`SELECT missed_count FROM report_compliance WHERE church_id = $1 AND user_id = $2 AND iso_week = $3`, churchID, userID, week).Scan(&missedCount1)
+
+	// Second sweep.
+	sweepChurch(db, churchID, monday, saturday, week)
+
+	var rowCount2, alertCount2, missedCount2 int
+	db.QueryRow(`SELECT COUNT(*) FROM report_compliance WHERE church_id = $1 AND iso_week = $2`, churchID, week).Scan(&rowCount2)
+	db.QueryRow(`SELECT COUNT(*) FROM discipleship_alerts WHERE church_id = $1`, churchID).Scan(&alertCount2)
+	db.QueryRow(`SELECT missed_count FROM report_compliance WHERE church_id = $1 AND user_id = $2 AND iso_week = $3`, churchID, userID, week).Scan(&missedCount2)
+
+	if rowCount1 != rowCount2 {
+		t.Errorf("compliance row count changed: %d → %d (not idempotent)", rowCount1, rowCount2)
+	}
+	if alertCount1 != alertCount2 {
+		t.Errorf("alert count changed: %d → %d (not idempotent)", alertCount1, alertCount2)
+	}
+	if missedCount1 != missedCount2 {
+		t.Errorf("missed_count changed: %d → %d (not idempotent)", missedCount1, missedCount2)
+	}
+}

--- a/apps/backend-go/handlers/discipleship_reports.go
+++ b/apps/backend-go/handlers/discipleship_reports.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -65,6 +66,58 @@ func (h *DiscipleshipReportsHandler) CreateReport(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Error al crear reporte",
 		})
+	}
+
+	// Write-through: update report_compliance for this user+week inside the same
+	// tenant-scoped transaction. This flips a missed row to late/on_time immediately
+	// when someone submits after the Saturday sweep has already run.
+	//
+	// Status logic:
+	//   - on_time: submitted at or before Saturday 23:59:59
+	//   - late:    submitted after Saturday 23:59:59 (sweep already ran, status was missed)
+	//
+	// CASE guard in ON CONFLICT:
+	//   - missed   → flip to on_time/late (the backfill scenario)
+	//   - on_time  → keep on_time (already submitted; no downgrade)
+	//   - late     → keep late    (no downgrade)
+	//   - pending  → set to on_time/late
+	if req.PeriodStart != "" {
+		isoW, wMonday, wSaturday, wDue, parseErr := isoWeekFromDateStr(req.PeriodStart)
+		if parseErr == nil {
+			submitStatus := "on_time"
+			if time.Now().After(timeAtEndOfDay(wDue)) {
+				submitStatus = "late"
+			}
+
+			_, _ = q.Exec(`
+				INSERT INTO report_compliance
+					(church_id, user_id, iso_week, period_start, period_end, due_date, status, report_id)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+				ON CONFLICT (church_id, user_id, iso_week) DO UPDATE
+				SET
+					status = CASE
+						WHEN report_compliance.status = 'missed'             THEN $7
+						WHEN report_compliance.status IN ('on_time', 'late') THEN report_compliance.status
+						ELSE $7
+					END,
+					report_id  = EXCLUDED.report_id,
+					updated_at = now()
+			`, churchID, userID, isoW, wMonday, wSaturday, wDue, submitStatus, reportID)
+
+			// Recompute missed_count (the count decrements when missed→late/on_time).
+			var missed int
+			_ = q.QueryRow(`
+				SELECT COUNT(*)
+				FROM report_compliance
+				WHERE church_id = $1 AND user_id = $2 AND status = 'missed'
+			`, churchID, userID).Scan(&missed)
+
+			_, _ = q.Exec(`
+				UPDATE report_compliance
+				SET missed_count = $1, updated_at = now()
+				WHERE church_id = $2 AND user_id = $3
+			`, missed, churchID, userID)
+		}
 	}
 
 	// Auto-update automatic goal progress from report data (fire-and-forget)

--- a/apps/backend-go/handlers/scheduler.go
+++ b/apps/backend-go/handlers/scheduler.go
@@ -11,13 +11,13 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// StartWeeklyReportScheduler lanza el goroutine que cada martes a las 8am
-// revisa qué usuarios no enviaron su reporte semanal y genera alertas.
+// StartWeeklyReportScheduler launches the goroutine that fires every Saturday
+// at 23:00 server local time and sweeps compliance for ALL churches.
 func StartWeeklyReportScheduler() {
 	go func() {
 		for {
-			next := nextTuesdayAt8AM(time.Now())
-			log.Printf("[scheduler] próxima revisión de reportes: %s", next.Format("Mon 02/01 15:04"))
+			next := nextSaturdayAt23(time.Now())
+			log.Printf("[scheduler] próxima revisión de cumplimiento: %s", next.Format("Mon 02/01 15:04"))
 			time.Sleep(time.Until(next))
 
 			db := config.GetDB()
@@ -26,136 +26,305 @@ func StartWeeklyReportScheduler() {
 				continue
 			}
 
-			count, err := checkMissingWeeklyReports(db.DB)
+			count, err := runComplianceSweep(db.DB, time.Now())
 			if err != nil {
-				log.Printf("[scheduler] error al revisar reportes: %v", err)
+				log.Printf("[scheduler] error en sweep de cumplimiento: %v", err)
 			} else {
-				log.Printf("[scheduler] alertas de reporte faltante creadas: %d", count)
+				log.Printf("[scheduler] alertas de cumplimiento creadas: %d", count)
 			}
 		}
 	}()
 }
 
-// nextTuesdayAt8AM calcula el próximo martes a las 08:00 local.
-// Si hoy es martes pero ya pasaron las 8am, devuelve el martes siguiente.
-func nextTuesdayAt8AM(from time.Time) time.Time {
-	const tuesday = time.Tuesday
-	daysUntil := (int(tuesday) - int(from.Weekday()) + 7) % 7
-	if daysUntil == 0 && (from.Hour() > 8 || (from.Hour() == 8 && from.Minute() >= 1)) {
-		daysUntil = 7
+// nextSaturdayAt23 returns the next Saturday at 23:00 local time after `from`.
+// If `from` is already Saturday but before 23:00, it returns today's 23:00.
+// If `from` is Saturday at or after 23:01, it returns next Saturday's 23:00.
+func nextSaturdayAt23(from time.Time) time.Time {
+	const sat = time.Saturday
+	days := (int(sat) - int(from.Weekday()) + 7) % 7
+	if days == 0 && (from.Hour() > 23 || (from.Hour() == 23 && from.Minute() >= 1)) {
+		days = 7
 	}
-	target := from.AddDate(0, 0, daysUntil)
-	return time.Date(target.Year(), target.Month(), target.Day(), 8, 0, 0, 0, from.Location())
+	t := from.AddDate(0, 0, days)
+	return time.Date(t.Year(), t.Month(), t.Day(), 23, 0, 0, 0, from.Location())
 }
 
-// checkMissingWeeklyReports busca usuarios con jerarquía asignada que no
-// enviaron reporte en los últimos 7 días y crea una alerta por cada uno.
-// Retorna la cantidad de alertas nuevas creadas.
-func checkMissingWeeklyReports(db *sql.DB) (int, error) {
-	rows, err := db.Query(`
-		SELECT h.user_id,
-		       COALESCE(u.first_name || ' ' || u.last_name, u.email) AS user_name,
-		       h.hierarchy_level,
-		       h.zone_id
-		FROM discipleship_hierarchy h
-		JOIN users u ON h.user_id = u.id
-		WHERE u.is_active = true
-		  AND h.hierarchy_level BETWEEN 1 AND 4
-	`)
+// isoWeek formats a time.Time as an ISO-8601 week string "YYYY-Www".
+// Uses Go stdlib time.ISOWeek() which implements the ISO-8601 Jan4 method —
+// matches the frontend getIsoWeek() utility in src/lib/iso-week.ts.
+// NOTE: isoWeekLabel() in report_compliance.go is the same function;
+// both live in the same package so both are accessible. isoWeek is the
+// scheduler-local alias kept for test clarity.
+func isoWeek(t time.Time) string {
+	y, w := t.ISOWeek()
+	return fmt.Sprintf("%04d-W%02d", y, w)
+}
+
+// justEndedWeekBounds returns the Monday..Saturday of the ISO week that
+// contains `now`. When fired at Saturday 23:00 this is the week that just closed.
+//
+// offset: Mon=0, Tue=1, … Sat=5, Sun=6 (so Monday is subtracted by Go weekday-1 with wrap).
+func justEndedWeekBounds(now time.Time) (monday, saturday time.Time, week string) {
+	// Go's time.Weekday: Sun=0, Mon=1, … Sat=6
+	// We want Monday as day 0 of the ISO week.
+	offset := (int(now.Weekday()) + 6) % 7 // Mon→0, Tue→1, …, Sun→6
+	monday = time.Date(now.Year(), now.Month(), now.Day()-offset, 0, 0, 0, 0, now.Location())
+	saturday = monday.AddDate(0, 0, 5)
+	week = isoWeek(monday)
+	return
+}
+
+// isoWeekFromDateStr parses a YYYY-MM-DD string and derives:
+// - the ISO week label (YYYY-Www)
+// - the Monday of that ISO week (period_start)
+// - the Saturday of that ISO week (period_end / due_date)
+// - the due date (Saturday of that week, same as period_end for v1)
+// Returns an error if the string cannot be parsed.
+func isoWeekFromDateStr(s string) (isoW string, monday, saturday, dueDate time.Time, err error) {
+	t, err := time.Parse("2006-01-02", s)
 	if err != nil {
-		return 0, fmt.Errorf("consultando jerarquía: %w", err)
+		return "", time.Time{}, time.Time{}, time.Time{},
+			fmt.Errorf("isoWeekFromDateStr: invalid date %q: %w", s, err)
+	}
+	// Back up to Monday of that ISO week.
+	offset := (int(t.Weekday()) + 6) % 7
+	monday = time.Date(t.Year(), t.Month(), t.Day()-offset, 0, 0, 0, 0, t.Location())
+	saturday = monday.AddDate(0, 0, 5)
+	dueDate = saturday
+	isoW = isoWeek(monday)
+	return
+}
+
+// timeAtEndOfDay returns 23:59:59 of the given date (same location).
+// Used to determine whether a submission crossed the Saturday deadline.
+func timeAtEndOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, t.Location())
+}
+
+// runComplianceSweep fetches every church from the superuser pool, then
+// calls sweepChurch for each one using the ISO week that just ended.
+// Returns the total number of new alerts created across all churches.
+//
+// The scheduler runs OUTSIDE TenantTx (it is a background goroutine, not an
+// HTTP request), so it uses the superuser pool directly. Per-church isolation
+// is enforced by passing explicit church_id to every query inside sweepChurch.
+func runComplianceSweep(db *sql.DB, now time.Time) (int, error) {
+	monday, saturday, week := justEndedWeekBounds(now)
+
+	rows, err := db.Query(`SELECT id FROM churches`)
+	if err != nil {
+		return 0, fmt.Errorf("runComplianceSweep: fetching churches: %w", err)
 	}
 	defer rows.Close()
 
-	levelNames := map[int]string{
-		1: "Líder",
-		2: "Supervisor Auxiliar",
-		3: "Supervisor General",
-		4: "Coordinador",
-	}
-
-	count := 0
+	var churchIDs []string
 	for rows.Next() {
-		var userID, userName string
-		var level int
-		var zoneID sql.NullString
-
-		if err := rows.Scan(&userID, &userName, &level, &zoneID); err != nil {
-			continue
-		}
-
-		// ¿Ya tiene un reporte enviado/aprobado esta semana?
-		var hasReport bool
-		_ = db.QueryRow(`
-			SELECT EXISTS (
-				SELECT 1 FROM discipleship_reports
-				WHERE reporter_id   = $1
-				  AND report_level  = $2
-				  AND status        IN ('submitted', 'approved')
-				  AND period_end    >= CURRENT_DATE - INTERVAL '7 days'
-			)
-		`, userID, level).Scan(&hasReport)
-
-		if hasReport {
-			continue
-		}
-
-		// ¿Ya existe una alerta activa de no_reports para este usuario esta semana?
-		var alertExists bool
-		_ = db.QueryRow(`
-			SELECT EXISTS (
-				SELECT 1 FROM discipleship_alerts
-				WHERE related_user_id = $1
-				  AND alert_type      = 'no_reports'
-				  AND resolved        = false
-				  AND created_at      >= CURRENT_DATE - INTERVAL '7 days'
-			)
-		`, userID).Scan(&alertExists)
-
-		if alertExists {
-			continue
-		}
-
-		levelName := levelNames[level]
-		if levelName == "" {
-			levelName = fmt.Sprintf("Nivel %d", level)
-		}
-
-		var zoneIDVal interface{}
-		if zoneID.Valid && zoneID.String != "" {
-			zoneIDVal = zoneID.String
-		}
-
-		_, err = db.Exec(`
-			INSERT INTO discipleship_alerts (
-				alert_type, title, message, priority,
-				related_user_id, zone_id, action_required
-			) VALUES (
-				'no_reports', $1, $2, 2, $3, $4, true
-			)
-		`,
-			fmt.Sprintf("Reporte semanal pendiente — %s", levelName),
-			fmt.Sprintf("%s (%s) no envió su reporte semanal", userName, levelName),
-			userID,
-			zoneIDVal,
-		)
-		if err == nil {
-			count++
+		var id string
+		if rows.Scan(&id) == nil {
+			churchIDs = append(churchIDs, id)
 		}
 	}
+	rows.Close()
 
-	return count, nil
+	total := 0
+	for _, cid := range churchIDs {
+		n, err := sweepChurch(db, cid, monday, saturday, week)
+		if err != nil {
+			log.Printf("[scheduler] church %s sweep error: %v", cid, err)
+			continue
+		}
+		total += n
+	}
+	return total, nil
 }
 
-// SchedulerHandler expone endpoints para administrar el scheduler.
+// sweepChurch processes compliance for a single church for the given ISO week.
+// For every active discipleship hierarchy user at level 1-4 it:
+//  1. Checks whether they submitted a report for this exact period.
+//  2. UPSERTs a report_compliance row (CASE guard: never overwrite on_time/late → missed).
+//  3. Recomputes missed_count via COUNT (ground truth, not blind increment).
+//  4. Fires a missed_report alert (addressed to the user) if missed and not yet notified.
+//  5. Fires an escalated_non_compliance alert (addressed to the supervisor) when
+//     missed_count >= 3 and escalation has not been sent yet.
+//
+// Returns the count of new alerts created.
+func sweepChurch(db *sql.DB, churchID string, monday, saturday time.Time, week string) (int, error) {
+	due := saturday // v1: due_date == Saturday of the week
+
+	// Fetch all active hierarchy users for this church, levels 1-4.
+	rows, err := db.Query(`
+		SELECT
+			h.user_id,
+			COALESCE(u.first_name || ' ' || u.last_name, u.email) AS name,
+			h.hierarchy_level,
+			h.supervisor_id
+		FROM discipleship_hierarchy h
+		JOIN users u ON u.id = h.user_id AND u.church_id = $1
+		WHERE h.church_id = $1
+		  AND u.is_active = true
+		  AND h.hierarchy_level BETWEEN 1 AND 4
+	`, churchID)
+	if err != nil {
+		return 0, fmt.Errorf("sweepChurch(%s): fetching hierarchy: %w", churchID, err)
+	}
+	defer rows.Close()
+
+	type hierarchyUser struct {
+		uid   string
+		name  string
+		level int
+		sup   sql.NullString
+	}
+	var users []hierarchyUser
+	for rows.Next() {
+		var u hierarchyUser
+		if rows.Scan(&u.uid, &u.name, &u.level, &u.sup) == nil {
+			users = append(users, u)
+		}
+	}
+	rows.Close()
+
+	created := 0
+	for _, u := range users {
+		// 1. Did this user submit a report for this exact period?
+		var reportID sql.NullString
+		var submittedAt sql.NullTime
+		_ = db.QueryRow(`
+			SELECT id, submitted_at
+			FROM discipleship_reports
+			WHERE church_id   = $1
+			  AND reporter_id = $2
+			  AND report_level = $3
+			  AND status IN ('submitted', 'approved')
+			  AND period_start = $4
+			  AND period_end   = $5
+			ORDER BY submitted_at DESC
+			LIMIT 1
+		`, churchID, u.uid, u.level, monday, saturday).Scan(&reportID, &submittedAt)
+
+		// Determine compliance status for this week.
+		status := "missed"
+		var ridArg interface{} // nil → SQL NULL for report_id when no report exists
+		if reportID.Valid {
+			ridArg = reportID.String
+			// Submitted after Saturday 23:59:59 → late; otherwise on_time.
+			if submittedAt.Valid && submittedAt.Time.After(timeAtEndOfDay(due)) {
+				status = "late"
+			} else {
+				status = "on_time"
+			}
+		}
+
+		// 2. UPSERT compliance row.
+		// CASE guard: never overwrite an existing on_time or late status back to missed.
+		// This protects against a re-sweep clobbering a write-through flip.
+		_, _ = db.Exec(`
+			INSERT INTO report_compliance
+				(church_id, user_id, iso_week, period_start, period_end, due_date, status, report_id)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			ON CONFLICT (church_id, user_id, iso_week) DO UPDATE
+			SET
+				status = CASE
+					WHEN report_compliance.status IN ('on_time', 'late') THEN report_compliance.status
+					ELSE EXCLUDED.status
+				END,
+				report_id  = COALESCE(EXCLUDED.report_id, report_compliance.report_id),
+				updated_at = now()
+		`, churchID, u.uid, week, monday, saturday, due, status, ridArg)
+
+		// 3. Recompute missed_count from ground truth (COUNT, not increment).
+		// Updates only the current week's row to avoid a full-table update.
+		var missed int
+		_ = db.QueryRow(`
+			SELECT COUNT(*)
+			FROM report_compliance
+			WHERE church_id = $1 AND user_id = $2 AND status = 'missed'
+		`, churchID, u.uid).Scan(&missed)
+
+		_, _ = db.Exec(`
+			UPDATE report_compliance
+			SET missed_count = $1, updated_at = now()
+			WHERE church_id = $2 AND user_id = $3 AND iso_week = $4
+		`, missed, churchID, u.uid, week)
+
+		// 4. Failer nudge: fire once per (user, week) when status is missed.
+		if status == "missed" {
+			var notified bool
+			_ = db.QueryRow(`
+				SELECT notified_failer
+				FROM report_compliance
+				WHERE church_id = $1 AND user_id = $2 AND iso_week = $3
+			`, churchID, u.uid, week).Scan(&notified)
+
+			if !notified {
+				_, _ = db.Exec(`
+					INSERT INTO discipleship_alerts
+						(alert_type, title, message, priority,
+						 related_user_id, addressed_to, action_required, church_id)
+					VALUES ('missed_report', $1, $2, 3, $3, $3, true, $4)
+				`,
+					"Reporte semanal pendiente",
+					fmt.Sprintf("No enviaste tu reporte de la semana %s. Enviálo cuanto antes.", week),
+					u.uid,
+					churchID,
+				)
+				_, _ = db.Exec(`
+					UPDATE report_compliance
+					SET notified_failer = true, updated_at = now()
+					WHERE church_id = $1 AND user_id = $2 AND iso_week = $3
+				`, churchID, u.uid, week)
+				created++
+			}
+		}
+
+		// 5. Escalation to supervisor when missed_count >= 3, once per crossing event.
+		// escalation_sent is per-row (per-week), so recovery + relapse re-arms naturally:
+		// a future week's row will have escalation_sent=false when it crosses the threshold.
+		if missed >= 3 && u.sup.Valid && u.sup.String != "" {
+			var escalated bool
+			_ = db.QueryRow(`
+				SELECT escalation_sent
+				FROM report_compliance
+				WHERE church_id = $1 AND user_id = $2 AND iso_week = $3
+			`, churchID, u.uid, week).Scan(&escalated)
+
+			if !escalated {
+				_, _ = db.Exec(`
+					INSERT INTO discipleship_alerts
+						(alert_type, title, message, priority,
+						 related_user_id, addressed_to, action_required, church_id)
+					VALUES ('escalated_non_compliance', $1, $2, 1, $3, $4, true, $5)
+				`,
+					"Incumplimiento de reportes (3+ semanas)",
+					fmt.Sprintf("%s acumula %d semanas sin reporte. Requiere seguimiento.", u.name, missed),
+					u.uid,
+					u.sup.String,
+					churchID,
+				)
+				_, _ = db.Exec(`
+					UPDATE report_compliance
+					SET escalation_sent = true, updated_at = now()
+					WHERE church_id = $1 AND user_id = $2 AND iso_week = $3
+				`, churchID, u.uid, week)
+				created++
+			}
+		}
+	}
+
+	return created, nil
+}
+
+// SchedulerHandler exposes endpoints to administer the scheduler.
 type SchedulerHandler struct{}
 
 func NewSchedulerHandler() *SchedulerHandler {
 	return &SchedulerHandler{}
 }
 
-// TriggerMissingReportsCheck permite disparar la revisión manualmente
-// sin esperar al martes. Útil para testing y ejecución manual desde el panel.
+// TriggerMissingReportsCheck allows manually triggering the compliance sweep
+// without waiting for Saturday. Useful for testing and manual runs from the panel.
+//
+// POST /discipleship/trigger-report-check
 func (h *SchedulerHandler) TriggerMissingReportsCheck(c echo.Context) error {
 	db := config.GetDB()
 	if db == nil || db.DB == nil {
@@ -164,16 +333,16 @@ func (h *SchedulerHandler) TriggerMissingReportsCheck(c echo.Context) error {
 		})
 	}
 
-	count, err := checkMissingWeeklyReports(db.DB)
+	count, err := runComplianceSweep(db.DB, time.Now())
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
-			"error": fmt.Sprintf("Error al revisar reportes: %v", err),
+			"error": fmt.Sprintf("Error en sweep de cumplimiento: %v", err),
 		})
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
 		"alerts_created": count,
-		"message":        fmt.Sprintf("Revisión completada. %d alertas nuevas creadas.", count),
+		"message":        fmt.Sprintf("Sweep completado. %d alertas nuevas creadas.", count),
 		"checked_at":     time.Now().Format(time.RFC3339),
 	})
 }

--- a/apps/backend-go/handlers/scheduler_test.go
+++ b/apps/backend-go/handlers/scheduler_test.go
@@ -1,0 +1,143 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+// ─── isoWeek pure-function tests (no DB required) ────────────────────────────
+
+// TestISOWeekLabel verifies that isoWeek() matches Go stdlib time.ISOWeek()
+// for the W52/W53/W01 year-boundary dates — the canonical regression suite for
+// spec R6 (Frontend/Backend ISO Week Parity).
+//
+// These dates are intentionally chosen to exercise the Jan4 rule:
+//   2020-12-28 (Mon) → 2020-W53   (last week of 2020 is W53)
+//   2021-01-04 (Mon) → 2021-W01   (first Mon of 2021 in its own year)
+//   2025-12-29 (Mon) → 2026-W01   (Mon after Tue 2025-12-30; Jan 4 2026 is in this week)
+//   2026-01-01 (Thu) → 2026-W01   (same week as 2025-12-29)
+func TestISOWeekLabel(t *testing.T) {
+	cases := []struct {
+		date string
+		want string
+	}{
+		{"2020-12-28", "2020-W53"},
+		{"2021-01-04", "2021-W01"},
+		{"2025-12-29", "2026-W01"},
+		{"2026-01-01", "2026-W01"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.date, func(t *testing.T) {
+			parsed, err := time.Parse("2006-01-02", tc.date)
+			if err != nil {
+				t.Fatalf("cannot parse date %q: %v", tc.date, err)
+			}
+			got := isoWeek(parsed)
+			if got != tc.want {
+				t.Errorf("isoWeek(%s) = %q, want %q", tc.date, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNextSaturdayAt23 verifies the scheduler fires at the right time.
+func TestNextSaturdayAt23(t *testing.T) {
+	loc := time.UTC
+
+	cases := []struct {
+		name    string
+		from    time.Time
+		wantDay time.Weekday
+		wantH   int
+		wantM   int
+	}{
+		{
+			name:    "Wednesday → next Saturday 23:00",
+			from:    time.Date(2026, 6, 24, 10, 0, 0, 0, loc), // Wednesday
+			wantDay: time.Saturday,
+			wantH:   23,
+			wantM:   0,
+		},
+		{
+			name:    "Saturday before 23:00 → same day 23:00",
+			from:    time.Date(2026, 6, 27, 22, 0, 0, 0, loc), // Saturday 22:00
+			wantDay: time.Saturday,
+			wantH:   23,
+			wantM:   0,
+		},
+		{
+			name:    "Saturday after 23:01 → next Saturday",
+			from:    time.Date(2026, 6, 27, 23, 30, 0, 0, loc), // Saturday 23:30
+			wantDay: time.Saturday,
+			wantH:   23,
+			wantM:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextSaturdayAt23(tc.from)
+			if got.Weekday() != tc.wantDay {
+				t.Errorf("weekday = %v, want %v", got.Weekday(), tc.wantDay)
+			}
+			if got.Hour() != tc.wantH || got.Minute() != tc.wantM {
+				t.Errorf("time = %02d:%02d, want %02d:%02d", got.Hour(), got.Minute(), tc.wantH, tc.wantM)
+			}
+			// "next Saturday after 23:01" must be 7 days later, not the same day.
+			if tc.name == "Saturday after 23:01 → next Saturday" {
+				diff := got.Sub(tc.from)
+				if diff < 6*24*time.Hour {
+					t.Errorf("expected next week Saturday, got diff=%v", diff)
+				}
+			}
+		})
+	}
+}
+
+// TestJustEndedWeekBounds verifies Mon..Sat derivation for a known input.
+func TestJustEndedWeekBounds(t *testing.T) {
+	loc := time.UTC
+	// Fire on Saturday 2026-06-27 at 23:00.
+	now := time.Date(2026, 6, 27, 23, 0, 0, 0, loc)
+	monday, saturday, week := justEndedWeekBounds(now)
+
+	wantMonday := "2026-06-22"
+	wantSaturday := "2026-06-27"
+	wantWeek := "2026-W26"
+
+	if monday.Format("2006-01-02") != wantMonday {
+		t.Errorf("monday = %s, want %s", monday.Format("2006-01-02"), wantMonday)
+	}
+	if saturday.Format("2006-01-02") != wantSaturday {
+		t.Errorf("saturday = %s, want %s", saturday.Format("2006-01-02"), wantSaturday)
+	}
+	if week != wantWeek {
+		t.Errorf("week = %s, want %s", week, wantWeek)
+	}
+}
+
+// TestIsoWeekFromDateStr verifies the parse-and-derive helper used by the write-through.
+func TestIsoWeekFromDateStr(t *testing.T) {
+	isoW, monday, saturday, dueDate, err := isoWeekFromDateStr("2026-06-24")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isoW != "2026-W26" {
+		t.Errorf("isoW = %q, want 2026-W26", isoW)
+	}
+	if monday.Format("2006-01-02") != "2026-06-22" {
+		t.Errorf("monday = %s, want 2026-06-22", monday.Format("2006-01-02"))
+	}
+	if saturday.Format("2006-01-02") != "2026-06-27" {
+		t.Errorf("saturday = %s, want 2026-06-27", saturday.Format("2006-01-02"))
+	}
+	if dueDate.Format("2006-01-02") != "2026-06-27" {
+		t.Errorf("dueDate = %s, want 2026-06-27", dueDate.Format("2006-01-02"))
+	}
+
+	_, _, _, _, err2 := isoWeekFromDateStr("not-a-date")
+	if err2 == nil {
+		t.Error("expected error for invalid date, got nil")
+	}
+}


### PR DESCRIPTION
## Reportes inteligentes — PR 2 of 3 (stacked on PR #118)

**Backend Go, sin migraciones ni UI.** El motor de cumplimiento.

> ⚠️ Base = `feat/report-compliance-pr1`. Cuando se mergee PR #118, cambiar la base de este PR a `develop`.

### Scheduler reescrito
- `nextSaturdayAt23` reemplaza el martes 8am → corre **sábado 23:00** (deadline antes de la reunión del domingo)
- `runComplianceSweep` itera **por iglesia** (fix del bug multi-tenancy: el scheduler viejo no tenía church_id y creaba alertas cruzadas)
- Semana ISO Lunes→Sábado vía `time.ISOWeek()`

### Lógica de cumplimiento (`sweepChurch`)
- UPSERT en `report_compliance` por persona/semana: `on_time` / `late` / `missed`
- **CASE guard**: nunca degrada un `on_time`/`late` de vuelta a `missed` (idempotente)
- `missed_count` recalculado con `COUNT(status='missed')` — nunca incremento ciego
- **Nudge a la persona** desde la 1ra omisión (`missed_report`, addressed_to = ella), dedup por `notified_failer`
- **Escalación al supervisor** a las 3 faltas (`escalated_non_compliance`, addressed_to = supervisor_id, prioridad alta), dedup por `escalation_sent`

### Write-through en CreateReport (transición missed→late)
- Al enviar un reporte (incluso vencido), upsert del compliance: si esa semana estaba `missed`, pasa a `late` y `missed_count` baja → deja de contar para las 3

### Tests
- Puros (sin DB, corren en CI): ISO week parity (W52/W53/W01), nextSaturdayAt23, justEndedWeekBounds ✅
- Integración (skip sin TEST_DATABASE_URL): missed→late, escalación 3-faltas + dedup, nudge dedup, aislamiento por iglesia, sweep idempotente

### Chain
PR #118 (schema) ← **PR 2** ← PR 3 (frontend)