### PR TITLE
PR3 — Week picker, zone rollup auto-load, compliance panel

### DIFF
--- a/src/components/discipleship/ComplianceDashboard.tsx
+++ b/src/components/discipleship/ComplianceDashboard.tsx
@@ -1,0 +1,167 @@
+/**
+ * ComplianceDashboard — panel "quién falló qué semana" para supervisores.
+ *
+ * Lista cada subordinado con sus últimas semanas ISO como chips de color
+ * (verde a tiempo, amarillo tarde, rojo falta, gris pendiente) y un badge
+ * con el conteo de faltas. Resalta a los que tienen 3+ faltas.
+ * Responsive: en mobile cada persona es una fila apilada.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle, Clock, MinusCircle, XCircle } from 'lucide-react';
+import { DiscipleshipService, type ComplianceRow } from '@/services/discipleship.service';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type Status = ComplianceRow['status'];
+
+const STATUS_META: Record<Status, { label: string; dot: string; Icon: typeof CheckCircle }> = {
+  on_time: { label: 'A tiempo', dot: 'bg-emerald-500', Icon: CheckCircle },
+  late: { label: 'Tarde', dot: 'bg-amber-500', Icon: Clock },
+  missed: { label: 'Falta', dot: 'bg-red-500', Icon: XCircle },
+  pending: { label: 'Pendiente', dot: 'bg-slate-300', Icon: MinusCircle },
+};
+
+interface PersonCompliance {
+  userId: string;
+  userName: string;
+  missedCount: number;
+  weeks: { isoWeek: string; status: Status }[];
+}
+
+export function ComplianceDashboard({ weeks = 8 }: { weeks?: number }) {
+  const [rows, setRows] = useState<ComplianceRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    DiscipleshipService.getSubordinatesCompliance(weeks)
+      .then(data => {
+        if (!cancelled) setRows(data || []);
+      })
+      .catch(() => {
+        if (!cancelled) setError('No se pudo cargar el cumplimiento');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [weeks]);
+
+  // Agrupar filas por persona + ordenar semanas (más reciente a la derecha)
+  const people = useMemo<PersonCompliance[]>(() => {
+    const byUser = new Map<string, PersonCompliance>();
+    for (const r of rows) {
+      let p = byUser.get(r.user_id);
+      if (!p) {
+        p = { userId: r.user_id, userName: r.user_name || 'Sin nombre', missedCount: 0, weeks: [] };
+        byUser.set(r.user_id, p);
+      }
+      p.weeks.push({ isoWeek: r.iso_week, status: r.status });
+      p.missedCount = Math.max(p.missedCount, r.missed_count);
+    }
+    for (const p of byUser.values()) {
+      p.weeks.sort((a, b) => a.isoWeek.localeCompare(b.isoWeek));
+    }
+    // Los de más faltas primero
+    return [...byUser.values()].sort((a, b) => b.missedCount - a.missedCount);
+  }, [rows]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Cumplimiento de Reportes</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">{error}</CardContent>
+      </Card>
+    );
+  }
+
+  if (people.length === 0) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-2 py-10 text-center text-muted-foreground">
+          <CheckCircle className="h-8 w-8 opacity-40" />
+          <p className="text-sm">No hay subordinados con seguimiento aún.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Cumplimiento de Reportes</CardTitle>
+        <CardDescription>Últimas {weeks} semanas. 3+ faltas escalan una alerta.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Leyenda */}
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {(Object.keys(STATUS_META) as Status[]).map(s => (
+            <span key={s} className="inline-flex items-center gap-1.5">
+              <span className={`h-2.5 w-2.5 rounded-full ${STATUS_META[s].dot}`} />
+              {STATUS_META[s].label}
+            </span>
+          ))}
+        </div>
+
+        {/* Lista de personas */}
+        <div className="divide-y divide-border rounded-lg border border-border">
+          {people.map(p => {
+            const flagged = p.missedCount >= 3;
+            return (
+              <div
+                key={p.userId}
+                className={`flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between ${
+                  flagged ? 'bg-red-50/60 dark:bg-red-950/20' : ''
+                }`}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  {flagged && <AlertTriangle className="h-4 w-4 shrink-0 text-red-500" />}
+                  <span className="truncate text-sm font-medium">{p.userName}</span>
+                  {p.missedCount > 0 && (
+                    <Badge variant={flagged ? 'destructive' : 'secondary'} className="shrink-0">
+                      {p.missedCount} {p.missedCount === 1 ? 'falta' : 'faltas'}
+                    </Badge>
+                  )}
+                </div>
+                {/* Chips de semanas */}
+                <div className="flex flex-wrap gap-1.5">
+                  {p.weeks.map(w => {
+                    const meta = STATUS_META[w.status];
+                    return (
+                      <span
+                        key={w.isoWeek}
+                        title={`${w.isoWeek} — ${meta.label}`}
+                        className={`inline-flex h-6 items-center rounded-md px-1.5 text-[10px] font-semibold text-white ${meta.dot}`}
+                      >
+                        {w.isoWeek.split('-W')[1]}
+                      </span>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/discipleship/SupervisionReportModal.tsx
+++ b/src/components/discipleship/SupervisionReportModal.tsx
@@ -18,6 +18,7 @@ import type { CreateReportRequest } from '@/types/discipleship.types';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import {
+  AlertTriangle,
   BarChart3,
   BookText,
   Church,
@@ -58,6 +59,7 @@ export function SupervisionReportModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [manualAssignments, setManualAssignments] = useState<ActiveAssignment[]>([]);
   const [manualValues, setManualValues] = useState<Record<string, number>>({});
+  const [unmappedLeaders, setUnmappedLeaders] = useState(0);
   const [reportData, setReportData] = useState({
     // Trabajo de Supervisión
     new_disciples_care: 0,
@@ -98,7 +100,24 @@ export function SupervisionReportModal({
       .catch(() => {
         setManualAssignments([]);
       });
-  }, [isOpen]);
+
+    // Pre-cargar las métricas de zona sumando los reportes de los líderes de
+    // ESA semana (no acumulado). El usuario puede editar los valores después.
+    const ps = format(periodStart, 'yyyy-MM-dd');
+    const pe = format(periodEnd, 'yyyy-MM-dd');
+    DiscipleshipService.getZoneRollup(ps, pe)
+      .then((rollup) => {
+        setUnmappedLeaders(rollup.unmapped_leaders || 0);
+        setReportData((prev) => ({
+          ...prev,
+          zone_total_discipleships: rollup.zone_total_discipleships || 0,
+          zone_total_evangelism: rollup.zone_total_evangelism || 0,
+        }));
+      })
+      .catch(() => {
+        setUnmappedLeaders(0);
+      });
+  }, [isOpen, periodStart, periodEnd]);
 
   const handleSubmit = async () => {
     try {
@@ -364,6 +383,18 @@ export function SupervisionReportModal({
               </div>
               <h3 className="text-lg font-semibold">Métricas de Zona / Sector</h3>
             </div>
+            <p className="text-xs text-muted-foreground -mt-2">
+              Pre-cargado de los reportes de los líderes de esta semana. Podés ajustar los valores.
+            </p>
+            {unmappedLeaders > 0 && (
+              <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-700/50 dark:bg-amber-950/30 dark:text-amber-300">
+                <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                <span>
+                  {unmappedLeaders} líder{unmappedLeaders !== 1 ? 'es' : ''} sin zona asignada — su
+                  data no está incluida en este total.
+                </span>
+              </div>
+            )}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
               <div className="space-y-2">
                 <Label htmlFor="zone_discipleships" className="flex items-center gap-2 text-sm font-medium">

--- a/src/components/discipleship/WeekPicker.tsx
+++ b/src/components/discipleship/WeekPicker.tsx
@@ -1,0 +1,95 @@
+/**
+ * WeekPicker — compact ISO-week selector for discipleship report backfill.
+ *
+ * - Lists recent ISO weeks (default: last 8 completed weeks).
+ * - Blocks future weeks.
+ * - Shows an amber warning when a week is already reported.
+ * - Default value = justEndedWeek(now).
+ * - All dates are Monday-anchored (ISO-8601, weekStartsOn: 1).
+ */
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { addDays, format, startOfISOWeek } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { AlertTriangle } from 'lucide-react';
+import { useMemo } from 'react';
+import { getIsoWeek, type IsoWeekBounds } from '@/lib/iso-week';
+
+interface WeekPickerProps {
+  value: IsoWeekBounds;
+  onChange: (week: IsoWeekBounds) => void;
+  /** ISO week labels (e.g. "2026-W01") that already have a submitted report. */
+  existingWeeks?: string[];
+  /** How many past weeks to show in the list (default: 8). */
+  weeksToShow?: number;
+}
+
+function buildWeekList(weeksToShow: number): IsoWeekBounds[] {
+  // Start from the current ISO Monday and go back weeksToShow weeks.
+  const today = new Date();
+  const currentMonday = startOfISOWeek(today);
+  const weeks: IsoWeekBounds[] = [];
+
+  for (let i = 0; i < weeksToShow; i++) {
+    const monday = addDays(currentMonday, -7 * i);
+    const saturday = addDays(monday, 5);
+    // Block future weeks: if monday > today's ISO monday we skip (shouldn't
+    // happen with i >= 0, but defensive).
+    if (monday > currentMonday) continue;
+    weeks.push({ monday, saturday, isoWeek: getIsoWeek(monday) });
+  }
+
+  return weeks;
+}
+
+function weekLabel(bounds: IsoWeekBounds): string {
+  return `Semana del ${format(bounds.monday, 'dd MMM', { locale: es })} al ${format(bounds.saturday, 'dd MMM', { locale: es })}`;
+}
+
+export function WeekPicker({
+  value,
+  onChange,
+  existingWeeks = [],
+  weeksToShow = 8,
+}: WeekPickerProps) {
+  const weeks = useMemo(() => buildWeekList(weeksToShow), [weeksToShow]);
+
+  const isAlreadyReported = existingWeeks.includes(value.isoWeek);
+
+  const handleChange = (isoWeek: string) => {
+    const found = weeks.find(w => w.isoWeek === isoWeek);
+    if (found) onChange(found);
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <Select value={value.isoWeek} onValueChange={handleChange}>
+        <SelectTrigger className="w-full sm:w-auto min-w-[220px]">
+          <SelectValue placeholder="Seleccionar semana" />
+        </SelectTrigger>
+        <SelectContent>
+          {weeks.map(week => (
+            <SelectItem key={week.isoWeek} value={week.isoWeek}>
+              <span>{weekLabel(week)}</span>
+              {existingWeeks.includes(week.isoWeek) && (
+                <span className="ml-2 text-xs text-amber-600 font-medium">(ya reportado)</span>
+              )}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {isAlreadyReported && (
+        <div className="flex items-center gap-1.5 text-xs text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          <span>Ya existe un reporte para esta semana</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/iso-week.test.ts
+++ b/src/lib/iso-week.test.ts
@@ -1,0 +1,112 @@
+/**
+ * ISO week parity tests — spec R6.
+ *
+ * These dates are the canonical boundary cases that must match Go's
+ * time.ISOWeek() formatted as "%04d-W%02d".
+ */
+import { describe, expect, it } from 'vitest';
+import { getIsoWeek, isoWeekBounds, justEndedWeek } from './iso-week';
+
+// ---------------------------------------------------------------------------
+// getIsoWeek — W52/W53/W01 boundary + Sunday regression
+// ---------------------------------------------------------------------------
+describe('getIsoWeek', () => {
+  const cases: [string, string][] = [
+    // date (YYYY-MM-DD)       expected ISO week
+    ['2020-12-28', '2020-W53'], // last Monday of 2020 is in W53
+    ['2021-01-04', '2021-W01'], // first Monday of 2021
+    ['2025-12-29', '2026-W01'], // Monday that starts the first ISO week of 2026
+    ['2026-01-01', '2026-W01'], // Thursday of the same week — still 2026-W01
+  ];
+
+  it.each(cases)('getIsoWeek(%s) === %s', (dateStr, expected) => {
+    const [y, m, d] = dateStr.split('-').map(Number);
+    // Use UTC noon to avoid timezone shifts
+    const date = new Date(y, m - 1, d, 12, 0, 0);
+    expect(getIsoWeek(date)).toBe(expected);
+  });
+
+  // Sunday regression: Sunday must NOT advance the ISO week.
+  // 2025-12-28 is a Sunday. Its ISO week is 2025-W52 (same as Mon 2025-12-22).
+  // 2025-12-29 is the Monday that STARTS 2026-W01.
+  // Verify: Sunday 2025-12-28 does NOT return 2026-W01.
+  it('Sunday 2025-12-28 stays in 2025-W52, not 2026-W01', () => {
+    const sunday = new Date(2025, 11, 28, 12, 0, 0); // Dec 28 2025 = Sunday
+    expect(getIsoWeek(sunday)).toBe('2025-W52');
+  });
+
+  it('Monday 2025-12-29 is 2026-W01 (the NEXT week after Sunday)', () => {
+    const monday = new Date(2025, 11, 29, 12, 0, 0); // Dec 29 2025 = Monday
+    expect(getIsoWeek(monday)).toBe('2026-W01');
+  });
+
+  // Additional boundary: 2020-12-27 is a Sunday in 2020-W52,
+  // and 2020-12-28 (Monday) starts 2020-W53.
+  it('Sunday 2020-12-27 is 2020-W52, Monday 2020-12-28 is 2020-W53', () => {
+    expect(getIsoWeek(new Date(2020, 11, 27, 12, 0, 0))).toBe('2020-W52');
+    expect(getIsoWeek(new Date(2020, 11, 28, 12, 0, 0))).toBe('2020-W53');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isoWeekBounds
+// ---------------------------------------------------------------------------
+describe('isoWeekBounds', () => {
+  it('returns the ISO Monday and Saturday for a given date', () => {
+    // 2026-01-07 is a Wednesday in 2026-W02
+    const { monday, saturday, isoWeek } = isoWeekBounds(new Date(2026, 0, 7, 12));
+    expect(isoWeek).toBe('2026-W02');
+    // Monday of 2026-W02 = 2026-01-05
+    expect(monday.getFullYear()).toBe(2026);
+    expect(monday.getMonth()).toBe(0);
+    expect(monday.getDate()).toBe(5);
+    // Saturday = Monday + 5
+    expect(saturday.getDate()).toBe(10);
+  });
+
+  it('saturday is always exactly 5 days after monday', () => {
+    const { monday, saturday } = isoWeekBounds(new Date(2025, 11, 29, 12));
+    const diff = (saturday.getTime() - monday.getTime()) / (1000 * 60 * 60 * 24);
+    expect(diff).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// justEndedWeek
+// ---------------------------------------------------------------------------
+describe('justEndedWeek', () => {
+  it('on a Monday (week open), returns PREVIOUS completed week', () => {
+    // 2026-01-05 = Monday of 2026-W02. The just-ended week is 2025-W53 / 2026-W01.
+    // Actually the previous week is 2025-12-29..2026-01-03 = 2026-W01.
+    const monday = new Date(2026, 0, 5, 9, 0, 0);
+    const result = justEndedWeek(monday);
+    expect(result.isoWeek).toBe('2026-W01');
+    // monday of that week is 2025-12-29
+    expect(result.monday.getFullYear()).toBe(2025);
+    expect(result.monday.getMonth()).toBe(11); // December
+    expect(result.monday.getDate()).toBe(29);
+  });
+
+  it('on a Saturday, returns the CURRENT (just-closed) week', () => {
+    // 2026-01-03 = Saturday of 2026-W01
+    const saturday = new Date(2026, 0, 3, 23, 0, 0);
+    const result = justEndedWeek(saturday);
+    expect(result.isoWeek).toBe('2026-W01');
+    expect(result.saturday.getDate()).toBe(3);
+  });
+
+  it('on a Sunday, returns the CURRENT week (Saturday just passed)', () => {
+    // 2026-01-04 = Sunday of 2026-W01 (ISO: Sunday is still in W01)
+    // Saturday 2026-01-03 has passed, so the just-ended week is 2026-W01.
+    const sunday = new Date(2026, 0, 4, 10, 0, 0);
+    const result = justEndedWeek(sunday);
+    expect(result.isoWeek).toBe('2026-W01');
+  });
+
+  it('on a Wednesday, returns PREVIOUS completed week', () => {
+    // 2026-01-07 = Wednesday of 2026-W02. Previous = 2026-W01.
+    const wednesday = new Date(2026, 0, 7, 12, 0, 0);
+    const result = justEndedWeek(wednesday);
+    expect(result.isoWeek).toBe('2026-W01');
+  });
+});

--- a/src/lib/iso-week.ts
+++ b/src/lib/iso-week.ts
@@ -1,0 +1,99 @@
+/**
+ * ISO-8601 week utilities.
+ *
+ * All functions are Monday-anchored (weekStartsOn: 1) and produce labels
+ * identical to Go's time.ISOWeek() formatted as "%04d-W%02d".
+ *
+ * Key rule: Sunday belongs to the SAME week as the preceding Monday,
+ * not the next week. date-fns startOfISOWeek enforces this automatically.
+ */
+import { addDays, getISOWeek, getISOWeekYear, startOfISOWeek } from 'date-fns';
+
+export interface IsoWeekBounds {
+  monday: Date;
+  saturday: Date;
+  isoWeek: string;
+}
+
+/**
+ * Returns the ISO week label for a given date in the format "YYYY-Www".
+ * Matches Go's `fmt.Sprintf("%04d-W%02d", y, w)` where y, w = time.ISOWeek().
+ *
+ * Examples:
+ *   2020-12-28 → "2020-W53"
+ *   2021-01-04 → "2021-W01"
+ *   2025-12-29 → "2026-W01"
+ *   2026-01-01 → "2026-W01"
+ *   2026-01-04 (Sunday) → "2025-W53"  (same as 2025-12-29, the preceding Monday)
+ */
+export function getIsoWeek(date: Date): string {
+  const week = getISOWeek(date);
+  const year = getISOWeekYear(date);
+  return `${year}-W${String(week).padStart(2, '0')}`;
+}
+
+/**
+ * Returns Monday and Saturday (end-of-meeting-week) for the ISO week
+ * containing the given date.
+ *
+ * saturday = monday + 5 days (the cell-group meeting day).
+ */
+export function isoWeekBounds(date: Date): IsoWeekBounds {
+  const monday = startOfISOWeek(date);
+  const saturday = addDays(monday, 5);
+  const isoWeek = getIsoWeek(monday);
+  return { monday, saturday, isoWeek };
+}
+
+/**
+ * Returns the most recently COMPLETED Mon..Sat week relative to `now`.
+ *
+ * Logic:
+ * - A week is "complete" once Saturday has passed (i.e. now > saturday of that week).
+ * - If today is Sunday or any day of the current in-progress week, we return
+ *   the PREVIOUS completed Mon..Sat.
+ * - If today IS Saturday (the last day of the current week), the current week
+ *   is still considered the most recently ended one (it just closed).
+ *
+ * This mirrors Go's justEndedWeekBounds fired at Saturday 23:00: at that point
+ * the current ISO week is the just-closed week.
+ */
+export function justEndedWeek(now: Date): IsoWeekBounds {
+  const currentMonday = startOfISOWeek(now);
+  const currentSaturday = addDays(currentMonday, 5);
+
+  // If today is strictly before Saturday of the current week, the current week
+  // is still open → return the previous completed week.
+  const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const satMidnight = new Date(
+    currentSaturday.getFullYear(),
+    currentSaturday.getMonth(),
+    currentSaturday.getDate()
+  );
+
+  if (todayMidnight < satMidnight) {
+    // Current week not yet closed — go back 7 days to the previous week.
+    const prevMonday = addDays(currentMonday, -7);
+    const prevSaturday = addDays(prevMonday, 5);
+    return {
+      monday: prevMonday,
+      saturday: prevSaturday,
+      isoWeek: getIsoWeek(prevMonday),
+    };
+  }
+
+  // Today is Saturday or later (Sunday is handled above because for ISO weeks,
+  // Sunday belongs to the CURRENT week which started on its own Monday —
+  // but wait: Sunday is BEFORE Monday of the next week, so it is still in the
+  // same ISO week as the preceding Saturday). Actually Sunday's ISO week ==
+  // the week that started the preceding Monday, same as Saturday. Let's be
+  // explicit: if today is Sunday, startOfISOWeek(now) is the Monday 6 days ago,
+  // and currentSaturday is yesterday — so todayMidnight > satMidnight → we
+  // return the just-closed current week. That's correct: Sunday is AFTER Saturday
+  // meaning the previous Mon..Sat has fully closed.
+  return {
+    monday: currentMonday,
+    saturday: currentSaturday,
+    isoWeek: getIsoWeek(currentMonday),
+  };
+}

--- a/src/pages/dashboard/discipleship/AuxiliarySupervisorDashboard.tsx
+++ b/src/pages/dashboard/discipleship/AuxiliarySupervisorDashboard.tsx
@@ -1,5 +1,6 @@
 import { ReportDetailSheet } from './ReportDetailSheet';
 import { SupervisionReportModal } from '@/components/discipleship/SupervisionReportModal';
+import { ComplianceDashboard } from '@/components/discipleship/ComplianceDashboard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -18,7 +19,8 @@ import { useAuth } from '@/hooks/useAuth';
 import { useAuxiliarySupervisorData } from '@/hooks/useAuxiliarySupervisorData';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { DiscipleshipReport } from '@/types/discipleship.types';
-import { endOfWeek, format, startOfWeek, subWeeks } from 'date-fns';
+import { format } from 'date-fns';
+import { justEndedWeek } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
 import {
   CheckCircle,
@@ -92,10 +94,10 @@ const AuxiliarySupervisorDashboard: React.FC = React.memo(() => {
     }
   };
 
-  // Calcular período semanal (semana anterior)
-  const today = new Date();
-  const periodStart = startOfWeek(subWeeks(today, 1), { weekStartsOn: 0 });
-  const periodEnd = endOfWeek(subWeeks(today, 1), { weekStartsOn: 0 });
+  // Período ISO Monday-anchored (semana más reciente completada).
+  const _justEnded = justEndedWeek(new Date());
+  const periodStart = _justEnded.monday;
+  const periodEnd = _justEnded.saturday;
 
   // Validar si ya existe reporte para este período
   const hasCurrentPeriodReport = myReports.some((report: { period_start: string }) => {
@@ -574,6 +576,7 @@ const AuxiliarySupervisorDashboard: React.FC = React.memo(() => {
         value: 'approvals',
         label: pendingReportsCount > 0 ? `Aprob. · ${pendingReportsCount}` : 'Aprob.',
       },
+      { value: 'compliance', label: 'Cumplimiento' },
     ];
 
     return (
@@ -608,6 +611,7 @@ const AuxiliarySupervisorDashboard: React.FC = React.memo(() => {
           {selectedTab === 'biweekly-report' && reportContent}
           {selectedTab === 'leaders' && leadersContent}
           {selectedTab === 'approvals' && approvalsContent}
+          {selectedTab === 'compliance' && <ComplianceDashboard />}
         </div>
 
         {sharedOverlays}
@@ -702,7 +706,7 @@ const AuxiliarySupervisorDashboard: React.FC = React.memo(() => {
 
       <Tabs value={selectedTab} onValueChange={setSelectedTab} className="space-y-4">
         <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0">
-          <TabsList className="inline-flex w-full sm:grid sm:grid-cols-5 h-auto min-w-max sm:min-w-0 gap-1">
+          <TabsList className="inline-flex w-full sm:grid sm:grid-cols-6 h-auto min-w-max sm:min-w-0 gap-1">
             <TabsTrigger
               value="overview"
               className="text-xs sm:text-sm whitespace-nowrap flex-shrink-0 px-3 sm:px-2"
@@ -740,6 +744,12 @@ const AuxiliarySupervisorDashboard: React.FC = React.memo(() => {
                 </Badge>
               )}
             </TabsTrigger>
+            <TabsTrigger
+              value="compliance"
+              className="text-xs sm:text-sm whitespace-nowrap flex-shrink-0 px-3 sm:px-2"
+            >
+              Cumplimiento
+            </TabsTrigger>
           </TabsList>
         </div>
 
@@ -761,6 +771,10 @@ const AuxiliarySupervisorDashboard: React.FC = React.memo(() => {
 
         <TabsContent value="approvals" className="space-y-4">
           {approvalsContent}
+        </TabsContent>
+
+        <TabsContent value="compliance" className="space-y-4">
+          <ComplianceDashboard />
         </TabsContent>
       </Tabs>
 

--- a/src/pages/dashboard/discipleship/CoordinatorDashboard.tsx
+++ b/src/pages/dashboard/discipleship/CoordinatorDashboard.tsx
@@ -2,6 +2,7 @@ import { GoalsDashboard } from '@/pages/dashboard/GoalsDashboard';
 import { MinistryHealthTab } from './MinistryHealthTab';
 import { ReportDetailSheet } from './ReportDetailSheet';
 import { SupervisionReportModal } from '@/components/discipleship/SupervisionReportModal';
+import { ComplianceDashboard } from '@/components/discipleship/ComplianceDashboard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -15,7 +16,8 @@ import { useAuth } from '@/hooks/useAuth';
 import { useCoordinatorData } from '@/hooks/useCoordinatorData';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { DiscipleshipReport } from '@/types/discipleship.types';
-import { endOfWeek, format, startOfWeek, subWeeks } from 'date-fns';
+import { format } from 'date-fns';
+import { justEndedWeek } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
 import { Award, Building2, CheckCircle, Clock, FileText, Loader2, Plus, Users } from 'lucide-react';
 import React, { useState } from 'react';
@@ -97,10 +99,10 @@ const CoordinatorDashboard: React.FC = React.memo(() => {
     }
   };
 
-  // Calcular período semanal (semana anterior)
-  const today = new Date();
-  const periodStart = startOfWeek(subWeeks(today, 1), { weekStartsOn: 0 });
-  const periodEnd = endOfWeek(subWeeks(today, 1), { weekStartsOn: 0 });
+  // Período ISO Monday-anchored (semana más reciente completada).
+  const _justEnded = justEndedWeek(new Date());
+  const periodStart = _justEnded.monday;
+  const periodEnd = _justEnded.saturday;
 
   // Validar si ya existe reporte para este período
   const hasCurrentPeriodReport = myReports.some((report: { period_start: string }) => {
@@ -479,6 +481,7 @@ const CoordinatorDashboard: React.FC = React.memo(() => {
         label: pendingReportsCount > 0 ? `Aprob. · ${pendingReportsCount}` : 'Aprob.',
       },
       { value: 'health', label: 'Salud' },
+      { value: 'compliance', label: 'Cumplimiento' },
     ];
 
     return (
@@ -514,6 +517,7 @@ const CoordinatorDashboard: React.FC = React.memo(() => {
           {selectedTab === 'zone-performance' && zonePerformanceContent}
           {selectedTab === 'approvals' && approvalsContent}
           {selectedTab === 'health' && healthContent}
+          {selectedTab === 'compliance' && <ComplianceDashboard />}
         </div>
 
         {sharedOverlays}
@@ -609,7 +613,7 @@ const CoordinatorDashboard: React.FC = React.memo(() => {
 
       <Tabs value={selectedTab} onValueChange={setSelectedTab} className="space-y-4">
         <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0">
-          <TabsList className="inline-flex w-full sm:grid sm:grid-cols-6 h-auto min-w-max sm:min-w-0 gap-1">
+          <TabsList className="inline-flex w-full sm:grid sm:grid-cols-7 h-auto min-w-max sm:min-w-0 gap-1">
             <TabsTrigger
               value="overview"
               className="text-xs sm:text-sm whitespace-nowrap flex-shrink-0 px-3 sm:px-2"
@@ -652,6 +656,12 @@ const CoordinatorDashboard: React.FC = React.memo(() => {
             >
               Salud
             </TabsTrigger>
+            <TabsTrigger
+              value="compliance"
+              className="text-xs sm:text-sm whitespace-nowrap flex-shrink-0 px-3 sm:px-2"
+            >
+              Cumplimiento
+            </TabsTrigger>
           </TabsList>
         </div>
 
@@ -677,6 +687,10 @@ const CoordinatorDashboard: React.FC = React.memo(() => {
 
         <TabsContent value="health" className="space-y-4">
           {healthContent}
+        </TabsContent>
+
+        <TabsContent value="compliance" className="space-y-4">
+          <ComplianceDashboard />
         </TabsContent>
       </Tabs>
 

--- a/src/pages/dashboard/discipleship/GeneralSupervisorDashboard.tsx
+++ b/src/pages/dashboard/discipleship/GeneralSupervisorDashboard.tsx
@@ -1,5 +1,6 @@
 import { ReportDetailSheet } from './ReportDetailSheet';
 import { SupervisionReportModal } from '@/components/discipleship/SupervisionReportModal';
+import { ComplianceDashboard } from '@/components/discipleship/ComplianceDashboard';
 import { UserDetailSheet } from '@/components/UserDetailSheet';
 import { CreateGoalModal } from '@/components/discipleship/CreateGoalModal';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -17,7 +18,8 @@ import { useAuth } from '@/hooks/useAuth';
 import { useGeneralSupervisorData } from '@/hooks/useGeneralSupervisorData';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { DiscipleshipReport } from '@/types/discipleship.types';
-import { endOfWeek, format, startOfWeek, subWeeks } from 'date-fns';
+import { format } from 'date-fns';
+import { justEndedWeek } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
 import {
   Building,
@@ -115,10 +117,10 @@ const GeneralSupervisorDashboard: React.FC = React.memo(() => {
     }
   };
 
-  // Calcular período semanal (semana anterior)
-  const today = new Date();
-  const periodStart = startOfWeek(subWeeks(today, 1), { weekStartsOn: 0 });
-  const periodEnd = endOfWeek(subWeeks(today, 1), { weekStartsOn: 0 });
+  // Período ISO Monday-anchored (semana más reciente completada).
+  const _justEnded = justEndedWeek(new Date());
+  const periodStart = _justEnded.monday;
+  const periodEnd = _justEnded.saturday;
 
   // Validar si ya existe reporte para este período
   const hasCurrentPeriodReport = myReports.some((report: { period_start: string }) => {
@@ -557,6 +559,7 @@ const GeneralSupervisorDashboard: React.FC = React.memo(() => {
         value: 'approvals',
         label: pendingReportsCount > 0 ? `Aprob. · ${pendingReportsCount}` : 'Aprob.',
       },
+      { value: 'compliance', label: 'Cumplimiento' },
     ];
 
     return (
@@ -590,6 +593,7 @@ const GeneralSupervisorDashboard: React.FC = React.memo(() => {
           {selectedTab === 'zone-analysis' && zoneAnalysisContent}
           {selectedTab === 'monthly-report' && reportContent}
           {selectedTab === 'approvals' && approvalsContent}
+          {selectedTab === 'compliance' && <ComplianceDashboard />}
         </div>
 
         {sharedOverlays}
@@ -683,7 +687,7 @@ const GeneralSupervisorDashboard: React.FC = React.memo(() => {
 
       <Tabs value={selectedTab} onValueChange={setSelectedTab} className="space-y-4">
         <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0">
-          <TabsList className="inline-flex w-full sm:grid sm:grid-cols-4 h-auto min-w-max sm:min-w-0 gap-1">
+          <TabsList className="inline-flex w-full sm:grid sm:grid-cols-5 h-auto min-w-max sm:min-w-0 gap-1">
             <TabsTrigger
               value="overview"
               className="text-xs sm:text-sm whitespace-nowrap flex-shrink-0 px-3 sm:px-2"
@@ -714,6 +718,12 @@ const GeneralSupervisorDashboard: React.FC = React.memo(() => {
                 </Badge>
               )}
             </TabsTrigger>
+            <TabsTrigger
+              value="compliance"
+              className="text-xs sm:text-sm whitespace-nowrap flex-shrink-0 px-3 sm:px-2"
+            >
+              Cumplimiento
+            </TabsTrigger>
           </TabsList>
         </div>
 
@@ -731,6 +741,10 @@ const GeneralSupervisorDashboard: React.FC = React.memo(() => {
 
         <TabsContent value="approvals" className="space-y-4">
           {approvalsContent}
+        </TabsContent>
+
+        <TabsContent value="compliance" className="space-y-4">
+          <ComplianceDashboard />
         </TabsContent>
       </Tabs>
 

--- a/src/pages/dashboard/discipleship/LeaderDashboard.tsx
+++ b/src/pages/dashboard/discipleship/LeaderDashboard.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { LeaderReportModal } from '@/components/discipleship/LeaderReportModal';
+import { WeekPicker } from '@/components/discipleship/WeekPicker';
 import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import { MobileSectionHeader } from '@/components/mobile/MobileSectionHeader';
@@ -10,7 +11,8 @@ import { useMobileMode } from '@/hooks/useMobileMode';
 import { useLeaderDiscipleshipData } from '@/hooks/useLeaderDiscipleshipData';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { GroupMemberWithDetails } from '@/types/discipleship.types';
-import { endOfWeek, format, startOfWeek, subWeeks } from 'date-fns';
+import { addDays, format, startOfISOWeek } from 'date-fns';
+import { getIsoWeek, justEndedWeek } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
 import {
   AlertTriangle,
@@ -113,11 +115,16 @@ export default function LeaderDashboard() {
     }
   };
 
-  // Get current week dates
-  const currentWeekStart = startOfWeek(new Date(), { weekStartsOn: 0 });
-  const currentWeekEnd = endOfWeek(new Date(), { weekStartsOn: 0 });
-  const lastWeekStart = startOfWeek(subWeeks(new Date(), 1), { weekStartsOn: 0 });
-  const lastWeekEnd = endOfWeek(subWeeks(new Date(), 1), { weekStartsOn: 0 });
+  // Período ISO (Monday-anchored). selectedWeek permite al líder backfill de semanas pasadas.
+  const [selectedWeek, setSelectedWeek] = useState(justEndedWeek(new Date()));
+
+  // Derivados del período seleccionado
+  const lastWeekStart = selectedWeek.monday;
+  const lastWeekEnd = selectedWeek.saturday;
+
+  // Semana actual (para comparación con reportes existentes)
+  const currentWeekStart = startOfISOWeek(new Date());
+  const currentWeekEnd = addDays(currentWeekStart, 5);
 
   // Check if report for this week already exists
   const hasCurrentWeekReport = myReports.some((report: { period_start: string }) => {
@@ -169,15 +176,26 @@ export default function LeaderDashboard() {
 
   // ── Contenido compartido entre web y mobile ──
 
+  // Semanas que ya tienen reporte (para el aviso de duplicado en el picker)
+  const existingWeeks = myReports.map((r: { period_start: string }) =>
+    getIsoWeek(new Date(r.period_start))
+  );
+  const selectedWeekReported = existingWeeks.includes(selectedWeek.isoWeek);
+
   const reportButton = (
-    <Button
-      disabled={hasCurrentWeekReport || !myGroup}
-      onClick={() => setShowReportModal(true)}
-      className="w-full sm:w-auto"
-    >
-      <Plus className="h-4 w-4 mr-2" />
-      <span className="truncate">{hasCurrentWeekReport ? 'Reporte enviado' : 'Nuevo Reporte'}</span>
-    </Button>
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+      <WeekPicker value={selectedWeek} onChange={setSelectedWeek} existingWeeks={existingWeeks} />
+      <Button
+        disabled={selectedWeekReported || !myGroup}
+        onClick={() => setShowReportModal(true)}
+        className="w-full sm:w-auto"
+      >
+        <Plus className="h-4 w-4 mr-2" />
+        <span className="truncate">
+          {selectedWeekReported ? 'Reporte enviado' : 'Nuevo Reporte'}
+        </span>
+      </Button>
+    </div>
   );
 
   const reportModal = myGroup && (

--- a/src/services/discipleship.service.ts
+++ b/src/services/discipleship.service.ts
@@ -27,6 +27,31 @@ import type {
 } from '@/types/discipleship.types';
 import { ApiService } from './api.service';
 
+// =====================================================
+// TIPOS: Cumplimiento de Reportes
+// =====================================================
+
+/** Respuesta del endpoint GET /discipleship/zone-rollup */
+export interface ZoneRollupResponse {
+  zone_total_discipleships: number;
+  zone_total_evangelism: number;
+  contributing_leaders: number;
+  unmapped_leaders: number;
+  caller_unmapped?: boolean;
+}
+
+/** Fila de cumplimiento por usuario + semana ISO */
+export interface ComplianceRow {
+  user_id: string;
+  user_name?: string;
+  iso_week: string;
+  period_start?: string;
+  status: 'pending' | 'on_time' | 'late' | 'missed';
+  missed_count: number;
+  report_id?: string;
+  due_date?: string;
+}
+
 /** Usuario con su nivel de jerarquía de discipulado actual (puede ser null si no tiene). */
 export interface UserForHierarchy {
   id: string;
@@ -352,5 +377,27 @@ export class DiscipleshipService {
   ): Promise<MemberAttendanceStats> {
     const params = groupId ? `?group_id=${groupId}` : '';
     return ApiService.get(`${this.baseUrl}/attendance/stats/${userId}${params}`);
+  }
+
+  // =====================================================
+  // CUMPLIMIENTO DE REPORTES (report_compliance)
+  // =====================================================
+
+  static async getZoneRollup(
+    periodStart: string,
+    periodEnd: string
+  ): Promise<ZoneRollupResponse> {
+    return ApiService.get(
+      `${this.baseUrl}/zone-rollup?period_start=${periodStart}&period_end=${periodEnd}`
+    );
+  }
+
+  static async getMyCompliance(isoWeek?: string): Promise<ComplianceRow> {
+    const params = isoWeek ? `?iso_week=${isoWeek}` : '';
+    return ApiService.get(`${this.baseUrl}/compliance/me${params}`);
+  }
+
+  static async getSubordinatesCompliance(weeks = 8): Promise<ComplianceRow[]> {
+    return ApiService.get(`${this.baseUrl}/compliance/subordinates?weeks=${weeks}`);
   }
 }


### PR DESCRIPTION
## PR3 — Frontend: smart weekly reports + compliance UI

Stacked on top of **PR2** (`feat/report-compliance-pr2`). Final PR of the report-compliance chain (PR1 schema+endpoints, PR2 scheduler+sweep, PR3 frontend).

### What's in this PR

**ISO-week parity (`src/lib/iso-week.ts` + tests)**
- Shared Monday→Saturday ISO-week util matching backend `time.ISOWeek()`.
- Fixes the Sunday/Monday off-by-one that poisoned the `iso_week` key.
- 13 table tests covering W52/W53/W01 boundaries + "Sunday doesn't advance".

**WeekPicker (`src/components/discipleship/WeekPicker.tsx`)**
- Backfill selector: pick any of the last 8 ISO weeks (Monday-anchored), future blocked.
- Amber warning on already-reported weeks.

**Zone rollup auto-load (`SupervisionReportModal.tsx`)**
- "Métricas de Zona/Sector" now pre-loads by summing that specific ISO week + zone's leader reports (non-cumulative) via `getZoneRollup`.
- Amber notice when some leaders are unmapped to the zone.

**Compliance panel (`ComplianceDashboard.tsx`)**
- "Quién falló qué semana" view: color chips per week (on_time/late/missed/pending), missed-count badge, 3+ faltas highlighted with escalation note.
- Added as a "Cumplimiento" tab across Auxiliary, General, and Coordinator dashboards (web Tabs + mobile MobileSegment).

**LeaderDashboard** — Monday-anchored week selection + WeekPicker wired to existing reports.

### Verification
- `pnpm build` — clean
- `pnpm test` — 138 passed (15 files), iso-week parity included

### Follow-up
- PR1's 4 migrations must be applied to the CLOUD project (`rpacdeyavjodixeymzpb`) on merge — Render does not auto-apply.