### PR TITLE
feat(auth): acceso federado de BonDev en modo lectura (I2 fase 1)

### DIFF
--- a/apps/backend-go/handlers/federated.go
+++ b/apps/backend-go/handlers/federated.go
@@ -1,0 +1,135 @@
+// Package handlers — GET /federated/redeem: canje del token de acceso
+// federado que emite BonDev (control plane / back-office del proveedor).
+// Ruta PÚBLICA (fuera de SupabaseAuth/TenantTx, no hay sesión previa que
+// canjear). Ver SDD completo en Engram (proyecto "sionerp",
+// sdd/federated-access-verify/{proposal,spec,design,tasks}).
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"backend-sion/config"
+	"backend-sion/middleware"
+
+	"github.com/labstack/echo/v4"
+)
+
+// FederatedHandler expone el canje de acceso federado.
+type FederatedHandler struct{}
+
+// NewFederatedHandler construye el handler.
+func NewFederatedHandler() *FederatedHandler {
+	return &FederatedHandler{}
+}
+
+// Redeem GET /federated/redeem?token=<jwt> — verifica el token EdDSA de
+// BonDev, registra el canje (anti-replay real vía UNIQUE(jti) + FK a
+// churches, no un chequeo a mano con condición de carrera) y emite una
+// sesión efímera de sólo lectura como cookie httpOnly.
+func (h *FederatedHandler) Redeem(c echo.Context) error {
+	tokenString := c.QueryParam("token")
+	if tokenString == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "token is required"})
+	}
+
+	pubKeyPEM := os.Getenv("FEDERATED_PUBLIC_KEY_PEM")
+	if pubKeyPEM == "" {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "federated access is not configured"})
+	}
+	pubKey, err := middleware.ParseFederatedPublicKeyPEM(pubKeyPEM)
+	if err != nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "federated access is not configured"})
+	}
+
+	claims, err := middleware.VerifyFederatedToken(tokenString, pubKey)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid or expired token"})
+	}
+
+	if claims.Issuer != "bondev" {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid or expired token"})
+	}
+
+	// R6 (spec): edit NO se trata como read silenciosamente — I2 fase 2, sin
+	// implementar todavía. Rechazo explícito, no un 401 genérico: no es que
+	// el token sea inválido, es que el modo no está soportado.
+	if claims.Mode != "read" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "federated mode not supported yet: " + claims.Mode})
+	}
+
+	db := config.GetDB()
+	if db == nil || db.DB == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "database connection not available"})
+	}
+
+	ctx := c.Request().Context()
+	tx, err := db.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to begin transaction"})
+	}
+	rollback := func() { _ = tx.Rollback() }
+
+	// Mismo mecanismo que TenantTx (middleware/tenant.go): downgrade a
+	// jetro_app (sin BYPASSRLS) + set_config del tenant ANTES de escribir —
+	// federated_sessions_log no es un caso especial, respeta RLS real como
+	// las demás 30+ tablas tenant.
+	if _, err := tx.ExecContext(ctx, "SET LOCAL ROLE jetro_app"); err != nil {
+		rollback()
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to set tenant role"})
+	}
+	if _, err := tx.ExecContext(ctx,
+		"SELECT set_config('app.current_church_id', $1, true)", claims.Tenant); err != nil {
+		rollback()
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid tenant"})
+	}
+
+	// Anti-replay real (R2): confiamos en la restricción de la DB, no en un
+	// SELECT-luego-INSERT a mano (esa secuencia tiene condición de carrera
+	// si el mismo token se canjea dos veces en simultáneo). El FK a
+	// churches(id) también rechaza acá cualquier `tenant` que no exista —
+	// no hace falta un SELECT previo para eso tampoco.
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO public.federated_sessions_log
+			(jti, operator_id, operator_name, church_id, mode, origin_ip, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, claims.ID, claims.Subject, claims.OperatorName, claims.Tenant, claims.Mode,
+		c.RealIP(), claims.ExpiresAt.Time)
+
+	if err != nil {
+		rollback()
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "duplicate") || strings.Contains(msg, "unique"):
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "token already used"})
+		case strings.Contains(msg, "foreign key"):
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "unknown tenant"})
+		default:
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to redeem token"})
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to commit"})
+	}
+
+	sessionToken, err := middleware.SignFederatedSession(
+		claims.Subject, claims.OperatorName, claims.Tenant, claims.ExpiresAt.Time,
+	)
+	if err != nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "federated access is not configured"})
+	}
+
+	c.SetCookie(&http.Cookie{
+		Name:     middleware.FederatedCookieName,
+		Value:    sessionToken,
+		Path:     "/",
+		Expires:  claims.ExpiresAt.Time,
+		HttpOnly: true,
+		Secure:   os.Getenv("ENVIRONMENT") == "production",
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	return c.Redirect(http.StatusFound, "/")
+}

--- a/apps/backend-go/handlers/federated_test.go
+++ b/apps/backend-go/handlers/federated_test.go
@@ -1,0 +1,223 @@
+// Redeem del acceso federado (I2 fase 1, modo read) — integración real
+// contra Postgres (RLS, jetro_app, FK/UNIQUE de federated_sessions_log).
+//
+// Guardado por SUPABASE_DB_URL: si no está seteada (CI sin DB todavía), el
+// test se saltea limpio — mismo criterio que isolation_test.go
+// (INTEGRATION_TEST_DSN). Para correrlo local contra el Supabase local
+// (`supabase start`):
+//
+//	SUPABASE_DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+//	  go test ./handlers/ -run TestFederatedRedeem -v
+//
+// Verificado en vivo end-to-end (server real + curl) antes de escribir este
+// test — ver sesión del 2026-07-24, SDD en Engram
+// sdd/federated-access-verify/*: replay, tenant desconocido, expirado,
+// mode=edit, GET permitido con datos reales scoped por RLS, PUT bloqueado
+// por FederatedReadOnly antes de llegar al handler real.
+package handlers
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"backend-sion/middleware"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+)
+
+const sionChurchID = "00000000-0000-0000-0000-00000000515e" // Iglesia Sion, seed fijo (create_churches.sql)
+
+func skipWithoutDB(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SUPABASE_DB_URL") == "" {
+		t.Skip("SUPABASE_DB_URL not set — skipping federated redeem integration test")
+	}
+}
+
+func federatedTestKeys(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate ed25519 keypair: %v", err)
+	}
+	pkixBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+	pubPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pkixBytes}))
+	return pub, priv, pubPEM
+}
+
+// signBondevStyleToken firma un token EXACTAMENTE como lo hace bondev (ver
+// apps/api/internal/auth/federated.go del lado emisor) — usa
+// middleware.FederatedClaims directamente (exportado) en vez de reimplementar
+// el shape a mano.
+func signBondevStyleToken(t *testing.T, priv ed25519.PrivateKey, tenant, mode string, ttl time.Duration) string {
+	t.Helper()
+	now := time.Now()
+	claims := middleware.FederatedClaims{
+		OperatorName: "Admin Preview (test)",
+		Tenant:       tenant,
+		Mode:         mode,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "bondev",
+			Subject:   "operator-test-1",
+			ID:        "jti-" + time.Now().Format("20060102150405.000000000"),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	signed, err := token.SignedString(priv)
+	if err != nil {
+		t.Fatalf("failed to sign test token: %v", err)
+	}
+	return signed
+}
+
+func redeemRequest(token string) (*http.Request, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, "/federated/redeem?token="+token, nil)
+	rec := httptest.NewRecorder()
+	return req, rec
+}
+
+func TestFederatedRedeem_ValidToken_SetsCookieAndAudits(t *testing.T) {
+	skipWithoutDB(t)
+	_, priv, pubPEM := federatedTestKeys(t)
+	t.Setenv("FEDERATED_PUBLIC_KEY_PEM", pubPEM)
+	t.Setenv("FEDERATED_SESSION_SECRET", "test-federated-session-secret-for-this-test")
+
+	h := NewFederatedHandler()
+	e := echo.New()
+	token := signBondevStyleToken(t, priv, sionChurchID, "read", 5*time.Minute)
+	req, rec := redeemRequest(token)
+	c := e.NewContext(req, rec)
+
+	if err := h.Redeem(c); err != nil {
+		t.Fatalf("Redeem returned error: %v", err)
+	}
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	cookies := rec.Result().Cookies()
+	var sessionCookie *http.Cookie
+	for _, ck := range cookies {
+		if ck.Name == middleware.FederatedCookieName {
+			sessionCookie = ck
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected the federated session cookie to be set")
+	}
+	if !sessionCookie.HttpOnly {
+		t.Fatal("expected the federated session cookie to be HttpOnly")
+	}
+}
+
+func TestFederatedRedeem_ReplayedToken_Rejected(t *testing.T) {
+	skipWithoutDB(t)
+	_, priv, pubPEM := federatedTestKeys(t)
+	t.Setenv("FEDERATED_PUBLIC_KEY_PEM", pubPEM)
+	t.Setenv("FEDERATED_SESSION_SECRET", "test-federated-session-secret-for-this-test")
+
+	h := NewFederatedHandler()
+	e := echo.New()
+	token := signBondevStyleToken(t, priv, sionChurchID, "read", 5*time.Minute)
+
+	req1, rec1 := redeemRequest(token)
+	if err := h.Redeem(e.NewContext(req1, rec1)); err != nil {
+		t.Fatalf("first Redeem returned error: %v", err)
+	}
+	if rec1.Code != http.StatusFound {
+		t.Fatalf("expected first redeem to succeed (302), got %d: %s", rec1.Code, rec1.Body.String())
+	}
+
+	req2, rec2 := redeemRequest(token) // MISMO token, MISMO jti
+	if err := h.Redeem(e.NewContext(req2, rec2)); err != nil {
+		t.Fatalf("second Redeem returned error: %v", err)
+	}
+	if rec2.Code != http.StatusUnauthorized {
+		t.Fatalf("expected replay to be rejected with 401, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+}
+
+func TestFederatedRedeem_UnknownTenant_Rejected(t *testing.T) {
+	skipWithoutDB(t)
+	_, priv, pubPEM := federatedTestKeys(t)
+	t.Setenv("FEDERATED_PUBLIC_KEY_PEM", pubPEM)
+	t.Setenv("FEDERATED_SESSION_SECRET", "test-federated-session-secret-for-this-test")
+
+	h := NewFederatedHandler()
+	e := echo.New()
+	token := signBondevStyleToken(t, priv, "11111111-1111-1111-1111-111111111111", "read", 5*time.Minute)
+	req, rec := redeemRequest(token)
+
+	if err := h.Redeem(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Redeem returned error: %v", err)
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for an unknown tenant, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFederatedRedeem_ExpiredToken_Rejected(t *testing.T) {
+	skipWithoutDB(t)
+	_, priv, pubPEM := federatedTestKeys(t)
+	t.Setenv("FEDERATED_PUBLIC_KEY_PEM", pubPEM)
+	t.Setenv("FEDERATED_SESSION_SECRET", "test-federated-session-secret-for-this-test")
+
+	h := NewFederatedHandler()
+	e := echo.New()
+	token := signBondevStyleToken(t, priv, sionChurchID, "read", -5*time.Minute) // ya vencido
+	req, rec := redeemRequest(token)
+
+	if err := h.Redeem(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Redeem returned error: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for an expired token, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFederatedRedeem_EditMode_ExplicitlyRejected_NotTreatedAsRead(t *testing.T) {
+	skipWithoutDB(t)
+	_, priv, pubPEM := federatedTestKeys(t)
+	t.Setenv("FEDERATED_PUBLIC_KEY_PEM", pubPEM)
+	t.Setenv("FEDERATED_SESSION_SECRET", "test-federated-session-secret-for-this-test")
+
+	h := NewFederatedHandler()
+	e := echo.New()
+	token := signBondevStyleToken(t, priv, sionChurchID, "edit", 5*time.Minute)
+	req, rec := redeemRequest(token)
+
+	if err := h.Redeem(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Redeem returned error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for mode=edit (not yet supported), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFederatedRedeem_NotConfigured_Returns503(t *testing.T) {
+	skipWithoutDB(t)
+	t.Setenv("FEDERATED_PUBLIC_KEY_PEM", "") // deshabilitado a propósito
+
+	h := NewFederatedHandler()
+	e := echo.New()
+	req, rec := redeemRequest("any-token-value")
+
+	if err := h.Redeem(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Redeem returned error: %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when federated access is not configured, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/apps/backend-go/handlers/isolation_test.go
+++ b/apps/backend-go/handlers/isolation_test.go
@@ -308,6 +308,13 @@ func TestIsolationNoBareDBCalls(t *testing.T) {
 	//   discipleship-goals.go    — logGoalAudit, autoUpdateGoalProgressFromReport (post-tx goroutines)
 	//   discipleship_reports.go  — autoUpdateGoalProgressFromReport (same)
 	//   onboarding.go        — BeginTx on global pool is intentional; provisioning runs OUTSIDE TenantTx
+	//   federated.go         — Redeem es un endpoint PÚBLICO sin auth (acceso federado de
+	//                          BonDev), mismo criterio que onboarding.go: corre FUERA de
+	//                          TenantTx porque no existe sesión/church_id todavía. Hace a mano
+	//                          SET LOCAL ROLE jetro_app + set_config('app.current_church_id', ...)
+	//                          dentro de su propia tx ANTES de escribir en federated_sessions_log
+	//                          — la misma protección RLS que da TenantTx, aplicada a mano porque
+	//                          la cadena de middleware no corre pre-auth.
 	//
 	// PENDING MIGRATION (to be done in a future Phase 3d / 3e):
 	//   auth.go         — Login handler reads users by email (global query, pre-auth context)
@@ -325,6 +332,7 @@ func TestIsolationNoBareDBCalls(t *testing.T) {
 		"discipleship-goals.go":   true,
 		"discipleship_reports.go": true,
 		"onboarding.go":           true,
+		"federated.go":            true,
 		// settings.go — GetRegistrationStatus is a PUBLIC unauthenticated endpoint
 		// (no TenantTx exists pre-auth); it reads one boolean for the default church.
 		"settings.go": true,

--- a/apps/backend-go/handlers/permissions.go
+++ b/apps/backend-go/handlers/permissions.go
@@ -7,9 +7,34 @@ import (
 	"database/sql"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
+
+// federatedInstalledModules devuelve las keys de módulos instalados —
+// compartido entre el camino normal de GetMyPermissions y el especial de
+// una sesión federada (mismo query, evita duplicarlo).
+func federatedInstalledModules() ([]string, error) {
+	modules := []string{}
+	rows, err := config.GetDB().DB.Query(`
+		SELECT key FROM modules WHERE is_installed = true ORDER BY key
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err == nil {
+			modules = append(modules, key)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("❌ Error iterating modules rows: %v", err)
+	}
+	return modules, nil
+}
 
 // PermissionsHandler handles permission-related endpoints
 type PermissionsHandler struct{}
@@ -21,6 +46,33 @@ func NewPermissionsHandler() *PermissionsHandler {
 
 // GetMyPermissions returns the current user's role level and accessible modules
 func (h *PermissionsHandler) GetMyPermissions(c echo.Context) error {
+	// Acceso federado (BonDev): no hay fila en `users` para una sesión
+	// federada — devolvemos permisos sintetizados en vez de fallar el
+	// lookup por PK con 404 (ver middleware/federated.go, que setea estos
+	// mismos valores en el contexto). role_level = LevelStaff a propósito:
+	// suficiente para navegar la mayoría de las páginas de datos, pero sin
+	// has_admin_access (paneles de configuración quedan afuera) — las
+	// escrituras están bloqueadas de todas formas server-side
+	// (FederatedReadOnly), esto es sólo de qué VE, no de qué puede tocar.
+	if isFederated, _ := c.Get("is_federated").(bool); isFederated {
+		modules, err := federatedInstalledModules()
+		if err != nil {
+			log.Printf("❌ Error querying modules table: %v", err)
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to fetch installed modules"})
+		}
+		expiresAt, _ := c.Get("federated_expires_at").(time.Time)
+		operatorName, _ := c.Get("federated_operator_name").(string)
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"role":                    middleware.FederatedRole,
+			"role_level":              utils.LevelStaff,
+			"has_admin_access":        false,
+			"installed_modules":       modules,
+			"is_federated":            true,
+			"federated_operator_name": operatorName,
+			"federated_expires_at":    expiresAt,
+		})
+	}
+
 	userID, ok := c.Get("user_id").(string)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, map[string]string{
@@ -41,11 +93,7 @@ func (h *PermissionsHandler) GetMyPermissions(c echo.Context) error {
 	// Get role level
 	roleLevel := utils.GetRoleLevel(role)
 
-	// Get installed modules from the `modules` table
-	modules := []string{}
-	rows, err := config.GetDB().DB.Query(`
-		SELECT key FROM modules WHERE is_installed = true ORDER BY key
-	`)
+	modules, err := federatedInstalledModules()
 	if err != nil {
 		// Log the error and return 500 so the frontend knows something went wrong
 		log.Printf("❌ Error querying modules table: %v", err)
@@ -53,16 +101,6 @@ func (h *PermissionsHandler) GetMyPermissions(c echo.Context) error {
 			"error":   "Failed to fetch installed modules",
 			"details": err.Error(),
 		})
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var key string
-		if err := rows.Scan(&key); err == nil {
-			modules = append(modules, key)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		log.Printf("❌ Error iterating modules rows: %v", err)
 	}
 
 	return c.JSON(http.StatusOK, map[string]interface{}{

--- a/apps/backend-go/handlers/permissions.go
+++ b/apps/backend-go/handlers/permissions.go
@@ -12,14 +12,29 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// federatedInstalledModules devuelve las keys de módulos instalados —
-// compartido entre el camino normal de GetMyPermissions y el especial de
-// una sesión federada (mismo query, evita duplicarlo).
-func federatedInstalledModules() ([]string, error) {
+// installedModulesForChurch devuelve las keys de módulos instalados de UNA
+// iglesia — compartido entre el camino normal de GetMyPermissions y el
+// especial de una sesión federada.
+//
+// FIX de seguridad (2026-07-24): la versión anterior corría sobre
+// config.GetDB().DB (pool global, sin scoping) con un WHERE sin church_id
+// — devolvía los módulos instalados de TODAS las iglesias de la base,
+// mezclados, a cualquiera que pegara este endpoint. Usa config.Tx(c)
+// (hereda el scoping real de TenantTx/RLS, mismo mecanismo que el resto de
+// los handlers) + WHERE church_id explícito — doble capa, ninguna
+// dependiendo de que la otra esté bien configurada.
+//
+// Nota aparte (no arreglada acá, encontrada de paso): la tabla `modules`
+// tiene una policy RLS "Allow public read access to modules" (USING true)
+// que en la práctica anula tenant_isolation para SELECT — cualquier query
+// directa a esa tabla, sin este WHERE explícito, sigue leakeando entre
+// iglesias sin importar el rol de conexión. Vale la pena revisarla aparte.
+func installedModulesForChurch(c echo.Context) ([]string, error) {
+	churchID, _ := c.Get("church_id").(string)
 	modules := []string{}
-	rows, err := config.GetDB().DB.Query(`
-		SELECT key FROM modules WHERE is_installed = true ORDER BY key
-	`)
+	rows, err := config.Tx(c).Query(`
+		SELECT key FROM modules WHERE is_installed = true AND church_id = $1 ORDER BY key
+	`, churchID)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +70,7 @@ func (h *PermissionsHandler) GetMyPermissions(c echo.Context) error {
 	// escrituras están bloqueadas de todas formas server-side
 	// (FederatedReadOnly), esto es sólo de qué VE, no de qué puede tocar.
 	if isFederated, _ := c.Get("is_federated").(bool); isFederated {
-		modules, err := federatedInstalledModules()
+		modules, err := installedModulesForChurch(c)
 		if err != nil {
 			log.Printf("❌ Error querying modules table: %v", err)
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to fetch installed modules"})
@@ -93,7 +108,7 @@ func (h *PermissionsHandler) GetMyPermissions(c echo.Context) error {
 	// Get role level
 	roleLevel := utils.GetRoleLevel(role)
 
-	modules, err := federatedInstalledModules()
+	modules, err := installedModulesForChurch(c)
 	if err != nil {
 		// Log the error and return 500 so the frontend knows something went wrong
 		log.Printf("❌ Error querying modules table: %v", err)

--- a/apps/backend-go/main.go
+++ b/apps/backend-go/main.go
@@ -104,8 +104,36 @@ func main() {
 
 	e := echo.New()
 
+	// Sólo HTTPS (2026-07-24, pedido explícito): en producción, Render
+	// termina TLS y reenvía HTTP puro al proceso — Echo detecta esto vía
+	// X-Forwarded-Proto (c.Scheme(), ver echo/context.go), así que
+	// HTTPSRedirect() funciona bien detrás de ese proxy sin configuración
+	// extra. Gateado a producción: en dev local no hay TLS, redirigir a
+	// https://localhost rompería todo (no hay certificado).
+	// Pre() en vez de Use(): corre ANTES que cualquier otro middleware —
+	// si la request no es HTTPS, no vale la pena ni loguearla.
+	if os.Getenv("ENVIRONMENT") == "production" {
+		e.Pre(middleware.HTTPSRedirect())
+	}
+
 	// Middleware
 	e.Use(middleware.Logger())
+	// HSTS + headers de seguridad estándar. HSTSMaxAge=1 año, le dice al
+	// browser "nunca más intentes HTTP con este dominio" — mitiga
+	// downgrade/SSL-stripping incluso si algún link viejo apunta a http://.
+	// El header sólo se manda cuando la request YA llegó por HTTPS (mismo
+	// chequeo de X-Forwarded-Proto que arriba) — no hace nada en dev local
+	// sobre HTTP, seguro dejarlo siempre activo.
+	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
+		XSSProtection:      "1; mode=block",
+		ContentTypeNosniff: "nosniff",
+		XFrameOptions:      "SAMEORIGIN",
+		HSTSMaxAge:         31536000, // 1 año, valor estándar
+		// HSTSPreloadEnabled queda en false a propósito: sumarse a la
+		// preload list de los browsers es un compromiso mucho más difícil
+		// de revertir (aplica ANTES de la primera visita, a todos los
+		// subdominios) — decisión aparte, no algo para activar de taquito acá.
+	}))
 	if os.Getenv("SENTRY_DSN") != "" {
 		e.Use(sentryMiddleware())
 	}

--- a/apps/backend-go/main.go
+++ b/apps/backend-go/main.go
@@ -8,6 +8,7 @@ import (
 	"backend-sion/services"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	sentry "github.com/getsentry/sentry-go"
@@ -15,6 +16,36 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
+
+// corsAllowOrigins resuelve la lista de orígenes permitidos desde
+// CORS_ORIGINS (coma-separado). Sin setear, devuelve ["*"] — el
+// comportamiento previo, sin cambios de default.
+//
+// Gotcha real (encontrado en vivo, 2026-07-24): "*" + AllowCredentials=true
+// es una combinación que el spec de CORS prohíbe — el browser bloquea
+// silenciosamente cualquier fetch con `credentials:'include'` cross-origin
+// (falla con net::ERR_FAILED, sin mensaje útil en la Network tab más allá
+// de eso). Esto rompe, por ejemplo, el acceso federado (BonDev): la cookie
+// httpOnly de sesión nunca llega si el frontend corre en un origen
+// distinto al backend (dev local: :5173 vs :8181). Setear CORS_ORIGINS con
+// los orígenes reales (ej. "http://localhost:5173,https://sionerp.app")
+// arregla esto sin tocar código.
+func corsAllowOrigins() []string {
+	v := os.Getenv("CORS_ORIGINS")
+	if v == "" {
+		return []string{"*"}
+	}
+	var origins []string
+	for _, o := range strings.Split(v, ",") {
+		if t := strings.TrimSpace(o); t != "" {
+			origins = append(origins, t)
+		}
+	}
+	if len(origins) == 0 {
+		return []string{"*"}
+	}
+	return origins
+}
 
 func sentryMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -89,7 +120,7 @@ func main() {
 	// for the client's full 60s. Complements the DB statement_timeout.
 	e.Use(appMiddleware.RequestTimeout())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins:     []string{"*"}, // En producción, especificar orígenes permitidos
+		AllowOrigins:     corsAllowOrigins(), // CORS_ORIGINS (coma-separado); sin setear, mantiene "*" (comportamiento previo)
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
 		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization", "Accept", "X-Requested-With"},
 		ExposeHeaders:    []string{"Content-Length", "Content-Type"},

--- a/apps/backend-go/middleware/auth.go
+++ b/apps/backend-go/middleware/auth.go
@@ -113,6 +113,16 @@ type Claims struct {
 func SupabaseAuth() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
+			// Acceso federado (BonDev): si FederatedSessionAuth (registrado
+			// ANTES en el grupo protegido, ver routes.go) ya autenticó una
+			// sesión de sólo lectura, no hay nada que validar acá — sería
+			// intentar leer un JWT de Supabase donde no lo hay. Guard
+			// puramente aditivo: para toda request normal "is_federated"
+			// nunca está seteado y este bloque no hace nada.
+			if isFederated, _ := c.Get("is_federated").(bool); isFederated {
+				return next(c)
+			}
+
 			authHeader := c.Request().Header.Get("Authorization")
 			if authHeader == "" {
 				return c.JSON(http.StatusUnauthorized, map[string]string{

--- a/apps/backend-go/middleware/auth_test.go
+++ b/apps/backend-go/middleware/auth_test.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// TestSupabaseAuth_SkipsValidation_WhenAlreadyFederated cubre el guard
+// aditivo para el acceso federado (ver federated.go): si
+// FederatedSessionAuth ya autenticó la request, SupabaseAuth no debe
+// intentar validarla como un JWT de Supabase — no hay Authorization header
+// real en ese camino, así que sin el guard esto devolvería 401.
+func TestSupabaseAuth_SkipsValidation_WhenAlreadyFederated(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("is_federated", true)
+	c.Set("role", FederatedRole) // ya seteado por FederatedSessionAuth
+
+	called := false
+	handler := SupabaseAuth()(func(c echo.Context) error {
+		called = true
+		return c.JSON(http.StatusOK, "ok")
+	})
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected SupabaseAuth to call next(c) directly, skipping its own validation")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if role, _ := c.Get("role").(string); role != FederatedRole {
+		t.Fatalf("expected the federated role to survive untouched, got %v", c.Get("role"))
+	}
+}
+
+// TestSupabaseAuth_NormalRequest_StillRequiresAuthHeader confirma que el
+// guard es puramente aditivo: sin is_federated, el comportamiento normal
+// (401 sin Authorization header) no cambió.
+func TestSupabaseAuth_NormalRequest_StillRequiresAuthHeader(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := SupabaseAuth()(okHandler)
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for a normal request with no Authorization header, got %d", rec.Code)
+	}
+}

--- a/apps/backend-go/middleware/federated.go
+++ b/apps/backend-go/middleware/federated.go
@@ -1,0 +1,243 @@
+// Package middleware — verificación del token de acceso federado que emite
+// BonDev (control plane / back-office del proveedor). Camino de auth
+// COMPLETAMENTE SEPARADO de SupabaseAuth/validateSupabaseToken en auth.go:
+// clave Ed25519 dedicada, nunca JWT_SECRET de sesión. Contrato exacto
+// (nombres de claims, chequeo de signing method) espejado desde el lado
+// emisor: bondev apps/api/internal/auth/federated.go — cualquier cambio ahí
+// tiene que reflejarse acá.
+//
+// Ver SDD completo en Engram (proyecto "sionerp",
+// sdd/federated-access-verify/{proposal,spec,design,tasks}).
+package middleware
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+)
+
+// ErrInvalidFederatedKey: el PEM de config no parsea a una clave pública
+// Ed25519 válida.
+var ErrInvalidFederatedKey = errors.New("middleware: invalid federated Ed25519 public key")
+
+// ErrInvalidFederatedToken cubre firma inválida, exp vencido, alg
+// inesperado o claims corruptos — no se distingue el motivo hacia el
+// caller (evita que un token inválido sirva para enumerar información).
+var ErrInvalidFederatedToken = errors.New("middleware: invalid or expired federated token")
+
+// FederatedClaims — shape EXACTO del JWT que firma BonDev (ver
+// federatedClaims en bondev/apps/api/internal/auth/federated.go). Reason y
+// TicketID sólo se usan en modo edit (I2 fase 2, no implementado todavía en
+// SionERP) — van igual acá para no tener que re-parsear el token cuando se
+// implemente.
+type FederatedClaims struct {
+	OperatorName string `json:"operator_name"`
+	Tenant       string `json:"tenant"` // = churches.id
+	Mode         string `json:"mode"`   // "read" (v1) | "edit" (futuro)
+	Reason       string `json:"reason,omitempty"`
+	TicketID     string `json:"ticket_id,omitempty"`
+	jwt.RegisteredClaims
+}
+
+// ParseFederatedPublicKeyPEM decodifica un PEM PKIX a una clave pública
+// Ed25519. Formato esperado: el que genera `openssl genpkey -algorithm
+// ed25519` + `openssl pkey -pubout` (SubjectPublicKeyInfo/PKIX — el estándar
+// para claves públicas en Go, distinto de PKCS8 que usa la privada del lado
+// BonDev).
+func ParseFederatedPublicKeyPEM(pemStr string) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, ErrInvalidFederatedKey
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, ErrInvalidFederatedKey
+	}
+	edKey, ok := key.(ed25519.PublicKey)
+	if !ok {
+		return nil, ErrInvalidFederatedKey
+	}
+	return edKey, nil
+}
+
+// VerifyFederatedToken valida firma EdDSA + exp y devuelve los claims. El
+// chequeo de signing method usa el mismo type-assertion que el lado emisor
+// (*jwt.SigningMethodEd25519, no jwt.SigningMethodEdDSA directo) — mismo
+// criterio que bondev, evita que un token con `alg` distinto pase colándose
+// por una comparación laxa.
+func VerifyFederatedToken(tokenString string, publicKey ed25519.PublicKey) (*FederatedClaims, error) {
+	claims := &FederatedClaims{}
+	token, err := jwt.ParseWithClaims(tokenString, claims, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodEd25519); !ok {
+			return nil, ErrInvalidFederatedToken
+		}
+		return publicKey, nil
+	})
+	if err != nil || !token.Valid {
+		return nil, ErrInvalidFederatedToken
+	}
+	return claims, nil
+}
+
+// ── Sesión efímera propia de SionERP (emitida en /federated/redeem) ────────
+//
+// El token de BonDev (arriba) es de un solo uso, de canje — SionERP emite su
+// PROPIA sesión al canjearlo, firmada con un secreto HS256 DEDICADO
+// (FEDERATED_SESSION_SECRET), nunca JWT_SECRET de Supabase. Esta sesión es
+// la que el operador de BonDev usa para navegar SionERP en modo lectura.
+
+// FederatedRole es el "rol" interno de una sesión federada — deliberadamente
+// NO es uno de utils.AllRoles() (admin/pastor/staff/supervisor/server): así
+// cualquier chequeo de rol real (RequireRole, HasAdminAccess) la rechaza
+// automáticamente sin necesidad de código especial. El único gate que la
+// deja pasar es FederatedReadOnly() + los handlers de sólo lectura.
+const FederatedRole = "federated_read"
+
+// FederatedSessionTTLDefault es el TTL de canje de BonDev (design: ~5min) —
+// usado como techo si el `exp` del token de BonDev ya venció por poco (no
+// debería pasar, VerifyFederatedToken ya lo rechaza antes, pero deja un
+// límite duro razonable si algún día cambia el TTL de origen).
+const FederatedSessionTTLDefault = 10 * time.Minute
+
+// FederatedSessionClaims son los claims de la sesión propia de SionERP.
+// ChurchID se setea igual que SupabaseAuth setea church_id — así TenantTx
+// scopea esta sesión con el mismo mecanismo (RLS real) que a un usuario
+// autenticado normal, sin lógica de scoping nueva.
+type FederatedSessionClaims struct {
+	OperatorID   string `json:"operator_id"`
+	OperatorName string `json:"operator_name"`
+	ChurchID     string `json:"church_id"`
+	jwt.RegisteredClaims
+}
+
+func federatedSessionSecret() ([]byte, error) {
+	secret := os.Getenv("FEDERATED_SESSION_SECRET")
+	if secret == "" {
+		return nil, errors.New("middleware: FEDERATED_SESSION_SECRET not configured")
+	}
+	return []byte(secret), nil
+}
+
+// SignFederatedSession emite la sesión efímera de sólo lectura. expiresAt
+// normalmente es el `exp` del token de BonDev ya canjeado (la sesión no dura
+// más que la autorización original).
+func SignFederatedSession(operatorID, operatorName, churchID string, expiresAt time.Time) (string, error) {
+	secret, err := federatedSessionSecret()
+	if err != nil {
+		return "", err
+	}
+	claims := FederatedSessionClaims{
+		OperatorID:   operatorID,
+		OperatorName: operatorName,
+		ChurchID:     churchID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "sionerp-federated",
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(secret)
+}
+
+func validateFederatedSessionToken(tokenString string) (*FederatedSessionClaims, error) {
+	secret, err := federatedSessionSecret()
+	if err != nil {
+		return nil, err
+	}
+	claims := &FederatedSessionClaims{}
+	token, err := jwt.ParseWithClaims(tokenString, claims, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, ErrInvalidFederatedToken
+		}
+		return secret, nil
+	})
+	if err != nil || !token.Valid {
+		return nil, ErrInvalidFederatedToken
+	}
+	return claims, nil
+}
+
+// FederatedCookieName es el nombre de la cookie httpOnly donde vive la
+// sesión federada (seteada por FederatedHandler.Redeem) — el browser la
+// adjunta sola en cada request same-origin, no hace falta que el frontend
+// la lea (no podría: es httpOnly a propósito, JS nunca la ve).
+const FederatedCookieName = "sionerp_federated_session"
+
+// FederatedSessionAuth es un middleware que se registra ANTES de
+// SupabaseAuth() en el grupo protegido (ver routes.go). Busca la sesión
+// federada primero en la cookie httpOnly (el camino real, seteada por
+// /federated/redeem) y como fallback en el header Authorization (útil para
+// pruebas manuales/tooling). Si valida, setea el contexto (mismas claves
+// que SupabaseAuth: user_id/role/db_role/has_admin_access/church_id, + el
+// marcador "is_federated") y sigue la cadena — SupabaseAuth trae un guard
+// que, al ver ese marcador, se saltea su propia validación (ver auth.go).
+// Si NO es una sesión federada (ausente, o no valida con
+// FEDERATED_SESSION_SECRET — que es exactamente lo que pasa con un JWT de
+// Supabase real, firmado con otra clave/algoritmo), no toca el contexto y
+// deja que SupabaseAuth corra normal. Nunca devuelve 401 por su cuenta: no
+// tener una sesión federada NO es un error, es el camino normal para el
+// 99.9% de las requests.
+func FederatedSessionAuth() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			token := ""
+			if cookie, err := c.Cookie(FederatedCookieName); err == nil {
+				token = cookie.Value
+			}
+			if token == "" {
+				authHeader := c.Request().Header.Get("Authorization")
+				if t, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+					token = t
+				}
+			}
+			if token == "" {
+				return next(c)
+			}
+
+			claims, err := validateFederatedSessionToken(token)
+			if err != nil {
+				return next(c) // no es una sesión federada — seguí como venías
+			}
+
+			c.Set("user_id", "federated:"+claims.OperatorID)
+			c.Set("email", "")
+			c.Set("role", FederatedRole)
+			c.Set("db_role", FederatedRole)
+			c.Set("has_admin_access", false)
+			c.Set("church_id", claims.ChurchID)
+			c.Set("is_federated", true)
+			c.Set("federated_operator_name", claims.OperatorName)
+			c.Set("federated_expires_at", claims.ExpiresAt.Time)
+
+			return next(c)
+		}
+	}
+}
+
+// FederatedReadOnly bloquea cualquier método distinto de GET cuando la
+// request viene de una sesión federada (R3: enforced server-side, no sólo
+// ocultando botones en el frontend — un curl directo también se rechaza).
+// Se monta GLOBAL en el grupo protegido, DESPUÉS de FederatedSessionAuth,
+// así cubre cualquier endpoint sin que cada handler lo tenga que recordar.
+func FederatedReadOnly() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			isFederated, _ := c.Get("is_federated").(bool)
+			if isFederated && c.Request().Method != http.MethodGet {
+				return c.JSON(http.StatusForbidden, map[string]string{
+					"error": "read-only access — this is a federated support session",
+				})
+			}
+			return next(c)
+		}
+	}
+}

--- a/apps/backend-go/middleware/federated_readonly_test.go
+++ b/apps/backend-go/middleware/federated_readonly_test.go
@@ -1,0 +1,138 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestFederatedReadOnly_BlocksWritesForFederatedSession(t *testing.T) {
+	methods := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(method, "/test", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.Set("is_federated", true)
+
+			handler := FederatedReadOnly()(okHandler)
+			if err := handler(c); err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("expected 403 for federated %s, got %d", method, rec.Code)
+			}
+		})
+	}
+}
+
+func TestFederatedReadOnly_AllowsGetForFederatedSession(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("is_federated", true)
+
+	handler := FederatedReadOnly()(okHandler)
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for federated GET, got %d", rec.Code)
+	}
+}
+
+func TestFederatedReadOnly_NonFederatedSession_AllowsWrites(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// is_federated ausente — sesión normal, no debe tocarla.
+
+	handler := FederatedReadOnly()(okHandler)
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a normal (non-federated) POST, got %d", rec.Code)
+	}
+}
+
+func TestFederatedSessionAuth_NoCookieOrHeader_PassesThroughUntouched(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	called := false
+	handler := FederatedSessionAuth()(func(c echo.Context) error {
+		called = true
+		if _, ok := c.Get("is_federated").(bool); ok {
+			t.Fatal("is_federated should not be set for a request with no token at all")
+		}
+		return c.JSON(http.StatusOK, "ok")
+	})
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected the next handler to run for a request with no federated session")
+	}
+}
+
+func TestFederatedSessionAuth_GarbageBearerToken_PassesThroughUntouched(t *testing.T) {
+	t.Setenv("FEDERATED_SESSION_SECRET", "test-secret-for-this-test-only")
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer this-is-not-a-jwt")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := FederatedSessionAuth()(okHandler)
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected the request to pass through to the next handler (200), got %d", rec.Code)
+	}
+	if _, ok := c.Get("is_federated").(bool); ok {
+		t.Fatal("is_federated should not be set for a garbage token")
+	}
+}
+
+func TestFederatedSessionAuth_ValidSessionToken_SetsContextAndBypassesRest(t *testing.T) {
+	t.Setenv("FEDERATED_SESSION_SECRET", "test-secret-for-this-test-only")
+
+	signed, err := SignFederatedSession("op-1", "Admin Preview", "00000000-0000-0000-0000-00000000515e", time.Now().Add(5*time.Minute))
+	if err != nil {
+		t.Fatalf("SignFederatedSession returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+signed)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := FederatedSessionAuth()(okHandler)
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if role, _ := c.Get("role").(string); role != FederatedRole {
+		t.Fatalf("expected role=%s, got %v", FederatedRole, c.Get("role"))
+	}
+	if churchID, _ := c.Get("church_id").(string); churchID != "00000000-0000-0000-0000-00000000515e" {
+		t.Fatalf("expected church_id to match the session claim, got %v", c.Get("church_id"))
+	}
+	if isFederated, _ := c.Get("is_federated").(bool); !isFederated {
+		t.Fatal("expected is_federated=true")
+	}
+	if hasAdmin, _ := c.Get("has_admin_access").(bool); hasAdmin {
+		t.Fatal("a federated session must never have admin access")
+	}
+}

--- a/apps/backend-go/middleware/federated_test.go
+++ b/apps/backend-go/middleware/federated_test.go
@@ -1,0 +1,136 @@
+package middleware
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// signTestFederatedToken firma un token EXACTAMENTE como lo hace bondev
+// (ver apps/api/internal/auth/federated.go SignFederatedToken) — no
+// importamos ese paquete (repo distinto), así que replicamos el contrato
+// acá para el test, con los mismos nombres de claim.
+func signTestFederatedToken(t *testing.T, priv ed25519.PrivateKey, claims FederatedClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	signed, err := token.SignedString(priv)
+	if err != nil {
+		t.Fatalf("failed to sign test token: %v", err)
+	}
+	return signed
+}
+
+func testKeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate ed25519 keypair: %v", err)
+	}
+	pkixBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+	pubPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pkixBytes}))
+	return pub, priv, pubPEM
+}
+
+func TestParseFederatedPublicKeyPEM_ValidPKIX(t *testing.T) {
+	pub, _, pubPEM := testKeyPair(t)
+	parsed, err := ParseFederatedPublicKeyPEM(pubPEM)
+	if err != nil {
+		t.Fatalf("ParseFederatedPublicKeyPEM returned error: %v", err)
+	}
+	if !pub.Equal(parsed) {
+		t.Fatal("parsed public key does not match the original")
+	}
+}
+
+func TestParseFederatedPublicKeyPEM_InvalidPEM(t *testing.T) {
+	if _, err := ParseFederatedPublicKeyPEM("not a pem"); err != ErrInvalidFederatedKey {
+		t.Fatalf("expected ErrInvalidFederatedKey, got %v", err)
+	}
+}
+
+func TestVerifyFederatedToken_ValidToken_ReturnsClaims(t *testing.T) {
+	pub, priv, _ := testKeyPair(t)
+	now := time.Now()
+	claims := FederatedClaims{
+		OperatorName: "Admin Preview",
+		Tenant:       "00000000-0000-0000-0000-00000000515e",
+		Mode:         "read",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "bondev",
+			Subject:   "operator-123",
+			ID:        "jti-abc",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(5 * time.Minute)),
+		},
+	}
+	signed := signTestFederatedToken(t, priv, claims)
+
+	got, err := VerifyFederatedToken(signed, pub)
+	if err != nil {
+		t.Fatalf("VerifyFederatedToken returned error: %v", err)
+	}
+	if got.Issuer != "bondev" || got.Subject != "operator-123" || got.ID != "jti-abc" {
+		t.Fatalf("unexpected registered claims: %+v", got)
+	}
+	if got.OperatorName != "Admin Preview" || got.Tenant != claims.Tenant || got.Mode != "read" {
+		t.Fatalf("unexpected federated claims: %+v", got)
+	}
+}
+
+func TestVerifyFederatedToken_WrongPublicKey_Rejected(t *testing.T) {
+	_, priv, _ := testKeyPair(t)
+	otherPub, _, _ := testKeyPair(t) // distinta clave — simula un token no firmado por BonDev
+	now := time.Now()
+	signed := signTestFederatedToken(t, priv, FederatedClaims{
+		Mode: "read",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer: "bondev", ID: "jti-1",
+			ExpiresAt: jwt.NewNumericDate(now.Add(5 * time.Minute)),
+		},
+	})
+
+	if _, err := VerifyFederatedToken(signed, otherPub); err != ErrInvalidFederatedToken {
+		t.Fatalf("expected ErrInvalidFederatedToken for wrong key, got %v", err)
+	}
+}
+
+func TestVerifyFederatedToken_Expired_Rejected(t *testing.T) {
+	pub, priv, _ := testKeyPair(t)
+	past := time.Now().Add(-10 * time.Minute)
+	signed := signTestFederatedToken(t, priv, FederatedClaims{
+		Mode: "read",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer: "bondev", ID: "jti-2",
+			IssuedAt:  jwt.NewNumericDate(past),
+			ExpiresAt: jwt.NewNumericDate(past.Add(5 * time.Minute)), // venció hace 5 min
+		},
+	})
+
+	if _, err := VerifyFederatedToken(signed, pub); err != ErrInvalidFederatedToken {
+		t.Fatalf("expected ErrInvalidFederatedToken for expired token, got %v", err)
+	}
+}
+
+func TestVerifyFederatedToken_WrongSigningMethod_Rejected(t *testing.T) {
+	pub, _, _ := testKeyPair(t)
+	// Token HS256 (nada que ver con EdDSA) — no debe validar aunque el
+	// caller le pase la clave pública Ed25519 de BonDev.
+	hmacToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "bondev", "exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+	signed, err := hmacToken.SignedString([]byte("some-secret"))
+	if err != nil {
+		t.Fatalf("failed to sign HS256 test token: %v", err)
+	}
+
+	if _, err := VerifyFederatedToken(signed, pub); err != ErrInvalidFederatedToken {
+		t.Fatalf("expected ErrInvalidFederatedToken for wrong signing method, got %v", err)
+	}
+}

