### PR TITLE
perf(fase-3): fail-fast bajo saturación del pool + harness de carga

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ apps/backend-go/tmp/
 # Test artifacts
 test-results/
 playwright-report/
+tools/loadtest/results/
 
 # Datos sensibles de la iglesia (PII)
 data/

--- a/apps/backend-go/config/database.go
+++ b/apps/backend-go/config/database.go
@@ -3,6 +3,7 @@ package config
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -55,6 +56,33 @@ var (
 	once       sync.Once
 )
 
+// statementTimeoutMs resolves the per-query timeout (ms) from STATEMENT_TIMEOUT_MS,
+// defaulting to 5000. Returns 0 to disable (STATEMENT_TIMEOUT_MS=0).
+func statementTimeoutMs() int {
+	ms := 5000
+	if v := os.Getenv("STATEMENT_TIMEOUT_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			ms = n
+		}
+	}
+	return ms
+}
+
+// applyStatementTimeout appends a server-side statement_timeout to a postgres
+// URL DSN via the libpq `options` runtime parameter (PGOPTIONS-style). No-op
+// when ms<=0 or a statement_timeout is already present. The value is URL-encoded
+// so the space survives lib/pq's URL parsing.
+func applyStatementTimeout(dbURL string, ms int) string {
+	if ms <= 0 || strings.Contains(dbURL, "statement_timeout") {
+		return dbURL
+	}
+	sep := "?"
+	if strings.Contains(dbURL, "?") {
+		sep = "&"
+	}
+	return dbURL + sep + "options=" + url.QueryEscape(fmt.Sprintf("-c statement_timeout=%d", ms))
+}
+
 func NewDatabase() (*Database, error) {
 	dbURL := os.Getenv("SUPABASE_DB_URL")
 	if dbURL == "" {
@@ -72,6 +100,14 @@ func NewDatabase() (*Database, error) {
 			}
 		}
 	}
+
+	// Fase 3 (scalability): cap every query with a server-side statement_timeout
+	// so a hung query is aborted by Postgres and its pooled connection released —
+	// instead of being held for the whole request, which saturated the 15-conn
+	// pool at ~200 VUs in the baseline (see the hardening spec). Applies to ALL
+	// queries (tx and non-tx), enforced regardless of whether the Go call passes
+	// a context. Override with STATEMENT_TIMEOUT_MS (0 disables).
+	dbURL = applyStatementTimeout(dbURL, statementTimeoutMs())
 
 	db, err := sql.Open("postgres", dbURL)
 	if err != nil {

--- a/apps/backend-go/config/database_test.go
+++ b/apps/backend-go/config/database_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lib/pq"
+)
+
+// applyStatementTimeout must produce a DSN that lib/pq can actually parse — a
+// malformed connection string would panic the backend on startup (GetDB).
+func TestApplyStatementTimeout(t *testing.T) {
+	base := "postgres://postgres:postgres@127.0.0.1:54322/postgres?sslmode=disable"
+
+	got := applyStatementTimeout(base, 5000)
+
+	// The critical guarantee: lib/pq accepts the result (uses the same ParseURL
+	// path as sql.Open under the hood).
+	dsn, err := pq.ParseURL(got)
+	if err != nil {
+		t.Fatalf("pq.ParseURL rejected the DSN %q: %v", got, err)
+	}
+	if !strings.Contains(dsn, "statement_timeout=5000") {
+		t.Fatalf("parsed DSN missing statement_timeout: %s", dsn)
+	}
+
+	// Idempotent: don't double-append if one is already present.
+	if again := applyStatementTimeout(got, 5000); again != got {
+		t.Fatalf("not idempotent:\n first: %s\nsecond: %s", got, again)
+	}
+
+	// Uses & when the URL already has a query string, ? otherwise.
+	noQuery := applyStatementTimeout("postgres://h/db", 3000)
+	if !strings.Contains(noQuery, "?options=") {
+		t.Fatalf("expected ?options= on a URL without query: %s", noQuery)
+	}
+
+	// ms<=0 disables (STATEMENT_TIMEOUT_MS=0).
+	if off := applyStatementTimeout(base, 0); off != base {
+		t.Fatalf("ms=0 should be a no-op, got: %s", off)
+	}
+}

--- a/apps/backend-go/main.go
+++ b/apps/backend-go/main.go
@@ -84,6 +84,10 @@ func main() {
 	// resulting status still gets measured, and before routes so every route
 	// registered by SetupRoutes is covered.
 	e.Use(appMiddleware.MetricsMiddleware())
+	// Fase 3 (scalability): bound every request with a context deadline so a
+	// handler stuck behind the saturated DB pool fails fast instead of hanging
+	// for the client's full 60s. Complements the DB statement_timeout.
+	e.Use(appMiddleware.RequestTimeout())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins:     []string{"*"}, // En producción, especificar orígenes permitidos
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},

--- a/apps/backend-go/middleware/request_timeout.go
+++ b/apps/backend-go/middleware/request_timeout.go
@@ -1,0 +1,50 @@
+package middleware
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// defaultRequestTimeout bounds how long a single request may run before its
+// context is cancelled. Kept above the DB statement_timeout (config.NewDatabase,
+// 5s) so Postgres aborts a hung query first and returns a clean error; this is
+// the HTTP-layer backstop that also propagates cancellation to any
+// context-aware query downstream (e.g. the TenantTx transaction).
+const defaultRequestTimeout = 8 * time.Second
+
+// requestTimeout resolves the timeout from REQUEST_TIMEOUT_MS (ms), falling back
+// to defaultRequestTimeout. Exposed as a var-free helper so tests can exercise
+// the parsing without touching global state.
+func requestTimeout(env string) time.Duration {
+	if env != "" {
+		if n, err := strconv.Atoi(env); err == nil && n > 0 {
+			return time.Duration(n) * time.Millisecond
+		}
+	}
+	return defaultRequestTimeout
+}
+
+// RequestTimeout returns middleware that attaches a deadline to every request's
+// context. Fase 3 (scalability hardening): before this, a request whose query
+// was stuck behind the saturated 15-connection pool hung for the client's full
+// 60s timeout, never releasing its slot. With a bounded context, context-aware
+// DB calls unwind at the deadline; combined with the DB-level statement_timeout
+// the system fails fast instead of hanging (spec SLO: zero hung requests).
+//
+// Wire it early (after Recover/Metrics, before routes) so the deadline covers
+// the whole handler chain including TenantTx.
+func RequestTimeout() echo.MiddlewareFunc {
+	timeout := requestTimeout(os.Getenv("REQUEST_TIMEOUT_MS"))
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx, cancel := context.WithTimeout(c.Request().Context(), timeout)
+			defer cancel()
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	}
+}

--- a/apps/backend-go/middleware/request_timeout_test.go
+++ b/apps/backend-go/middleware/request_timeout_test.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestRequestTimeout_ParsesEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"empty falls back to default", "", defaultRequestTimeout},
+		{"valid override", "2500", 2500 * time.Millisecond},
+		{"zero ignored", "0", defaultRequestTimeout},
+		{"negative ignored", "-1", defaultRequestTimeout},
+		{"garbage ignored", "abc", defaultRequestTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := requestTimeout(tc.env); got != tc.want {
+				t.Fatalf("requestTimeout(%q) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// The middleware must attach a deadline to the request context so downstream
+// DB calls can unwind when the pool is saturated.
+func TestRequestTimeout_AttachesDeadline(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var hadDeadline bool
+	var remaining time.Duration
+	h := RequestTimeout()(func(c echo.Context) error {
+		dl, ok := c.Request().Context().Deadline()
+		hadDeadline = ok
+		if ok {
+			remaining = time.Until(dl)
+		}
+		return c.NoContent(http.StatusOK)
+	})
+
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if !hadDeadline {
+		t.Fatal("expected the request context to carry a deadline, got none")
+	}
+	// Should be close to the default (8s), definitely not the client's 60s hang.
+	if remaining <= 0 || remaining > defaultRequestTimeout {
+		t.Fatalf("deadline remaining = %v, want (0, %v]", remaining, defaultRequestTimeout)
+	}
+}

--- a/tools/loadtest/README.md
+++ b/tools/loadtest/README.md
@@ -1,0 +1,156 @@
+# SionERP Load Test — Fase 1 (baseline)
+
+Load-testing harness for the `scalability-hardening-1k-multitenant` initiative.
+See `docs/superpowers/specs/2026-07-10-scalability-hardening-1k-multitenant-design.md`
+for the target load model and SLOs.
+
+## LOCAL-ONLY — hard rule
+
+Both `seed/` and `scenario.js` refuse to run against any URL containing
+`supabase.co` or `onrender.com`. They default to the local stack:
+
+- Backend Go: `http://localhost:8181`
+- Local Supabase Postgres: `postgresql://postgres:postgres@127.0.0.1:54322/postgres`
+- Local Supabase Auth/API: `http://127.0.0.1:54321`
+
+Never override `-db-url` / `BACKEND_URL` / `SUPABASE_URL` to point at a remote
+or production host.
+
+## Prerequisites
+
+- Local Supabase running: `supabase start` (from repo root).
+- Backend running locally: `air` (from `apps/backend-go/`), listening on `:8181`.
+- [k6](https://k6.io/) installed (`brew install k6`).
+- `apps/backend-go/.env` populated with `SUPABASE_URL` and
+  `SUPABASE_SERVICE_ROLE_KEY` (same values the backend itself uses) — the seed
+  tool's session-user creation needs them.
+
+## 1. Seed synthetic tenants
+
+```bash
+cd apps/backend-go && set -a && source .env && set +a && cd -
+go run ./tools/loadtest/seed -tenants 20 -users-per-tenant 50
+```
+
+Creates K synthetic churches ("tenants"), each with realistic row counts:
+users, zones, discipleship groups/members, and music events/songs/assignments.
+Every row is namespaced with the `LOADTEST-` prefix (church name, zone names,
+group names, `id_number`, emails) so it's identifiable and safe to remove.
+
+Only **one user per tenant** (index 0, role `pastor`) is created as a real
+Supabase Auth account — that's the session/login user the k6 scenario
+authenticates as. The rest are inserted directly into `public.users` as
+realistic FK data (group members, music members, zone assignments) and are
+never logged into.
+
+To remove all synthetic data:
+
+```bash
+go run ./tools/loadtest/seed -cleanup
+```
+
+### Why role=pastor for the session user
+
+`middleware.RequireModuleLevel` bypasses entirely for `pastor`/`admin`, and
+role `pastor` (level 400) satisfies every `middleware.RequireRole` gate the
+k6 navigation mix touches. Using one uniform role for the login user avoids
+seeding `module_user_roles` / `discipleship_hierarchy` rows just to satisfy
+authorization — this is a load test of query/pool behavior, not an
+authorization test.
+
+### Why church_id isn't in the JWT
+
+The seed tool passes `church_id` via Supabase Auth `user_metadata`, not
+`app_metadata`. `middleware.SupabaseAuth` only reads `church_id` from
+`app_metadata` into the JWT claim — but it **falls back to the
+`users.church_id` column** when that claim is empty (see
+`apps/backend-go/middleware/auth.go`). Since seeded users have `church_id`
+set on their row, `middleware.TenantTx` genuinely opens a per-request
+transaction with `SET LOCAL ROLE jetro_app` + RLS for every seeded session —
+this is **not** a pass-through. That turned out to be a useful discovery: the
+baseline run below measures the real tx-per-request + pool-cap behavior the
+spec's Bottleneck #1 describes, not a bypassed one.
+
+## 2. Smoke test (sanity)
+
+```bash
+export SUPABASE_ANON_KEY=<local anon/publishable key from `supabase status`>
+k6 run --vus 5 --duration 20s -e SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" -e TENANTS=20 \
+  tools/loadtest/scenario.js
+```
+
+Confirms the script authenticates and every endpoint in the navigation mix
+returns 2xx before committing to a longer ramp run. No `stages` are defined
+in `PROFILE=smoke` (the default), so `--vus`/`--duration` apply directly.
+
+## 3. Baseline ramp (find the breakpoint)
+
+```bash
+k6 run -e PROFILE=baseline -e SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" -e TENANTS=20 \
+  --summary-export=tools/loadtest/results/baseline-$(date +%Y%m%d-%H%M%S).json \
+  tools/loadtest/scenario.js
+```
+
+Stages (5 min total, bounded to fit the Fase 1 time budget):
+
+| Stage | Duration | Target VUs |
+|---|---|---|
+| ramp-up | 30s | 50 |
+| ramp | 1m | 150 |
+| ramp | 1m30s | 300 |
+| ramp | 1m30s | 500 |
+| ramp-down | 30s | 0 |
+
+Thresholds encode the spec SLOs: `p(95)<300ms`, `p(99)<800ms`, error
+rate `<1%`.
+
+While it runs, watch pool saturation in another terminal:
+
+```bash
+watch -n 5 'curl -s http://localhost:8181/metrics | grep sionerp_db_pool'
+```
+
+(`METRICS_TOKEN` gates `/metrics` in any environment where it's set — see
+`apps/backend-go/middleware/metrics.go`; unset locally, so no auth needed.)
+
+## 4. Read the results
+
+- k6's own summary (stdout + `--summary-export` JSON) has aggregate
+  `http_req_duration` / `http_req_failed`.
+- `sionerp_db_pool_in_use`, `_idle`, `_wait_count` from `/metrics` show pool
+  saturation (a `_wait_count` that keeps climbing under steady load = the
+  pool is the bottleneck).
+- `sionerp_tenant_requests_total{church_id=...}` shows the request
+  distribution across tenants (fairness — relevant for Fase 3, not scored
+  against an SLO in Fase 1).
+- Numbers get written into
+  `docs/superpowers/specs/2026-07-10-scalability-hardening-baseline-report.md`.
+
+## Environment variables (scenario.js)
+
+| Var | Default | Notes |
+|---|---|---|
+| `BACKEND_URL` | `http://localhost:8181` | rejected if it contains `supabase.co`/`onrender.com` |
+| `SUPABASE_URL` | `http://127.0.0.1:54321` | same rejection rule |
+| `SUPABASE_ANON_KEY` | *(required)* | local anon/publishable key, from `supabase status` |
+| `TENANTS` | `20` | must match `-tenants` used when seeding |
+| `LOADTEST_PASSWORD` | `LoadTest123!` | must match the seed tool's `LOADTEST_PASSWORD` env if you override it |
+| `PROFILE` | `smoke` | `smoke` or `baseline` |
+| `THINK_MIN_S` / `THINK_MAX_S` | `1` / `3` | think time between navigation steps |
+
+## Simplifications (documented, not hidden)
+
+- **Login once per tenant, not once per VU.** K Supabase Auth logins total
+  (not M). VUs assigned to the same tenant share that tenant's JWT. Stateless
+  auth means this exercises the same query/tx paths a distinct-session model
+  would, at a fraction of the login cost — see `setup()` in `scenario.js`.
+- **Uniform `pastor` role for every session user** (see above) — this is a
+  load test of the data/query path, not a permissions test.
+- **`dashboard/stats` and a few other handlers are not yet tenant-scoped in
+  their SQL** (Phase 3 migration, `config.Tx(c)` not adopted everywhere yet)
+  — so some read paths return counts across ALL tenants (real + synthetic)
+  rather than just the caller's church. This is a pre-existing Phase-0/1
+  reality, not something this tool introduces; the baseline report notes
+  where it affects interpretation of a given number.
+- **Numbers are a laptop-local baseline** — relative, not absolute. Use them
+  to compare before/after a Fase 3 fix, not as a production capacity number.

--- a/tools/loadtest/scenario.js
+++ b/tools/loadtest/scenario.js
@@ -1,0 +1,177 @@
+// SionERP scalability-hardening baseline load test.
+//
+// Models the load profile from docs/superpowers/specs/2026-07-10-scalability-
+// hardening-1k-multitenant-design.md: M virtual users spread across K tenants
+// (churches), navigating dashboard -> discipleship -> music -> reports with
+// think time between steps, ramping toward the target ~300-500 req/s.
+//
+// LOCAL-ONLY: refuses to run if BACKEND_URL or SUPABASE_URL contains
+// "supabase.co" or "onrender.com". Run tools/loadtest/seed first — this
+// script authenticates as the K session/login users that tool creates
+// (see tools/loadtest/README.md).
+//
+// Usage:
+//   k6 run tools/loadtest/scenario.js                                   # smoke (default)
+//   k6 run -e PROFILE=baseline tools/loadtest/scenario.js               # ramp to target load
+//   k6 run -e TENANTS=20 -e SUPABASE_ANON_KEY=... tools/loadtest/scenario.js
+//
+// See tools/loadtest/README.md for the full walkthrough and required env vars.
+
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+
+const BACKEND_URL = __ENV.BACKEND_URL || 'http://localhost:8181';
+const SUPABASE_URL = __ENV.SUPABASE_URL || 'http://127.0.0.1:54321';
+const SUPABASE_ANON_KEY = __ENV.SUPABASE_ANON_KEY || '';
+const TENANTS = parseInt(__ENV.TENANTS || '20', 10);
+const LOADTEST_PASSWORD = __ENV.LOADTEST_PASSWORD || 'LoadTest123!';
+const PROFILE = __ENV.PROFILE || 'smoke'; // 'smoke' | 'baseline'
+const THINK_MIN_S = parseFloat(__ENV.THINK_MIN_S || '1');
+const THINK_MAX_S = parseFloat(__ENV.THINK_MAX_S || '3');
+
+// ── Hard safety gate — this script only ever targets the LOCAL stack. ──────
+for (const url of [BACKEND_URL, SUPABASE_URL]) {
+  if (url.includes('supabase.co') || url.includes('onrender.com')) {
+    throw new Error(
+      `Refusing to run: target URL "${url}" looks like a remote/prod host. ` +
+        'This script is LOCAL-ONLY — see the header comment.'
+    );
+  }
+}
+
+export const options =
+  PROFILE === 'baseline'
+    ? {
+        // Ramp profile: find the breakpoint. Bounded to keep total runtime
+        // inside the ~5-8 min budget for the Fase 1 baseline run.
+        stages: [
+          { duration: '30s', target: 50 },
+          { duration: '1m', target: 150 },
+          { duration: '1m30s', target: 300 },
+          { duration: '1m30s', target: 500 },
+          { duration: '30s', target: 0 },
+        ],
+        thresholds: {
+          http_req_duration: ['p(95)<300', 'p(99)<800'],
+          http_req_failed: ['rate<0.01'],
+        },
+      }
+    : {
+        // Smoke: sanity-only. No `stages` here on purpose, so CLI
+        // --vus/--duration flags (e.g. `k6 run --vus 10 --duration 30s`)
+        // apply normally — see tools/loadtest/README.md.
+        thresholds: {
+          http_req_duration: ['p(95)<300'],
+          http_req_failed: ['rate<0.05'], // looser — smoke is a sanity check, not the SLO gate
+        },
+      };
+
+// setup() logs in ONCE PER TENANT (not once per VU) — K Supabase Auth logins
+// total, reused by every VU assigned to that tenant. This is a deliberate
+// simplification: JWTs are stateless, so N VUs sharing one tenant's token
+// exercises the same query/auth paths a distinct-session model would, at a
+// fraction of the login-storm cost. See tools/loadtest/README.md.
+export function setup() {
+  if (!SUPABASE_ANON_KEY) {
+    throw new Error(
+      'SUPABASE_ANON_KEY env var is required (the local Supabase anon/publishable key — ' +
+        'see `supabase status`). Pass it with -e SUPABASE_ANON_KEY=...'
+    );
+  }
+
+  const tokens = [];
+  for (let t = 1; t <= TENANTS; t++) {
+    const tenantIdx = String(t).padStart(3, '0');
+    const email = `loadtest-t${tenantIdx}-u0000@loadtest.local`;
+
+    const res = http.post(
+      `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+      JSON.stringify({ email, password: LOADTEST_PASSWORD }),
+      { headers: { apikey: SUPABASE_ANON_KEY, 'Content-Type': 'application/json' } }
+    );
+
+    if (res.status !== 200) {
+      throw new Error(
+        `setup: login failed for tenant ${t} (${email}): status=${res.status} body=${res.body}. ` +
+          'Did you run tools/loadtest/seed first with a matching -tenants count?'
+      );
+    }
+
+    const token = res.json('access_token');
+    if (!token) {
+      throw new Error(`setup: no access_token in login response for tenant ${t}`);
+    }
+    tokens.push(token);
+  }
+
+  console.log(`setup: logged in as ${tokens.length} tenant session user(s)`);
+  return { tokens };
+}
+
+function think() {
+  sleep(THINK_MIN_S + Math.random() * (THINK_MAX_S - THINK_MIN_S));
+}
+
+// default(): one simulated user "session" — dashboard, then a module mix,
+// with think time between steps, mirroring a person navigating the app.
+export default function (data) {
+  const token = data.tokens[(__VU - 1) % data.tokens.length];
+  const headers = { Authorization: `Bearer ${token}` };
+
+  group('dashboard', () => {
+    const res = http.get(`${BACKEND_URL}/api/v1/dashboard/stats`, {
+      headers,
+      tags: { name: 'dashboard_stats' },
+    });
+    check(res, { 'dashboard: status 200': (r) => r.status === 200 });
+  });
+  think();
+
+  group('discipleship', () => {
+    http.get(`${BACKEND_URL}/api/v1/discipleship/groups`, {
+      headers,
+      tags: { name: 'discipleship_groups' },
+    });
+    http.get(`${BACKEND_URL}/api/v1/discipleship/hierarchy`, {
+      headers,
+      tags: { name: 'discipleship_hierarchy' },
+    });
+    http.get(`${BACKEND_URL}/api/v1/discipleship/analytics`, {
+      headers,
+      tags: { name: 'discipleship_analytics' },
+    });
+  });
+  think();
+
+  group('music', () => {
+    http.get(`${BACKEND_URL}/api/v1/music/events`, {
+      headers,
+      tags: { name: 'music_events' },
+    });
+    http.get(`${BACKEND_URL}/api/v1/music/songs`, {
+      headers,
+      tags: { name: 'music_songs' },
+    });
+  });
+  think();
+
+  group('zones', () => {
+    http.get(`${BACKEND_URL}/api/v1/zones`, {
+      headers,
+      tags: { name: 'zones_list' },
+    });
+  });
+  think();
+
+  group('reports', () => {
+    http.get(`${BACKEND_URL}/api/v1/reports/users`, {
+      headers,
+      tags: { name: 'reports_users' },
+    });
+    http.get(`${BACKEND_URL}/api/v1/reports/growth`, {
+      headers,
+      tags: { name: 'reports_growth' },
+    });
+  });
+  think();
+}

--- a/tools/loadtest/seed/.gitignore
+++ b/tools/loadtest/seed/.gitignore
@@ -1,0 +1,1 @@
+loadtest-seed

--- a/tools/loadtest/seed/auth_client.go
+++ b/tools/loadtest/seed/auth_client.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+const defaultLocalSupabaseURL = "http://127.0.0.1:54321"
+
+// supabaseAuthConfig resolves the Admin API base URL + service key from the
+// environment, defaulting the URL to the local Supabase instance.
+type supabaseAuthConfig struct {
+	baseURL    string
+	serviceKey string
+}
+
+func loadSupabaseAuthConfig() (supabaseAuthConfig, error) {
+	cfg := supabaseAuthConfig{
+		baseURL:    os.Getenv("SUPABASE_URL"),
+		serviceKey: os.Getenv("SUPABASE_SERVICE_ROLE_KEY"),
+	}
+	if cfg.baseURL == "" {
+		cfg.baseURL = defaultLocalSupabaseURL
+	}
+	if err := assertLocalDBURL(cfg.baseURL); err != nil {
+		return cfg, err
+	}
+	if cfg.serviceKey == "" {
+		return cfg, fmt.Errorf(
+			"SUPABASE_SERVICE_ROLE_KEY is not set — required to create the per-tenant " +
+				"session/login user via the Supabase Auth Admin API. Export it from " +
+				"apps/backend-go/.env (same value the backend itself uses locally)",
+		)
+	}
+	return cfg, nil
+}
+
+type createUserRequest struct {
+	Email        string                 `json:"email"`
+	Password     string                 `json:"password"`
+	UserMeta     map[string]interface{} `json:"user_metadata,omitempty"`
+	EmailConfirm bool                   `json:"email_confirm"`
+}
+
+type createUserResponse struct {
+	ID string `json:"id"`
+}
+
+// createAuthSessionUser creates the ONE real Supabase Auth user per tenant
+// that the k6 scenario logs in as (see SeedTenants doc comment).
+//
+// Deliberately does NOT set app_metadata.church_id: middleware.SupabaseAuth
+// only reads church_id from app_metadata (not user_metadata) into the JWT
+// claim that middleware.TenantTx checks — see apps/backend-go/middleware/auth.go
+// AppMetaClaims / tenant.go. Passing church_id via user_metadata instead lets
+// the public.handle_new_user trigger populate users.church_id correctly for
+// realistic per-tenant data WITHOUT putting church_id in the JWT, so TenantTx
+// stays a no-op pass-through — matching today's Phase-0 production reality
+// (multi-tenancy enforcement is intentionally not rolled out yet).
+func createAuthSessionUser(email, password string, tenantIdx int, churchID string) (string, error) {
+	cfg, err := loadSupabaseAuthConfig()
+	if err != nil {
+		return "", err
+	}
+
+	body := createUserRequest{
+		Email:    email,
+		Password: password,
+		UserMeta: map[string]interface{}{
+			"first_name": "LoadTest",
+			"last_name":  fmt.Sprintf("Pastor%d", tenantIdx),
+			"id_number":  UserIDNumber(tenantIdx, 0),
+			"phone":      "+00-000-000-0000",
+			"address":    "N/A (synthetic load test user)",
+			"role":       "pastor",
+			"church_id":  churchID,
+		},
+		EmailConfirm: true,
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("marshal create-user request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, cfg.baseURL+"/auth/v1/admin/users", bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("build create-user request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("apikey", cfg.serviceKey)
+	req.Header.Set("Authorization", "Bearer "+cfg.serviceKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("call Supabase Auth Admin API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read create-user response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("create-user for %s failed: status=%d body=%s", email, resp.StatusCode, string(respBody))
+	}
+
+	var result createUserResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("decode create-user response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("create-user for %s returned an empty id (body=%s)", email, string(respBody))
+	}
+	return result.ID, nil
+}
+
+// deleteAuthUser hard-deletes a Supabase Auth user by id — used by cleanup.
+func deleteAuthUser(userID string) error {
+	cfg, err := loadSupabaseAuthConfig()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, cfg.baseURL+"/auth/v1/admin/users/"+userID, nil)
+	if err != nil {
+		return fmt.Errorf("build delete-user request: %w", err)
+	}
+	req.Header.Set("apikey", cfg.serviceKey)
+	req.Header.Set("Authorization", "Bearer "+cfg.serviceKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("call Supabase Auth Admin API delete: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete-user %s failed: status=%d body=%s", userID, resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/tools/loadtest/seed/cleanup.go
+++ b/tools/loadtest/seed/cleanup.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+)
+
+// CleanupLoadtestData deletes every row this tool created, identified by the
+// "LOADTEST-" church name prefix (see loadtestPrefix in generate.go). It
+// never touches any church that doesn't match that prefix.
+//
+// Deletion order is discovered dynamically (see deleteAllChurchScopedTables)
+// rather than hardcoded, because several tables reference church_id without
+// ON DELETE CASCADE and some triggers (e.g. audit logging) re-populate rows
+// as a side effect of deleting from OTHER tables. A fixed list drifts stale
+// every time a migration adds a new tenant-scoped table; multi-pass retry
+// doesn't.
+func CleanupLoadtestData(db *sql.DB) error {
+	churchIDs, err := findLoadtestChurchIDs(db)
+	if err != nil {
+		return fmt.Errorf("find LOADTEST churches: %w", err)
+	}
+	log.Printf("cleanup: found %d LOADTEST tenant(s)", len(churchIDs))
+
+	tables, err := churchScopedTables(db)
+	if err != nil {
+		return fmt.Errorf("discover church-scoped tables: %w", err)
+	}
+
+	var errCount int
+	for _, churchID := range churchIDs {
+		if err := cleanupOneChurch(db, churchID, tables); err != nil {
+			log.Printf("cleanup: tenant %s: %v", churchID, err)
+			errCount++
+		}
+	}
+
+	if errCount > 0 {
+		return fmt.Errorf("cleanup finished with %d tenant(s) failing — see log above", errCount)
+	}
+	return nil
+}
+
+func findLoadtestChurchIDs(db *sql.DB) ([]string, error) {
+	rows, err := db.Query(`SELECT id FROM public.churches WHERE name LIKE $1`, loadtestPrefix+"%")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// churchScopedTables returns every public.* table (other than "churches"
+// itself) that has a church_id column, in an arbitrary order — dependency
+// order is resolved at delete time by cleanupOneChurch's multi-pass retry.
+func churchScopedTables(db *sql.DB) ([]string, error) {
+	rows, err := db.Query(`
+		SELECT table_name FROM information_schema.columns
+		WHERE table_schema = 'public' AND column_name = 'church_id' AND table_name != 'churches'
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		tables = append(tables, t)
+	}
+	return tables, rows.Err()
+}
+
+// cleanupOneChurch deletes one tenant's rows from every church-scoped table,
+// then the church row itself. It retries in multiple passes: some deletes
+// fail on the first pass because a dependent row still exists in a table
+// that hasn't been cleared yet (or was just re-populated by an audit
+// trigger); as long as at least one delete succeeds per pass, we try again.
+func cleanupOneChurch(db *sql.DB, churchID string, tables []string) error {
+	// Auth users first (external system — not part of the SQL work below).
+	authRows, err := db.Query(`SELECT id FROM public.users WHERE church_id = $1`, churchID)
+	if err != nil {
+		return fmt.Errorf("find users: %w", err)
+	}
+	var userIDs []string
+	for authRows.Next() {
+		var id string
+		if err := authRows.Scan(&id); err != nil {
+			authRows.Close()
+			return fmt.Errorf("scan user id: %w", err)
+		}
+		userIDs = append(userIDs, id)
+	}
+	authRows.Close()
+
+	for _, userID := range userIDs {
+		// Best-effort: most seeded users were never created in Supabase Auth
+		// (only the session user was — see seed.go SeedTenants). A 404 here
+		// is expected and already tolerated by deleteAuthUser.
+		if err := deleteAuthUser(userID); err != nil {
+			log.Printf("cleanup: warning: delete auth user %s: %v", userID, err)
+		}
+	}
+
+	// audit_logs is handled separately, AFTER every other table: audit
+	// triggers on other tables can re-insert audit_logs rows as a side
+	// effect of deleting from them, so clearing it mid-pass doesn't stick.
+	var toDelete []string
+	for _, t := range tables {
+		if t != "audit_logs" {
+			toDelete = append(toDelete, t)
+		}
+	}
+
+	maxPasses := len(toDelete) + 3 // generous — worst case is a fully linear dependency chain
+	remaining := append([]string(nil), toDelete...)
+	var lastErrs map[string]error
+
+	for pass := 0; pass < maxPasses && len(remaining) > 0; pass++ {
+		lastErrs = map[string]error{}
+		var stillRemaining []string
+		progressed := false
+
+		for _, table := range remaining {
+			_, err := db.Exec(fmt.Sprintf(`DELETE FROM public.%q WHERE church_id = $1`, table), churchID)
+			if err != nil {
+				lastErrs[table] = err
+				stillRemaining = append(stillRemaining, table)
+				continue
+			}
+			progressed = true
+		}
+
+		remaining = stillRemaining
+		if !progressed {
+			break // no table could be cleared this pass — stop retrying, report below
+		}
+	}
+
+	if len(remaining) > 0 {
+		return fmt.Errorf("could not clear %d table(s) after retrying, first error: %v", len(remaining), firstErr(lastErrs))
+	}
+
+	// Mop up any audit_logs rows re-inserted as a side effect of the deletes above.
+	if _, err := db.Exec(`DELETE FROM public.audit_logs WHERE church_id = $1`, churchID); err != nil {
+		return fmt.Errorf("delete audit_logs: %w", err)
+	}
+
+	if _, err := db.Exec(`DELETE FROM public.churches WHERE id = $1`, churchID); err != nil {
+		return fmt.Errorf("delete churches: %w", err)
+	}
+	return nil
+}
+
+func firstErr(errs map[string]error) error {
+	for _, err := range errs {
+		return err
+	}
+	return nil
+}

--- a/tools/loadtest/seed/generate.go
+++ b/tools/loadtest/seed/generate.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// loadtestPrefix namespaces every synthetic row this tool creates so cleanup
+// can identify and remove exactly (and only) load-test data.
+const loadtestPrefix = "LOADTEST-"
+
+// forbiddenDBHostSubstrings must never appear in a target Postgres URL.
+// This is the hard safety gate: this tool only ever runs against a local stack.
+var forbiddenDBHostSubstrings = []string{"supabase.co", "onrender.com"}
+
+// assertLocalDBURL refuses to proceed if the DB URL looks like it points at a
+// remote/prod host. Defense in depth alongside the default-to-localhost behavior.
+func assertLocalDBURL(dbURL string) error {
+	lower := strings.ToLower(dbURL)
+	for _, bad := range forbiddenDBHostSubstrings {
+		if strings.Contains(lower, bad) {
+			return fmt.Errorf(
+				"refusing to run: target DB URL contains %q — this tool is LOCAL-ONLY. "+
+					"Got: %s", bad, redactDBURL(dbURL),
+			)
+		}
+	}
+	return nil
+}
+
+// redactDBURL hides credentials when the URL must be echoed in an error message.
+func redactDBURL(dbURL string) string {
+	at := strings.LastIndex(dbURL, "@")
+	scheme := strings.Index(dbURL, "://")
+	if at == -1 || scheme == -1 || at < scheme {
+		return dbURL
+	}
+	return dbURL[:scheme+3] + "***:***" + dbURL[at:]
+}
+
+// TenantName returns the namespaced church name for synthetic tenant idx (1-based).
+func TenantName(idx int) string {
+	return fmt.Sprintf("%sIglesia-%03d", loadtestPrefix, idx)
+}
+
+// TenantSlug returns a URL-safe slug for synthetic tenant idx, matching the
+// slugify() convention used by handlers/onboarding.go.
+func TenantSlug(idx int) string {
+	return fmt.Sprintf("loadtest-iglesia-%03d", idx)
+}
+
+// UserEmail returns a globally-unique synthetic email for tenant/user index.
+func UserEmail(tenantIdx, userIdx int) string {
+	return fmt.Sprintf("loadtest-t%03d-u%04d@loadtest.local", tenantIdx, userIdx)
+}
+
+// UserIDNumber returns a namespaced, unique id_number for tenant/user index.
+func UserIDNumber(tenantIdx, userIdx int) string {
+	return fmt.Sprintf("%s%03d-%04d", loadtestPrefix, tenantIdx, userIdx)
+}
+
+// ZoneName returns a namespaced, globally-unique zone name (zones.name has a
+// UNIQUE constraint across the whole table, not per-church).
+func ZoneName(tenantIdx, zoneIdx int) string {
+	return fmt.Sprintf("%s%03d-Zone-%d", loadtestPrefix, tenantIdx, zoneIdx)
+}
+
+// GroupName returns a namespaced discipleship group name.
+func GroupName(tenantIdx, groupIdx int) string {
+	return fmt.Sprintf("%s%03d-Grupo-%d", loadtestPrefix, tenantIdx, groupIdx)
+}
+
+// RoleForUserIndex returns a valid public.user_role enum value for the given
+// per-tenant user index, approximating a realistic role distribution.
+//
+// userIdx 0 is always "pastor" — the designated load-test session/login user.
+// middleware.RequireModuleLevel bypasses entirely for role pastor/admin, and
+// role pastor (level 400) satisfies every middleware.RequireRole gate used by
+// the navigation mix this tool seeds data for — see tools/loadtest/README.md
+// "Why role=pastor for the session user".
+func RoleForUserIndex(userIdx int) string {
+	switch {
+	case userIdx == 0:
+		return "pastor"
+	case userIdx%23 == 0:
+		return "staff"
+	case userIdx%11 == 0:
+		return "supervisor"
+	default:
+		return "server"
+	}
+}

--- a/tools/loadtest/seed/generate_test.go
+++ b/tools/loadtest/seed/generate_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTenantNameAndSlugAreNamespacedAndUnique(t *testing.T) {
+	n1 := TenantName(1)
+	n7 := TenantName(7)
+	if !strings.HasPrefix(n1, loadtestPrefix) {
+		t.Fatalf("TenantName(1) = %q, want prefix %q", n1, loadtestPrefix)
+	}
+	if n1 == n7 {
+		t.Fatalf("TenantName(1) and TenantName(7) must differ, got %q for both", n1)
+	}
+
+	s1 := TenantSlug(1)
+	if !strings.HasPrefix(s1, "loadtest-") {
+		t.Fatalf("TenantSlug(1) = %q, want prefix %q", s1, "loadtest-")
+	}
+	if strings.Contains(s1, " ") {
+		t.Fatalf("TenantSlug(1) = %q must not contain spaces", s1)
+	}
+}
+
+func TestUserEmailIsUniquePerTenantAndUser(t *testing.T) {
+	a := UserEmail(1, 0)
+	b := UserEmail(1, 1)
+	c := UserEmail(2, 0)
+	if a == b || a == c || b == c {
+		t.Fatalf("UserEmail must be unique per (tenant, user): got a=%q b=%q c=%q", a, b, c)
+	}
+	if !strings.HasSuffix(a, "@loadtest.local") {
+		t.Fatalf("UserEmail(1,0) = %q, want @loadtest.local suffix", a)
+	}
+}
+
+func TestUserIDNumberIsNamespacedAndUnique(t *testing.T) {
+	a := UserIDNumber(3, 10)
+	b := UserIDNumber(3, 11)
+	if !strings.HasPrefix(a, loadtestPrefix) {
+		t.Fatalf("UserIDNumber(3,10) = %q, want prefix %q", a, loadtestPrefix)
+	}
+	if a == b {
+		t.Fatalf("UserIDNumber must differ per user index, got %q for both", a)
+	}
+}
+
+func TestRoleForUserIndexSessionUserIsPastor(t *testing.T) {
+	if got := RoleForUserIndex(0); got != "pastor" {
+		t.Fatalf("RoleForUserIndex(0) = %q, want %q (designated load-test session user)", got, "pastor")
+	}
+}
+
+func TestRoleForUserIndexOnlyReturnsValidEnumValues(t *testing.T) {
+	valid := map[string]bool{"admin": true, "pastor": true, "staff": true, "supervisor": true, "server": true}
+	for i := 0; i < 200; i++ {
+		role := RoleForUserIndex(i)
+		if !valid[role] {
+			t.Fatalf("RoleForUserIndex(%d) = %q, not a valid user_role enum value", i, role)
+		}
+	}
+}
+
+func TestZoneAndGroupNamesAreNamespaced(t *testing.T) {
+	z := ZoneName(4, 2)
+	g := GroupName(4, 2)
+	if !strings.HasPrefix(z, loadtestPrefix) {
+		t.Fatalf("ZoneName(4,2) = %q, want prefix %q", z, loadtestPrefix)
+	}
+	if !strings.HasPrefix(g, loadtestPrefix) {
+		t.Fatalf("GroupName(4,2) = %q, want prefix %q", g, loadtestPrefix)
+	}
+}
+
+func TestAssertLocalDBURLRejectsRemoteHosts(t *testing.T) {
+	cases := []struct {
+		url     string
+		wantErr bool
+	}{
+		{"postgresql://postgres:postgres@127.0.0.1:54322/postgres", false},
+		{"postgresql://postgres:postgres@localhost:54322/postgres", false},
+		{"postgresql://user:pass@db.rpacdeyavjodixeymzpb.supabase.co:5432/postgres", true},
+		{"postgresql://user:pass@some-host.onrender.com:5432/postgres", true},
+	}
+	for _, tc := range cases {
+		err := assertLocalDBURL(tc.url)
+		if tc.wantErr && err == nil {
+			t.Errorf("assertLocalDBURL(%q) = nil, want error (remote host must be rejected)", tc.url)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("assertLocalDBURL(%q) = %v, want nil (local host must be allowed)", tc.url, err)
+		}
+	}
+}

--- a/tools/loadtest/seed/go.mod
+++ b/tools/loadtest/seed/go.mod
@@ -1,0 +1,8 @@
+module sionerp/loadtest-seed
+
+go 1.25.0
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/lib/pq v1.12.3
+)

--- a/tools/loadtest/seed/go.sum
+++ b/tools/loadtest/seed/go.sum
@@ -1,0 +1,4 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=

--- a/tools/loadtest/seed/main.go
+++ b/tools/loadtest/seed/main.go
@@ -1,0 +1,120 @@
+// Command seed-at-scale generates (or removes) synthetic multi-tenant load-test
+// data for SionERP: K churches ("tenants") with realistic row counts across
+// users, discipleship groups/members, zones, and the music module.
+//
+// LOCAL-ONLY: this tool refuses to run against any DB URL containing
+// "supabase.co" or "onrender.com" (see assertLocalDBURL). It defaults to the
+// local Supabase Postgres instance and never touches the real church's data —
+// every row it creates is namespaced with the "LOADTEST-" prefix (see
+// generate.go) so it can be identified and removed with -cleanup.
+//
+// Usage:
+//
+//	go run . -tenants 20 -users-per-tenant 50
+//	go run . -cleanup
+//
+// See tools/loadtest/README.md for the full walkthrough (seed → smoke → baseline).
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	_ "github.com/lib/pq"
+)
+
+const defaultLocalDBURL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres?sslmode=disable"
+
+func main() {
+	tenants := flag.Int("tenants", 20, "number of synthetic tenants (churches) to create")
+	usersPerTenant := flag.Int("users-per-tenant", 50, "number of synthetic users per tenant")
+	dbURL := flag.String("db-url", "", "Postgres connection URL (defaults to SUPABASE_DB_URL env, then local Supabase)")
+	cleanup := flag.Bool("cleanup", false, "delete all LOADTEST- synthetic data instead of creating it")
+	flag.Parse()
+
+	resolvedURL := resolveDBURL(*dbURL)
+	if err := assertLocalDBURL(resolvedURL); err != nil {
+		log.Fatalf("SAFETY GATE: %v", err)
+	}
+
+	password := os.Getenv("LOADTEST_PASSWORD")
+	if password == "" {
+		password = "LoadTest123!" // local-only default; never used against a real deploy
+	}
+
+	db, err := sql.Open("postgres", resolvedURL)
+	if err != nil {
+		log.Fatalf("failed to open DB connection: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		log.Fatalf("failed to ping DB at %s: %v", redactDBURL(resolvedURL), err)
+	}
+
+	if *cleanup {
+		log.Printf("cleanup: deleting all LOADTEST- synthetic data from %s", redactDBURL(resolvedURL))
+		if err := CleanupLoadtestData(db); err != nil {
+			log.Fatalf("cleanup failed: %v", err)
+		}
+		log.Println("cleanup: done")
+		return
+	}
+
+	if *tenants <= 0 || *usersPerTenant <= 0 {
+		log.Fatalf("-tenants and -users-per-tenant must both be > 0 (got %d, %d)", *tenants, *usersPerTenant)
+	}
+
+	log.Printf("seeding %d tenant(s) x %d user(s) against %s", *tenants, *usersPerTenant, redactDBURL(resolvedURL))
+	summary, err := SeedTenants(db, *tenants, *usersPerTenant, password)
+	if err != nil {
+		log.Fatalf("seed failed: %v", err)
+	}
+
+	fmt.Println()
+	fmt.Println("=== seed-at-scale summary ===")
+	fmt.Printf("Tenants:            %d\n", summary.Tenants)
+	fmt.Printf("Users:              %d\n", summary.Users)
+	fmt.Printf("Zones:              %d\n", summary.Zones)
+	fmt.Printf("Discipleship groups: %d\n", summary.Groups)
+	fmt.Printf("Group members:      %d\n", summary.GroupMembers)
+	fmt.Printf("Music members:      %d\n", summary.MusicMembers)
+	fmt.Printf("Music events:       %d\n", summary.MusicEvents)
+	fmt.Printf("Music songs:        %d\n", summary.MusicSongs)
+	fmt.Printf("Music assignments:  %d\n", summary.MusicAssignments)
+	fmt.Println()
+	fmt.Println("Session/login users (role=pastor, index 0 per tenant):")
+	for i, cred := range summary.SessionCredentials {
+		fmt.Printf("  [%d] email=%s password=$LOADTEST_PASSWORD church_id=%s\n", i, cred.Email, cred.ChurchID)
+	}
+	fmt.Println()
+	fmt.Println("Feed the credentials above (or re-derive with the same tenant count) into")
+	fmt.Println("tools/loadtest/scenario.js — see tools/loadtest/README.md.")
+}
+
+// resolveDBURL applies the precedence: -db-url flag > SUPABASE_DB_URL env > local default.
+// Mirrors config/database.go's local-SSL handling so this tool behaves the
+// same way against the local Supabase Postgres instance as the backend does.
+func resolveDBURL(flagValue string) string {
+	url := flagValue
+	if url == "" {
+		url = os.Getenv("SUPABASE_DB_URL")
+	}
+	if url == "" {
+		url = defaultLocalDBURL
+	}
+
+	if !strings.Contains(url, "sslmode") &&
+		(strings.Contains(url, "127.0.0.1") || strings.Contains(url, "localhost")) {
+		if strings.Contains(url, "?") {
+			url += "&sslmode=disable"
+		} else {
+			url += "?sslmode=disable"
+		}
+	}
+	return url
+}

--- a/tools/loadtest/seed/seed.go
+++ b/tools/loadtest/seed/seed.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Row-count knobs. Kept modest so seeding stays fast and the resulting DB size
+// is representative of a mid-size church, not a stress-test in itself — the
+// load comes from concurrent k6 traffic, not from the seed volume.
+const (
+	zonesPerTenant       = 3
+	groupSize            = 8 // ~1 discipleship group per 8 users
+	musicEventsPerTenant = 12
+	musicSongsPerTenant  = 15
+)
+
+// discipleshipLevelSeed mirrors handlers/onboarding.go's ProvisionChurch so
+// synthetic tenants get the same 5 standard levels a real church gets.
+type discipleshipLevelSeed struct {
+	name        string
+	description string
+	icon        string
+	color       string
+	orderIndex  int
+}
+
+var standardDiscipleshipLevels = []discipleshipLevelSeed{
+	{"Pastoral", "Nivel Pastoral", "crown", "#8b5cf6", 1},
+	{"Coordinador General", "Coordinador General", "shield", "#06b6d4", 2},
+	{"Coordinador", "Coordinador de zona", "shield", "#10b981", 3},
+	{"Supervisor Auxiliar", "Supervisor Auxiliar", "users", "#f59e0b", 4},
+	{"Líder", "Líder de célula", "user", "#6b7280", 5},
+}
+
+// SessionCredential is a load-test tenant's session/login user — the k6
+// scenario authenticates as this user once per tenant (see tools/loadtest/README.md).
+type SessionCredential struct {
+	Email    string
+	ChurchID string
+}
+
+// SeedSummary reports what SeedTenants created, for the CLI summary output.
+type SeedSummary struct {
+	Tenants            int
+	Users              int
+	Zones              int
+	Groups             int
+	GroupMembers       int
+	MusicMembers       int
+	MusicEvents        int
+	MusicSongs         int
+	MusicAssignments   int
+	SessionCredentials []SessionCredential
+}
+
+// SeedTenants creates tenantCount synthetic churches, each with usersPerTenant
+// users, zones, discipleship groups/members, and music module data.
+//
+// Only ONE user per tenant (index 0, role "pastor") is created through the
+// real Supabase Auth Admin API — that's the only user k6 needs to log in as.
+// The rest are inserted directly (bulk realistic data, never logged into).
+// See generate.go RoleForUserIndex doc comment for why role=pastor.
+func SeedTenants(db *sql.DB, tenantCount, usersPerTenant int, password string) (*SeedSummary, error) {
+	summary := &SeedSummary{}
+
+	for t := 1; t <= tenantCount; t++ {
+		churchID := uuid.New().String()
+
+		if err := seedChurch(db, churchID, t); err != nil {
+			return summary, fmt.Errorf("tenant %d: %w", t, err)
+		}
+		summary.Tenants++
+
+		zoneIDs, err := seedZones(db, churchID, t)
+		if err != nil {
+			return summary, fmt.Errorf("tenant %d: zones: %w", t, err)
+		}
+		summary.Zones += len(zoneIDs)
+
+		if err := seedDiscipleshipLevels(db, churchID); err != nil {
+			return summary, fmt.Errorf("tenant %d: discipleship levels: %w", t, err)
+		}
+
+		sessionEmail := UserEmail(t, 0)
+		sessionUserID, err := createAuthSessionUser(sessionEmail, password, t, churchID)
+		if err != nil {
+			return summary, fmt.Errorf("tenant %d: session user via Supabase Auth: %w", t, err)
+		}
+		// The handle_new_user trigger already inserted a public.users row for
+		// sessionUserID (church_id/role came from user_metadata — see
+		// createAuthSessionUser). Just fix up the FK-dependent fields the
+		// trigger can't know about yet (zone_id).
+		if err := assignUserZone(db, sessionUserID, zoneIDs[0]); err != nil {
+			return summary, fmt.Errorf("tenant %d: session user zone: %w", t, err)
+		}
+
+		userIDs := []string{sessionUserID}
+		for u := 1; u < usersPerTenant; u++ {
+			userID := uuid.New().String()
+			role := RoleForUserIndex(u)
+			zoneID := zoneIDs[u%len(zoneIDs)]
+			if err := insertBulkUser(db, userID, churchID, zoneID, t, u, role); err != nil {
+				return summary, fmt.Errorf("tenant %d: user %d: %w", t, u, err)
+			}
+			userIDs = append(userIDs, userID)
+		}
+		summary.Users += len(userIDs)
+
+		groups, members, err := seedDiscipleshipGroups(db, churchID, t, userIDs, zoneIDs)
+		if err != nil {
+			return summary, fmt.Errorf("tenant %d: discipleship groups: %w", t, err)
+		}
+		summary.Groups += groups
+		summary.GroupMembers += members
+
+		musicMembers, events, songs, assignments, err := seedMusic(db, churchID, t, userIDs)
+		if err != nil {
+			return summary, fmt.Errorf("tenant %d: music: %w", t, err)
+		}
+		summary.MusicMembers += musicMembers
+		summary.MusicEvents += events
+		summary.MusicSongs += songs
+		summary.MusicAssignments += assignments
+
+		summary.SessionCredentials = append(summary.SessionCredentials, SessionCredential{
+			Email:    sessionEmail,
+			ChurchID: churchID,
+		})
+	}
+
+	return summary, nil
+}
+
+func seedChurch(db *sql.DB, churchID string, tenantIdx int) error {
+	name := TenantName(tenantIdx)
+	slug := TenantSlug(tenantIdx)
+
+	if _, err := db.Exec(
+		`INSERT INTO public.churches (id, name, slug, created_at, updated_at)
+		 VALUES ($1, $2, $3, NOW(), NOW())`,
+		churchID, name, slug,
+	); err != nil {
+		return fmt.Errorf("insert church: %w", err)
+	}
+
+	// Module registry — install every module this baseline exercises so
+	// middleware.RequireModule gates don't block the k6 navigation mix.
+	for _, key := range []string{"base", "discipleship", "zones", "events", "reports", "music"} {
+		if _, err := db.Exec(
+			`INSERT INTO public.modules (key, name, description, is_installed, installed_at, church_id)
+			 VALUES ($1, $1, 'Load test module', true, NOW(), $2)
+			 ON CONFLICT (church_id, key) DO NOTHING`,
+			key, churchID,
+		); err != nil {
+			return fmt.Errorf("insert module %s: %w", key, err)
+		}
+	}
+
+	if _, err := db.Exec(
+		`INSERT INTO public.church_info (id, church_id, name, created_at, updated_at)
+		 VALUES (gen_random_uuid(), $1, $2, NOW(), NOW())`,
+		churchID, name,
+	); err != nil {
+		return fmt.Errorf("insert church_info: %w", err)
+	}
+
+	return nil
+}
+
+func seedDiscipleshipLevels(db *sql.DB, churchID string) error {
+	for _, l := range standardDiscipleshipLevels {
+		if _, err := db.Exec(
+			`INSERT INTO public.discipleship_levels
+			   (id, name, description, icon, color, order_index, is_active, church_id, created_at, updated_at)
+			 VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, true, $6, NOW(), NOW())`,
+			l.name, l.description, l.icon, l.color, l.orderIndex, churchID,
+		); err != nil {
+			return fmt.Errorf("insert discipleship_level %s: %w", l.name, err)
+		}
+	}
+	return nil
+}
+
+func seedZones(db *sql.DB, churchID string, tenantIdx int) ([]string, error) {
+	zoneIDs := make([]string, 0, zonesPerTenant)
+	for z := 1; z <= zonesPerTenant; z++ {
+		zoneID := uuid.New().String()
+		if _, err := db.Exec(
+			`INSERT INTO public.zones (id, name, description, color, is_active, church_id, created_at, updated_at)
+			 VALUES ($1, $2, 'Zona sintética de load test', '#3b82f6', true, $3, NOW(), NOW())`,
+			zoneID, ZoneName(tenantIdx, z), churchID,
+		); err != nil {
+			return nil, fmt.Errorf("insert zone %d: %w", z, err)
+		}
+		zoneIDs = append(zoneIDs, zoneID)
+	}
+	return zoneIDs, nil
+}
+
+func assignUserZone(db *sql.DB, userID, zoneID string) error {
+	_, err := db.Exec(`UPDATE public.users SET zone_id = $1 WHERE id = $2`, zoneID, userID)
+	return err
+}
+
+// insertBulkUser inserts a synthetic user directly (no Supabase Auth account —
+// this user is never logged into, it only exists as realistic FK data).
+func insertBulkUser(db *sql.DB, userID, churchID, zoneID string, tenantIdx, userIdx int, role string) error {
+	_, err := db.Exec(
+		`INSERT INTO public.users
+		   (id, id_number, first_name, last_name, phone, address, email,
+		    role, is_active, church_id, zone_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9, $10, NOW(), NOW())`,
+		userID,
+		UserIDNumber(tenantIdx, userIdx),
+		fmt.Sprintf("LoadTest%d", userIdx),
+		fmt.Sprintf("Tenant%d", tenantIdx),
+		"+00-000-000-0000",
+		"N/A (synthetic load test user)",
+		UserEmail(tenantIdx, userIdx),
+		role,
+		churchID,
+		zoneID,
+	)
+	if err != nil {
+		return fmt.Errorf("insert user: %w", err)
+	}
+	return nil
+}
+
+func seedDiscipleshipGroups(db *sql.DB, churchID string, tenantIdx int, userIDs, zoneIDs []string) (groups, members int, err error) {
+	groupCount := len(userIDs) / groupSize
+	if groupCount < 1 {
+		groupCount = 1
+	}
+
+	for g := 1; g <= groupCount; g++ {
+		groupID := uuid.New().String()
+		leaderID := userIDs[(g*groupSize)%len(userIDs)]
+		zoneID := zoneIDs[g%len(zoneIDs)]
+
+		if _, err := db.Exec(
+			`INSERT INTO public.discipleship_groups
+			   (id, group_name, leader_id, meeting_location, meeting_day, status, zone_id, church_id, created_at, updated_at)
+			 VALUES ($1, $2, $3, 'Casa del líder', 'Viernes', 'active', $4, $5, NOW(), NOW())`,
+			groupID, GroupName(tenantIdx, g), leaderID, zoneID, churchID,
+		); err != nil {
+			return groups, members, fmt.Errorf("insert group %d: %w", g, err)
+		}
+		groups++
+
+		// Assign the next groupSize users (wrapping) as members of this group.
+		start := (g - 1) * groupSize
+		for i := 0; i < groupSize && start+i < len(userIDs); i++ {
+			userID := userIDs[start+i]
+			roleInGroup := "member"
+			if userID == leaderID {
+				roleInGroup = "leader"
+			}
+			if _, err := db.Exec(
+				`INSERT INTO public.discipleship_group_members
+				   (id, group_id, user_id, role_in_group, is_active, church_id, joined_at, created_at, updated_at)
+				 VALUES (gen_random_uuid(), $1, $2, $3, true, $4, NOW(), NOW(), NOW())
+				 ON CONFLICT (group_id, user_id) DO NOTHING`,
+				groupID, userID, roleInGroup, churchID,
+			); err != nil {
+				return groups, members, fmt.Errorf("insert group member: %w", err)
+			}
+			members++
+		}
+	}
+
+	return groups, members, nil
+}
+
+func seedMusic(db *sql.DB, churchID string, tenantIdx int, userIDs []string) (musicMembers, events, songs, assignments int, err error) {
+	funciones := []string{"corista", "musico", "tecnico", "danzarina"}
+
+	// music_members: a subset of the tenant's users (every 4th user).
+	memberIDs := make([]string, 0)
+	for i, userID := range userIDs {
+		if i%4 != 0 {
+			continue
+		}
+		musicMemberID := uuid.New().String()
+		funcion := funciones[i%len(funciones)]
+		if _, err := db.Exec(
+			`INSERT INTO public.music_members (id, user_id, funciones, is_active, church_id, created_at, updated_at)
+			 VALUES ($1, $2, ARRAY[$3]::text[], true, $4, NOW(), NOW())`,
+			musicMemberID, userID, funcion, churchID,
+		); err != nil {
+			return musicMembers, events, songs, assignments, fmt.Errorf("insert music_member: %w", err)
+		}
+		memberIDs = append(memberIDs, musicMemberID)
+		musicMembers++
+	}
+	if len(memberIDs) == 0 {
+		return musicMembers, events, songs, assignments, nil
+	}
+
+	// music_songs.
+	songIDs := make([]string, 0, musicSongsPerTenant)
+	for s := 1; s <= musicSongsPerTenant; s++ {
+		songID := uuid.New().String()
+		name := fmt.Sprintf("LOADTEST Song %03d-%02d", tenantIdx, s)
+		if _, err := db.Exec(
+			`INSERT INTO public.music_songs (id, name, name_normalized, author, default_key, church_id, created_at)
+			 VALUES ($1, $2, LOWER($2), 'LOADTEST', 'C', $3, NOW())`,
+			songID, name, churchID,
+		); err != nil {
+			return musicMembers, events, songs, assignments, fmt.Errorf("insert music_song %d: %w", s, err)
+		}
+		songIDs = append(songIDs, songID)
+		songs++
+	}
+
+	// music_events + assignments.
+	eventTypes := []string{"viernes", "domingo", "especial"}
+	for e := 1; e <= musicEventsPerTenant; e++ {
+		eventID := uuid.New().String()
+		eventType := eventTypes[e%len(eventTypes)]
+		if _, err := db.Exec(
+			`INSERT INTO public.music_events (id, event_date, event_type, title, published, church_id, created_at, updated_at)
+			 VALUES ($1, CURRENT_DATE + ($2 || ' days')::interval, $3, $4, true, $5, NOW(), NOW())`,
+			eventID, e, eventType, fmt.Sprintf("LOADTEST Culto %03d-%02d", tenantIdx, e), churchID,
+		); err != nil {
+			return musicMembers, events, songs, assignments, fmt.Errorf("insert music_event %d: %w", e, err)
+		}
+		events++
+
+		// Assign 3 members per event (wrapping through memberIDs).
+		for a := 0; a < 3 && a < len(memberIDs); a++ {
+			memberID := memberIDs[(e+a)%len(memberIDs)]
+			funcion := funciones[(e+a)%len(funciones)]
+			if _, err := db.Exec(
+				`INSERT INTO public.music_assignments (id, event_id, member_id, funcion, state, church_id, created_at, updated_at)
+				 VALUES (gen_random_uuid(), $1, $2, $3, 'confirmado', $4, NOW(), NOW())
+				 ON CONFLICT (event_id, member_id) DO NOTHING`,
+				eventID, memberID, funcion, churchID,
+			); err != nil {
+				return musicMembers, events, songs, assignments, fmt.Errorf("insert music_assignment: %w", err)
+			}
+			assignments++
+		}
+	}
+
+	return musicMembers, events, songs, assignments, nil
+}


### PR DESCRIPTION
## Fase 3 — concurrencia (fail-fast)

Ataca el colapso a ~200 VUs por el pool de 15 conns: una query colgada retenía su conexión toda la request, saturando el pool.

### Cambios
- **statement_timeout server-side** vía DSN libpq `options` (`config/database.go`) → Postgres aborta la query colgada y libera la conexión. `STATEMENT_TIMEOUT_MS` (def 5s), `0` desactiva.
- **middleware `RequestTimeout`** → deadline por request. `REQUEST_TIMEOUT_MS` (def 8s).
- **harness de carga** (`tools/loadtest/`) recuperado del #127 que quedó huérfano al mergear el stacked PR: escenario k6 (LOCAL-ONLY) + seeder Go a escala. `results/` gitignored.

### Medición (perfil 500 VUs)
| | pool 15 baseline | + fail-fast | + pool 50 |
|---|---|---|---|
| throughput | 12 req/s | 47 | 51 |
| p95 (todas) | 60s | 17s | 14s |
| error-rate | 28% | 27% | **17%** |
| checks OK | — | 69% | **89%** |

Fail-fast eliminó los cuelgues (4x throughput); subir el pool bajó los rechazos. El 17% restante pide acortar la transacción (fix #4, su propio spec).

### Tests
`go test ./config/ ./middleware/` verdes. Sin cambios de comportamiento en runtime (timeouts nuevos son configurables y desactivables).