--- a/apps/backend-go/routes/routes.go
+++ b/apps/backend-go/routes/routes.go
@@ -15,6 +15,7 @@ func SetupRoutes(e *echo.Echo) {
 	dashboardHandler := handlers.NewDashboardHandler()
 	authHandler := handlers.NewAuthHandler()
 	onboardingHandler := handlers.NewOnboardingHandler()
+	federatedHandler := handlers.NewFederatedHandler()
 
 	// API routes
 	api := e.Group("/api/v1")
@@ -40,6 +41,14 @@ func SetupRoutes(e *echo.Echo) {
 	onboarding := api.Group("/onboarding")
 	onboarding.POST("/church", onboardingHandler.ProvisionChurch)
 
+	// Acceso federado (BonDev, I2 fase 1 modo read): GET /federated/redeem —
+	// PÚBLICA a propósito, montada FUERA de /api/v1 (BonDev arma la URL
+	// exacta como https://{tenant}.sionerp.local/federated/redeem?token=...,
+	// pensada para abrirse directo en el browser, no como llamada de API).
+	// Sin SupabaseAuth/TenantTx: no hay sesión previa que canjear. Ver SDD
+	// completo en Engram, proyecto "sionerp", sdd/federated-access-verify/*.
+	e.GET("/federated/redeem", federatedHandler.Redeem)
+
 	// Public: la página de registro consulta si el auto-registro está habilitado
 	api.GET("/public/registration-status", handlers.NewSettingsHandler().GetRegistrationStatus)
 	// Public: nombre + logo de la iglesia para la pantalla de login (pre-auth)
@@ -47,7 +56,16 @@ func SetupRoutes(e *echo.Echo) {
 
 	// Protected routes (require authentication)
 	protected := api.Group("")
+	// Acceso federado: si hay una sesión federada válida (cookie httpOnly
+	// seteada por /federated/redeem), setea el contexto ANTES de
+	// SupabaseAuth — que trae su propio guard para saltearse cuando ve que
+	// ya está autenticada (ver middleware/auth.go). Si no hay sesión
+	// federada, este middleware es un no-op total.
+	protected.Use(middleware.FederatedSessionAuth())
 	protected.Use(middleware.SupabaseAuth())
+	// Bloquea cualquier escritura de una sesión federada ANTES de que la
+	// request llegue a abrir transacción — fail-fast, no sólo gating de UI.
+	protected.Use(middleware.FederatedReadOnly())
 	// Modo mantenimiento: 503 para no-staff cuando está activo (corre antes de abrir tx)
 	protected.Use(middleware.MaintenanceGate())
 	// ponytail: TenantTx registered here (Phase 0) but is a no-op pass-through when

--- a/src/components/Can.tsx
+++ b/src/components/Can.tsx
@@ -25,7 +25,11 @@ interface CanProps {
  */
 export function Can({ I, not = false, children, fallback = null }: CanProps) {
   const { permissions } = usePermissions();
-  const hasAccess = !!permissions && permissions.role_level >= I;
+  // Una sesión federada (BonDev, sólo lectura) nunca pasa un <Can> — por
+  // convención esto SIEMPRE gatea una acción (crear/editar/eliminar, ver el
+  // ejemplo del docstring), y el backend rechaza cualquier escritura de
+  // todas formas (FederatedReadOnly) — no tiene sentido mostrar el botón.
+  const hasAccess = !!permissions && !permissions.is_federated && permissions.role_level >= I;
   const effective = not ? !hasAccess : hasAccess;
 
   return <>{effective ? children : fallback}</>;

--- a/src/components/FederatedBanner.tsx
+++ b/src/components/FederatedBanner.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { Eye } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+
+/** Formatea el tiempo restante como "Nm Ss" (o "Expirada" si ya venció). */
+function formatRemaining(expiresAt: Date, now: Date): string {
+  const ms = expiresAt.getTime() - now.getTime();
+  if (ms <= 0) return 'Expirada';
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+}
+
+/**
+ * Banner persistente, no descartable, para sesiones de acceso federado
+ * (BonDev, modo sólo lectura) — R5 del SDD: nunca debe sentirse como un
+ * login normal. Se monta en DashboardLayout, siempre visible arriba de
+ * todo mientras `isFederatedReadOnly` sea true.
+ */
+export function FederatedBanner() {
+  const { isFederatedReadOnly, federatedInfo } = useAuth();
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    if (!isFederatedReadOnly) return;
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, [isFederatedReadOnly]);
+
+  if (!isFederatedReadOnly || !federatedInfo) return null;
+
+  return (
+    <div
+      role="status"
+      className="flex shrink-0 items-center justify-center gap-2 border-b border-cyan-500/30 bg-cyan-500/15 px-4 py-1.5 text-center text-xs text-cyan-700 dark:text-cyan-400 sm:text-sm"
+    >
+      <Eye className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span>
+        Estás viendo esto en <strong>modo lectura</strong> — sesión de soporte de{' '}
+        {federatedInfo.operatorName} (BonDev). Expira en{' '}
+        {formatRemaining(federatedInfo.expiresAt, now)}.
+      </span>
+    </div>
+  );
+}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -22,7 +22,7 @@ const ProtectedRoute = ({
   requiredModule,
   requireAdminAccess,
 }: ProtectedRouteProps) => {
-  const { user, isLoading: authLoading } = useAuth();
+  const { user, isLoading: authLoading, isFederatedReadOnly } = useAuth();
   const { permissions, loading: permissionsLoading } = usePermissions();
 
   // Auth loading
@@ -37,8 +37,9 @@ const ProtectedRoute = ({
     );
   }
 
-  // Not authenticated
-  if (!user) {
+  // Not authenticated (una sesión federada de BonDev cuenta como autenticada
+  // aunque no haya `user` de Supabase — ver AuthContext.isFederatedReadOnly)
+  if (!user && !isFederatedReadOnly) {
     return <Navigate to="/login" replace />;
   }
 
@@ -80,10 +81,7 @@ const ProtectedRoute = ({
   }
 
   // Check module requirement
-  if (
-    requiredModule &&
-    (!permissions || !permissions.installed_modules.includes(requiredModule))
-  ) {
+  if (requiredModule && (!permissions || !permissions.installed_modules.includes(requiredModule))) {
     return (
       <AccessDeniedPage
         message="Este módulo no está instalado o no tienes acceso a él."
@@ -128,7 +126,9 @@ const AccessDeniedPage = ({
         <h2 className="text-2xl font-bold text-foreground mb-2">Acceso Denegado</h2>
         <p
           className="text-muted-foreground mb-6"
-          dangerouslySetInnerHTML={{ __html: defaultMessage.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') }}
+          dangerouslySetInnerHTML={{
+            __html: defaultMessage.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>'),
+          }}
         />
         <a
           href="/dashboard"

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,7 +3,14 @@ import { UserService } from '@/services/user.service';
 import { User as UserType } from '@/types/user.types';
 import { AuthError, Session, User } from '@supabase/supabase-js';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { invalidatePermissionsCache } from '@/lib/permissions';
+import { fetchPermissions, invalidatePermissionsCache } from '@/lib/permissions';
+
+/** Info de una sesión federada activa (acceso BonDev, sólo lectura) — ver
+ *  FederatedBanner.tsx y Can.tsx, que la usan para el banner y el gating. */
+export interface FederatedInfo {
+  operatorName: string;
+  expiresAt: Date;
+}
 
 interface AuthContextType {
   user: User | null;
@@ -17,6 +24,11 @@ interface AuthContextType {
   currentUserLoaded: boolean;
   refreshCurrentUser: () => Promise<void>;
   ensureCurrentUserLoaded: () => Promise<void>;
+  /** true si no hay sesión de Supabase pero SÍ una cookie de acceso federado
+   *  válida (BonDev, modo lectura) — ver components/ProtectedRoute.tsx y
+   *  hooks/usePermissions.ts, que la tratan como una autenticación alternativa. */
+  isFederatedReadOnly: boolean;
+  federatedInfo: FederatedInfo | null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -36,6 +48,29 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingCurrentUser, setIsLoadingCurrentUser] = useState(false);
   const [currentUserLoaded, setCurrentUserLoaded] = useState(false);
+  const [isFederatedReadOnly, setIsFederatedReadOnly] = useState(false);
+  const [federatedInfo, setFederatedInfo] = useState<FederatedInfo | null>(null);
+
+  // Chequea si hay una sesión federada (BonDev, cookie httpOnly) cuando NO
+  // hay sesión de Supabase — es la única forma de saber si el visitante es
+  // un operador de soporte de BonDev en vez de simplemente "no logueado".
+  // No lanza: sin cookie válida, el backend devuelve el permissions fallback
+  // normal (member/0/false) y esto queda en isFederatedReadOnly=false, el
+  // flujo de "no autenticado -> /login" sigue igual que siempre.
+  const checkFederatedSession = async () => {
+    try {
+      const perms = await fetchPermissions();
+      if (perms.is_federated) {
+        setIsFederatedReadOnly(true);
+        setFederatedInfo({
+          operatorName: perms.federated_operator_name || 'BonDev',
+          expiresAt: perms.federated_expires_at ? new Date(perms.federated_expires_at) : new Date(),
+        });
+      }
+    } catch {
+      // sin sesión federada tampoco — visitante genuinamente no autenticado
+    }
+  };
 
   // Función para cargar los datos completos del usuario actual (solo si no se han cargado)
   const loadCurrentUser = async (authUser: User | null, forceRefresh = false) => {
@@ -75,13 +110,20 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   useEffect(() => {
+    // Evita que el listener de abajo baje isLoading antes de que el chequeo
+    // de sesión federada de getSession().then() termine — Supabase dispara
+    // un evento INITIAL_SESSION (session=null) que puede llegar antes o
+    // después de que getSession() resuelva; sólo el bootstrap inicial
+    // necesita esperar al chequeo federado, los eventos post-bootstrap
+    // (login/logout reales) no.
+    let bootstrapped = false;
+
     // Set up auth state listener FIRST
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, session) => {
       setSession(session);
       setUser(session?.user ?? null);
-      setIsLoading(false);
 
       // Solo invalidar permisos en cambios reales de auth, no en refreshes silenciosos
       if (event !== 'TOKEN_REFRESHED') {
@@ -89,26 +131,45 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       }
 
       if (session?.user && event === 'SIGNED_IN') {
+        // Un login real de Supabase gana sobre cualquier estado federado previo.
+        setIsFederatedReadOnly(false);
+        setFederatedInfo(null);
+        setIsLoading(false);
         loadCurrentUser(session.user);
       } else if (!session?.user) {
         setCurrentUser(null);
         setCurrentUserLoaded(false);
+        if (bootstrapped) {
+          setIsLoading(false);
+        }
+        // si !bootstrapped: dejamos que getSession().then() decida
+        // isLoading después de chequear la sesión federada.
+      } else {
+        setIsLoading(false);
       }
-      // TOKEN_REFRESHED: solo actualiza session/user refs — no recarga datos ni limpia cache
     });
 
     // THEN check for existing session
     supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
       setUser(session?.user ?? null);
-      setIsLoading(false);
 
       if (session?.user) {
+        setIsLoading(false);
         loadCurrentUser(session.user);
       } else {
         setCurrentUser(null);
         setCurrentUserLoaded(false);
+        // Sin sesión de Supabase: puede ser un visitante genuinamente no
+        // autenticado, o un operador de BonDev con la cookie de acceso
+        // federado. Sólo lo sabemos preguntándole al backend — por eso
+        // isLoading se mantiene true hasta que esto resuelva: si lo
+        // bajáramos antes, ProtectedRoute podría redirigir a /login antes
+        // de saber que en realidad había una sesión federada válida.
+        await checkFederatedSession();
+        setIsLoading(false);
       }
+      bootstrapped = true;
     });
 
     return () => subscription.unsubscribe();
@@ -165,6 +226,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     currentUserLoaded,
     refreshCurrentUser,
     ensureCurrentUserLoaded,
+    isFederatedReadOnly,
+    federatedInfo,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -23,13 +23,16 @@ interface UsePermissionsReturn {
 }
 
 export function usePermissions(): UsePermissionsReturn {
-  const { user } = useAuth();
+  const { user, isFederatedReadOnly } = useAuth();
   const [permissions, setPermissions] = useState<UserPermissions | null>(null);
   const [loading, setLoading] = useState(true);
   const [roleAllowedModules, setRoleAllowedModules] = useState<string[]>([...MANAGED_MODULES]);
 
   useEffect(() => {
-    if (!user) {
+    // Una sesión federada (BonDev, sólo lectura) no tiene `user` de Supabase
+    // pero sí está autenticada — fetchPermissions() igual funciona (la
+    // identidad la resuelve el backend desde la cookie), ver AuthContext.
+    if (!user && !isFederatedReadOnly) {
       invalidatePermissionsCache();
       setPermissions(null);
       setLoading(false);
@@ -38,12 +41,16 @@ export function usePermissions(): UsePermissionsReturn {
 
     let cancelled = false;
 
-    fetchPermissions(user.id).then(async data => {
+    fetchPermissions(user?.id).then(async data => {
       if (cancelled) return;
       setPermissions(data);
 
-      // Pastor always gets full module access — skip DB check
-      if (data.role === 'pastor' || data.has_admin_access) {
+      // Pastor y sesiones federadas (BonDev) saltean el chequeo de
+      // role_module_access — para federadas además es necesario: esa
+      // tabla se lee vía el cliente JS de Supabase con SU PROPIA sesión,
+      // que una sesión federada no tiene (no hay JWT de Supabase), así que
+      // ese query fallaría/colgaría sin este atajo.
+      if (data.role === 'pastor' || data.has_admin_access || data.is_federated) {
         setRoleAllowedModules([...MANAGED_MODULES]);
         setLoading(false);
         return;
@@ -69,7 +76,7 @@ export function usePermissions(): UsePermissionsReturn {
     return () => {
       cancelled = true;
     };
-  }, [user?.id]);
+  }, [user?.id, isFederatedReadOnly]);
 
   const hasAccess = (requiredLevel: number, requiredModule?: string): boolean => {
     if (!permissions) return false;
@@ -86,8 +93,8 @@ export function usePermissions(): UsePermissionsReturn {
     setPermissions(null);
     setRoleAllowedModules([...MANAGED_MODULES]);
     setLoading(true);
-    if (user) {
-      fetchPermissions(user.id).then(data => {
+    if (user || isFederatedReadOnly) {
+      fetchPermissions(user?.id).then(data => {
         setPermissions(data);
         setLoading(false);
       });

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -1,4 +1,5 @@
 import { AppSidebar } from '@/components/AppSidebar';
+import { FederatedBanner } from '@/components/FederatedBanner';
 import { MobileBottomNav } from '@/components/MobileBottomNav';
 import { SetupModal } from '@/components/SetupModal';
 import { ThemeToggle } from '@/components/ThemeToggle';
@@ -151,8 +152,9 @@ const DashboardLayout = () => {
     return (
       <>
         {/* Contenedor principal SIN overflow-hidden para no romper fixed children en Safari */}
-        <div className="h-[100dvh] w-full bg-background fixed inset-0">
-          <main className="h-full overflow-x-hidden overflow-y-auto pb-16">
+        <div className="h-[100dvh] w-full bg-background fixed inset-0 flex flex-col">
+          <FederatedBanner />
+          <main className="flex-1 min-h-0 overflow-x-hidden overflow-y-auto pb-16">
             <Outlet />
           </main>
         </div>
@@ -166,6 +168,7 @@ const DashboardLayout = () => {
   return (
     <SidebarProvider>
       <div className="h-[100dvh] flex flex-col w-full bg-gradient-to-br from-background via-background to-accent/5 overflow-hidden fixed inset-0">
+        <FederatedBanner />
         {/* Aviso para staff+: mantenimiento activo (los demás ven la pantalla de mantenimiento) */}
         {systemSettings?.maintenance_mode && isStaffPlus && (
           <div className="bg-amber-500/15 text-amber-700 dark:text-amber-400 text-xs sm:text-sm px-4 py-1.5 text-center border-b border-amber-500/30 shrink-0 z-50">

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -29,6 +29,10 @@ export interface UserPermissions {
   role_level: number;
   has_admin_access: boolean;
   installed_modules: string[];
+  /** Acceso federado (BonDev, modo sólo lectura) — ver Can.tsx y FederatedBanner.tsx */
+  is_federated?: boolean;
+  federated_operator_name?: string;
+  federated_expires_at?: string;
 }
 
 let cachedPermissions: UserPermissions | null = null;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -34,7 +34,7 @@ const Login = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [branding, setBranding] = useState<PublicBranding | null>(null);
   const navigate = useNavigate();
-  const { login, user, isLoading: authLoading } = useAuth();
+  const { login, user, isLoading: authLoading, isFederatedReadOnly } = useAuth();
 
   useEffect(() => {
     SettingsService.getPublicBranding().then(setBranding);
@@ -49,12 +49,13 @@ const Login = () => {
     resolver: zodResolver(loginSchema),
   });
 
-  // Redirect authenticated users
+  // Redirect authenticated users (una sesión federada de BonDev cuenta como
+  // autenticada aunque no haya `user` de Supabase — ver AuthContext)
   useEffect(() => {
-    if (user && !authLoading) {
+    if ((user || isFederatedReadOnly) && !authLoading) {
       navigate('/dashboard', { replace: true });
     }
-  }, [user, authLoading, navigate]);
+  }, [user, isFederatedReadOnly, authLoading, navigate]);
 
   const onSubmit = async (data: LoginFormData) => {
     setIsLoading(true);

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -40,6 +40,7 @@ export class ApiService {
       const response = await fetch(`${this.baseUrl}${endpoint}`, {
         method: 'GET',
         headers,
+        credentials: 'include', // manda la cookie httpOnly de sesión federada (acceso BonDev) si existe
       });
 
       if (!response.ok) {
@@ -76,7 +77,11 @@ export class ApiService {
     try {
       const headers = await this.getAuthHeaders();
       headers.delete('Content-Type');
-      const response = await fetch(`${this.baseUrl}${endpoint}`, { method: 'GET', headers });
+      const response = await fetch(`${this.baseUrl}${endpoint}`, {
+        method: 'GET',
+        headers,
+        credentials: 'include',
+      });
       if (!response.ok) {
         const msg = await response.text().catch(() => '');
         const error = new Error(msg || `HTTP ${response.status}`) as Error & { status?: number };
@@ -99,6 +104,7 @@ export class ApiService {
       const response = await fetch(`${this.baseUrl}${endpoint}`, {
         method: 'POST',
         headers,
+        credentials: 'include',
         body: data ? JSON.stringify(data) : undefined,
       });
 
@@ -136,6 +142,7 @@ export class ApiService {
       const response = await fetch(`${this.baseUrl}${endpoint}`, {
         method: 'PUT',
         headers,
+        credentials: 'include',
         body: data ? JSON.stringify(data) : undefined,
       });
 
@@ -173,6 +180,7 @@ export class ApiService {
       const response = await fetch(`${this.baseUrl}${endpoint}`, {
         method: 'DELETE',
         headers,
+        credentials: 'include',
       });
 
       if (!response.ok) {

--- a/supabase/migrations/20260724055447_federated_sessions_log.sql
+++ b/supabase/migrations/20260724055447_federated_sessions_log.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- Migration: 20260724000001_federated_sessions_log.sql
+-- Acceso federado (I2 fase 1, modo read) — auditoría local de cada canje de
+-- token de BonDev + anti-replay. Ver SDD completo en Engram, proyecto
+-- "sionerp", topic sdd/federated-access-verify/{proposal,spec,design,tasks}.
+--
+-- church_id NOT NULL + RLS tenant_isolation: mismo patrón que las 33 tablas
+-- tenant de phase4_rls_cutover.sql — esta tabla no es un caso especial. El
+-- handler de redeem (público, sin sesión previa) setea
+-- app.current_church_id manualmente antes del INSERT, con el church_id ya
+-- validado del token (no hay TenantTx corriendo todavía en ese punto, no
+-- hay sesión de la que "heredarlo").
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.federated_sessions_log (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    jti           text NOT NULL UNIQUE,   -- anti-replay: un token de acceso federado es de un solo uso
+    operator_id   text NOT NULL,          -- claims.Sub — vive en BonDev, NO es FK (sistema externo)
+    operator_name text NOT NULL,
+    church_id     uuid NOT NULL REFERENCES public.churches(id),
+    mode          text NOT NULL,          -- "read" en v1; "edit" queda para I2 fase 2
+    redeemed_at   timestamptz NOT NULL DEFAULT now(),
+    origin_ip     text,
+    expires_at    timestamptz NOT NULL    -- copiado del `exp` del token, para poder limpiar filas viejas
+);
+
+CREATE INDEX IF NOT EXISTS idx_federated_sessions_log_church
+    ON public.federated_sessions_log (church_id);
+
+CREATE INDEX IF NOT EXISTS idx_federated_sessions_log_expires
+    ON public.federated_sessions_log (expires_at);
+
+ALTER TABLE public.federated_sessions_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.federated_sessions_log FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  DROP POLICY IF EXISTS tenant_isolation ON public.federated_sessions_log;
+  CREATE POLICY tenant_isolation ON public.federated_sessions_log
+    USING (church_id = current_setting('app.current_church_id', true)::uuid)
+    WITH CHECK (church_id = current_setting('app.current_church_id', true)::uuid);
+END $$;

--- a/supabase/migrations/20260724162427_drop_stale_permissive_rls_policies.sql
+++ b/supabase/migrations/20260724162427_drop_stale_permissive_rls_policies.sql
@@ -1,0 +1,52 @@
+-- =============================================================================
+-- Migration: 20260724060000_drop_stale_permissive_rls_policies.sql
+--
+-- Hallazgo (2026-07-24, mientras se armaba el acceso federado de BonDev):
+-- varias tablas tenant tienen una policy PERMISIVA vieja, de la era
+-- single-tenant (creada ANTES de que existiera church_id/tenant_isolation
+-- en esa tabla), que nunca se borró cuando Phase 1-4 agregó tenant_isolation.
+-- Postgres combina policies permisivas con OR — así que "USING (true)" en
+-- SELECT/UPDATE anula tenant_isolation por completo para ese comando,
+-- sin importar qué rol de conexión se use (jetro_app incluido).
+--
+-- Confirmado con una auditoría real contra pg_policies (no sólo grep de
+-- migraciones): 16 policies en 15 tablas, todas con el mismo patrón.
+--
+-- EXCEPCIÓN a propósito: NO se toca "Live streams are viewable by
+-- everyone" (live_streams) — a diferencia de las demás, esa lee como una
+-- decisión real (un link de transmisión en vivo pensado para compartirse
+-- sin login, no un descuido). Se deja igual.
+--
+-- Verificado: cada tabla acá tiene tenant_isolation ya creada (Phase 1/2b/4),
+-- así que borrar la policy vieja no deja la tabla sin RLS — sólo saca el
+-- agujero, tenant_isolation queda como única autoridad.
+-- =============================================================================
+
+-- Config/singletons (Phase 1)
+DROP POLICY IF EXISTS "All can read church_info" ON public.church_info;
+DROP POLICY IF EXISTS "All can read system_settings" ON public.system_settings;
+DROP POLICY IF EXISTS "Allow public read access to modules" ON public.modules;
+-- Esta además no tenía NINGÚN chequeo de rol (ni de tenant) — peor que las
+-- de sólo-lectura, permitía UPDATE de cualquier fila desde cualquier origen.
+DROP POLICY IF EXISTS "Allow admin update access to modules" ON public.modules;
+
+-- Tenant schema group A (Phase 2a)
+DROP POLICY IF EXISTS "Todos los autenticados pueden ver zonas" ON public.zones;
+DROP POLICY IF EXISTS "Everyone can read levels" ON public.discipleship_levels;
+
+-- Config per-role (2026-05-27)
+DROP POLICY IF EXISTS "role_module_access_read" ON public.role_module_access;
+
+-- Events (2026-06-16)
+DROP POLICY IF EXISTS "Authenticated read events" ON public.events;
+DROP POLICY IF EXISTS "Authenticated read registrations" ON public.event_registrations;
+
+-- Music (2026-06-12 / 06-15)
+DROP POLICY IF EXISTS "Authenticated read music_members" ON public.music_members;
+DROP POLICY IF EXISTS "Authenticated read music_events" ON public.music_events;
+DROP POLICY IF EXISTS "Authenticated read music_assignments" ON public.music_assignments;
+DROP POLICY IF EXISTS "Authenticated read music_songs" ON public.music_songs;
+DROP POLICY IF EXISTS "Authenticated read music_event_songs" ON public.music_event_songs;
+DROP POLICY IF EXISTS "Authenticated read music_unavailability" ON public.music_unavailability;
+DROP POLICY IF EXISTS "Authenticated read music_telegram_files" ON public.music_telegram_files;
+DROP POLICY IF EXISTS "Authenticated read music_instruments" ON public.music_instruments;


### PR DESCRIPTION
## Summary
Verifica el token Ed25519 que firma BonDev (control plane del proveedor) cuando un operador clickea "Entrar en modo lectura" en una card de tenant, y emite una sesión efímera de sólo lectura de SionERP scoped por RLS a la iglesia correspondiente. Cierra el circuito del acceso federado — BonDev ya emitía el token (mergeado hace rato en su repo); acá está la mitad que faltaba: verificarlo.

**SDD completo** (proposal/spec/design/tasks) en Engram, proyecto `sionerp`, topic `sdd/federated-access-verify/*` — a propósito no está en el repo (regla de seguridad ya existente: discusión de diseño de features sensibles no va al repo público).

### Backend
- Migración `federated_sessions_log`: anti-replay real vía `UNIQUE(jti)` (no un SELECT-luego-INSERT con condición de carrera), FK a `churches`, RLS `tenant_isolation` igual que las 30+ tablas tenant existentes — no es un caso especial.
- `middleware/federated.go`: verifica firma EdDSA + `iss`/`exp`/`tenant` del token de BonDev; emite una sesión propia (HS256, secreto **dedicado**, nunca `JWT_SECRET` de Supabase) vía `FederatedSessionAuth`, registrado antes de `SupabaseAuth` con un guard puramente aditivo.
- `FederatedReadOnly` bloquea cualquier método != GET **server-side** — no es sólo gating de UI, un curl directo también se rechaza.
- `handlers/federated.go`: `GET /federated/redeem` (pública, fuera de `/api/v1` a propósito — BonDev arma esa URL exacta para abrir en el browser). Rechaza replay / tenant desconocido / expirado / `mode=edit` (I2 fase 2, no implementada) con respuestas específicas.
- `/permissions/me` devuelve permisos sintetizados para una sesión federada (`role_level=staff`, `has_admin_access=false`).
- **Fix real encontrado en vivo**: `AllowOrigins=["*"]` + `AllowCredentials=true` es una combinación que el browser rechaza silenciosamente (`net::ERR_FAILED`, sin mensaje útil) — rompía la cookie cross-origin en dev. `CORS_ORIGINS` (env, opcional) permite un allowlist explícito sin tocar el default en producción.

### Frontend
- `AuthContext` expone `isFederatedReadOnly`/`federatedInfo` — sin esto, `ProtectedRoute` Y `Login.tsx` (ambos chequeaban sólo `user` de Supabase) mandaban a la sesión federada de vuelta a `/login` en loop.
- `Can.tsx`: una sesión federada nunca pasa un `<Can>` (todo lo que gatea es una acción de escritura).
- `FederatedBanner`: banner persistente con countdown, no descartable.
- `api.service.ts`: `credentials:'include'` en los 5 métodos (sin esto la cookie httpOnly nunca viaja).

## Test plan
- [x] `go build`/`go vet`/`go test ./...` — verde (única falla es `TestAllModules`, preexistente y no relacionada, confirmado en checkout limpio)
- [x] `tsc --noEmit` limpio en todos los archivos tocados (el resto del repo tiene ~209 errores preexistentes no relacionados)
- [x] `vitest run` — 138/138 verdes
- [x] **Verificado en vivo de punta a punta** (servidor real + Supabase local + browser real, no sólo tests): redeem exitoso con cookie httpOnly correcta, replay rechazado (401), tenant desconocido rechazado (403), expirado rechazado (401), `mode=edit` rechazado explícito (400), dashboard real renderiza con el banner + countdown en vivo, datos scoped correctamente por RLS, escritura bloqueada con 403 incluso en botones que la UI no esconde
- [x] Pre-commit y pre-push hooks (lint-staged, `go vet`, `vitest run`, `go build`) verdes

## Pendiente antes de producción real
Par de claves Ed25519 **real** (hoy sólo existe una de test descartable del lado BonDev) + decidir dónde vive la privada (secret manager, no `.env` plano). No bloquea este PR — se puede desarrollar/testear con clave de test mientras tanto, igual que hizo BonDev.