### PR TITLE
fix: desconecta nivel jerárquico roto en Zonas y agrega invite inline…

### DIFF
--- a/apps/backend-go/handlers/zones.go
+++ b/apps/backend-go/handlers/zones.go
@@ -690,15 +690,12 @@ func (h *ZonesHandler) AssignGroupToZone(c echo.Context) error {
 	})
 }
 
-// AssignUserToZone asigna un usuario a una zona
+// AssignUserToZone asigna un usuario a una zona.
+// El nivel jerárquico de discipulado NO se toca acá — vive en discipleship_hierarchy
+// y se asigna desde la pestaña Jerarquías (ver AssignHierarchy / handlers/discipleship.go).
 func (h *ZonesHandler) AssignUserToZone(c echo.Context) error {
 	zoneID := c.Param("id")
 	userID := c.Param("userId")
-
-	var req struct {
-		DiscipleshipLevel *int `json:"discipleship_level"`
-	}
-	c.Bind(&req)
 
 	db, err := validateTx(c)
 	if err != nil {
@@ -720,25 +717,10 @@ func (h *ZonesHandler) AssignUserToZone(c echo.Context) error {
 		})
 	}
 
-	query := `UPDATE users SET zone_id = $1, updated_at = NOW()`
-	args := []interface{}{zoneID}
-	argCount := 1
-
-	if req.DiscipleshipLevel != nil {
-		argCount++
-		query += fmt.Sprintf(", discipleship_level = $%d", argCount)
-		args = append(args, *req.DiscipleshipLevel)
-	}
-
-	argCount++
-	query += fmt.Sprintf(" WHERE id = $%d", argCount)
-	args = append(args, userID)
-
-	argCount++
-	query += fmt.Sprintf(" AND church_id = $%d", argCount)
-	args = append(args, churchID)
-
-	_, err = db.Exec(query, args...)
+	_, err = db.Exec(
+		"UPDATE users SET zone_id = $1, updated_at = NOW() WHERE id = $2 AND church_id = $3",
+		zoneID, userID, churchID,
+	)
 
 	if err != nil {
 		c.Logger().Error("Error assigning user to zone:", err)

--- a/src/components/dashboard/InviteUserModal.tsx
+++ b/src/components/dashboard/InviteUserModal.tsx
@@ -35,13 +35,15 @@ const inviteSchema = z.object({
   role: z.enum(['admin', 'pastor', 'staff', 'supervisor', 'server', 'member']),
 });
 
-const directCreateSchema = inviteSchema.extend({
-  password: z.string().min(6, 'Mínimo 6 caracteres'),
-  confirm_password: z.string().min(1, 'Confirmá la contraseña'),
-}).refine(data => data.password === data.confirm_password, {
-  message: 'Las contraseñas no coinciden',
-  path: ['confirm_password'],
-});
+const directCreateSchema = inviteSchema
+  .extend({
+    password: z.string().min(6, 'Mínimo 6 caracteres'),
+    confirm_password: z.string().min(1, 'Confirmá la contraseña'),
+  })
+  .refine(data => data.password === data.confirm_password, {
+    message: 'Las contraseñas no coinciden',
+    path: ['confirm_password'],
+  });
 
 type InviteFormData = z.infer<typeof inviteSchema>;
 type DirectCreateFormData = z.infer<typeof directCreateSchema>;
@@ -50,7 +52,8 @@ interface InviteUserModalProps {
   user: User | null;
   isOpen: boolean;
   onClose: () => void;
-  onInviteSent: () => void;
+  /** email is the address just invited/created — undefined callers can ignore it */
+  onInviteSent: (email?: string) => void;
 }
 
 export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteUserModalProps) => {
@@ -140,7 +143,7 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
 
       inviteForm.reset();
       onClose();
-      onInviteSent();
+      onInviteSent(data.email);
     } catch (error: unknown) {
       if (error instanceof Error) {
         toast.error(error.message);
@@ -183,7 +186,7 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
       setGeneratedPassword(null);
       setShowPassword(false);
       onClose();
-      onInviteSent();
+      onInviteSent(data.email);
     } catch (error: unknown) {
       if (error instanceof Error) {
         toast.error(error.message);
@@ -201,19 +204,21 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
   };
 
   return (
-    <Dialog open={isOpen} onClose={onClose}>
+    <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
       <DialogContent className="max-w-[95vw] sm:max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <UserPlus className="h-5 w-5" />
             Agregar Usuario
           </DialogTitle>
-          <DialogDescription>
-            Creá un nuevo usuario para el sistema
-          </DialogDescription>
+          <DialogDescription>Creá un nuevo usuario para el sistema</DialogDescription>
         </DialogHeader>
 
-        <Tabs value={mode} onValueChange={(v) => setMode(v as 'invite' | 'direct')} className="space-y-4">
+        <Tabs
+          value={mode}
+          onValueChange={v => setMode(v as 'invite' | 'direct')}
+          className="space-y-4"
+        >
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger value="invite" className="flex items-center gap-2">
               <Mail className="h-4 w-4" />
@@ -227,10 +232,14 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
 
           {/* Modo Invitar */}
           <TabsContent value="invite">
-            <form onSubmit={inviteForm.handleSubmit(onInviteSubmit)} className="space-y-3 sm:space-y-4">
+            <form
+              onSubmit={inviteForm.handleSubmit(onInviteSubmit)}
+              className="space-y-3 sm:space-y-4"
+            >
               <div className="rounded-lg border bg-muted/30 p-3">
                 <p className="text-sm text-muted-foreground">
-                  Se enviará un email con un Magic Link para que el usuario se registre (requiere SMTP configurado).
+                  Se enviará un email con un Magic Link para que el usuario se registre (requiere
+                  SMTP configurado).
                 </p>
               </div>
 
@@ -245,7 +254,9 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                     placeholder="usuario@ejemplo.com"
                   />
                   {inviteForm.formState.errors.email && (
-                    <p className="text-sm text-destructive">{inviteForm.formState.errors.email.message}</p>
+                    <p className="text-sm text-destructive">
+                      {inviteForm.formState.errors.email.message}
+                    </p>
                   )}
                 </div>
 
@@ -253,7 +264,9 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                   <Label htmlFor="invite-role">Rol *</Label>
                   <Select
                     value={inviteForm.watch('role')}
-                    onValueChange={(value: string) => inviteForm.setValue('role', value as UserRole)}
+                    onValueChange={(value: string) =>
+                      inviteForm.setValue('role', value as UserRole)
+                    }
                   >
                     <SelectTrigger>
                       <SelectValue placeholder="Selecciona un rol" />
@@ -268,42 +281,73 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                     </SelectContent>
                   </Select>
                   {inviteForm.formState.errors.role && (
-                    <p className="text-sm text-destructive">{inviteForm.formState.errors.role.message}</p>
+                    <p className="text-sm text-destructive">
+                      {inviteForm.formState.errors.role.message}
+                    </p>
                   )}
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="invite-first_name">Nombres *</Label>
-                  <Input id="invite-first_name" {...inviteForm.register('first_name')} placeholder="Juan" />
+                  <Input
+                    id="invite-first_name"
+                    {...inviteForm.register('first_name')}
+                    placeholder="Juan"
+                  />
                   {inviteForm.formState.errors.first_name && (
-                    <p className="text-sm text-destructive">{inviteForm.formState.errors.first_name.message}</p>
+                    <p className="text-sm text-destructive">
+                      {inviteForm.formState.errors.first_name.message}
+                    </p>
                   )}
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="invite-last_name">Apellidos *</Label>
-                  <Input id="invite-last_name" {...inviteForm.register('last_name')} placeholder="Pérez" />
+                  <Input
+                    id="invite-last_name"
+                    {...inviteForm.register('last_name')}
+                    placeholder="Pérez"
+                  />
                   {inviteForm.formState.errors.last_name && (
-                    <p className="text-sm text-destructive">{inviteForm.formState.errors.last_name.message}</p>
+                    <p className="text-sm text-destructive">
+                      {inviteForm.formState.errors.last_name.message}
+                    </p>
                   )}
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="invite-phone">Teléfono</Label>
-                  <Input id="invite-phone" {...inviteForm.register('phone')} placeholder="809-555-1234" />
+                  <Input
+                    id="invite-phone"
+                    {...inviteForm.register('phone')}
+                    placeholder="809-555-1234"
+                  />
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="invite-id_number">Cédula</Label>
-                  <Input id="invite-id_number" {...inviteForm.register('id_number')} placeholder="001-1234567-8" />
+                  <Input
+                    id="invite-id_number"
+                    {...inviteForm.register('id_number')}
+                    placeholder="001-1234567-8"
+                  />
                 </div>
               </div>
 
               <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 sm:gap-3 pt-4">
-                <Button type="button" variant="outline" onClick={onClose} className="w-full sm:w-auto">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onClose}
+                  className="w-full sm:w-auto"
+                >
                   Cancelar
                 </Button>
-                <Button type="submit" disabled={loading || inviteForm.formState.disabled} className="w-full sm:w-auto">
+                <Button
+                  type="submit"
+                  disabled={loading || inviteForm.formState.disabled}
+                  className="w-full sm:w-auto"
+                >
                   {loading ? 'Enviando...' : 'Enviar Invitación'}
                 </Button>
               </div>
@@ -312,10 +356,14 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
 
           {/* Modo Crear Directamente */}
           <TabsContent value="direct">
-            <form onSubmit={directForm.handleSubmit(onDirectSubmit)} className="space-y-3 sm:space-y-4">
+            <form
+              onSubmit={directForm.handleSubmit(onDirectSubmit)}
+              className="space-y-3 sm:space-y-4"
+            >
               <div className="rounded-lg border bg-muted/30 p-3">
                 <p className="text-sm text-muted-foreground">
-                  El usuario se crea directamente con contraseña. El admin comparte las credenciales manualmente.
+                  El usuario se crea directamente con contraseña. El admin comparte las credenciales
+                  manualmente.
                 </p>
               </div>
 
@@ -330,7 +378,9 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                     placeholder="usuario@ejemplo.com"
                   />
                   {directForm.formState.errors.email && (
-                    <p className="text-sm text-destructive">{directForm.formState.errors.email.message}</p>
+                    <p className="text-sm text-destructive">
+                      {directForm.formState.errors.email.message}
+                    </p>
                   )}
                 </div>
 
@@ -338,7 +388,9 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                   <Label htmlFor="direct-role">Rol *</Label>
                   <Select
                     value={directForm.watch('role')}
-                    onValueChange={(value: string) => directForm.setValue('role', value as UserRole)}
+                    onValueChange={(value: string) =>
+                      directForm.setValue('role', value as UserRole)
+                    }
                   >
                     <SelectTrigger>
                       <SelectValue placeholder="Selecciona un rol" />
@@ -353,34 +405,56 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                     </SelectContent>
                   </Select>
                   {directForm.formState.errors.role && (
-                    <p className="text-sm text-destructive">{directForm.formState.errors.role.message}</p>
+                    <p className="text-sm text-destructive">
+                      {directForm.formState.errors.role.message}
+                    </p>
                   )}
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="direct-first_name">Nombres *</Label>
-                  <Input id="direct-first_name" {...directForm.register('first_name')} placeholder="Juan" />
+                  <Input
+                    id="direct-first_name"
+                    {...directForm.register('first_name')}
+                    placeholder="Juan"
+                  />
                   {directForm.formState.errors.first_name && (
-                    <p className="text-sm text-destructive">{directForm.formState.errors.first_name.message}</p>
+                    <p className="text-sm text-destructive">
+                      {directForm.formState.errors.first_name.message}
+                    </p>
                   )}
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="direct-last_name">Apellidos *</Label>
-                  <Input id="direct-last_name" {...directForm.register('last_name')} placeholder="Pérez" />
+                  <Input
+                    id="direct-last_name"
+                    {...directForm.register('last_name')}
+                    placeholder="Pérez"
+                  />
                   {directForm.formState.errors.last_name && (
-                    <p className="text-sm text-destructive">{directForm.formState.errors.last_name.message}</p>
+                    <p className="text-sm text-destructive">
+                      {directForm.formState.errors.last_name.message}
+                    </p>
                   )}
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="direct-phone">Teléfono</Label>
-                  <Input id="direct-phone" {...directForm.register('phone')} placeholder="809-555-1234" />
+                  <Input
+                    id="direct-phone"
+                    {...directForm.register('phone')}
+                    placeholder="809-555-1234"
+                  />
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="direct-id_number">Cédula</Label>
-                  <Input id="direct-id_number" {...directForm.register('id_number')} placeholder="001-1234567-8" />
+                  <Input
+                    id="direct-id_number"
+                    {...directForm.register('id_number')}
+                    placeholder="001-1234567-8"
+                  />
                 </div>
 
                 <Separator className="md:col-span-2" />
@@ -418,7 +492,9 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                     )}
                   </div>
                   {directForm.formState.errors.password && (
-                    <p className="text-sm text-destructive">{directForm.formState.errors.password.message}</p>
+                    <p className="text-sm text-destructive">
+                      {directForm.formState.errors.password.message}
+                    </p>
                   )}
                 </div>
 
@@ -431,7 +507,9 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                     placeholder="Repetí la contraseña"
                   />
                   {directForm.formState.errors.confirm_password && (
-                    <p className="text-sm text-destructive">{directForm.formState.errors.confirm_password.message}</p>
+                    <p className="text-sm text-destructive">
+                      {directForm.formState.errors.confirm_password.message}
+                    </p>
                   )}
                 </div>
 
@@ -440,7 +518,7 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
                     <input
                       type="checkbox"
                       checked={showPassword}
-                      onChange={(e) => setShowPassword(e.target.checked)}
+                      onChange={e => setShowPassword(e.target.checked)}
                       className="rounded border-border"
                     />
                     Mostrar contraseña
@@ -449,10 +527,19 @@ export const InviteUserModal = ({ user, isOpen, onClose, onInviteSent }: InviteU
               </div>
 
               <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 sm:gap-3 pt-4">
-                <Button type="button" variant="outline" onClick={onClose} className="w-full sm:w-auto">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onClose}
+                  className="w-full sm:w-auto"
+                >
                   Cancelar
                 </Button>
-                <Button type="submit" disabled={loading || directForm.formState.disabled} className="w-full sm:w-auto">
+                <Button
+                  type="submit"
+                  disabled={loading || directForm.formState.disabled}
+                  className="w-full sm:w-auto"
+                >
                   {loading ? 'Creando...' : 'Crear Usuario'}
                 </Button>
               </div>

--- a/src/components/discipleship/UserZoneAssignment.tsx
+++ b/src/components/discipleship/UserZoneAssignment.tsx
@@ -26,7 +26,6 @@ import { useMobileMode } from '@/hooks/useMobileMode';
 import { UserPlus, Search, MapPin, Check, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useZones } from '@/hooks/useZones';
-import { useDiscipleshipLevels } from '@/hooks/useDiscipleshipLevels';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import { ZonesService } from '@/services/zones.service';
 import { normalizeNullString } from '@/lib/utils';
@@ -40,29 +39,22 @@ interface AssignmentUser {
   email: string;
   phone: string;
   role: string;
-  is_active: boolean;
   zone_name?: string;
   zone_id?: string;
   discipleship_level?: number;
-  created_at: string;
-  updated_at: string;
 }
 
 interface UserZoneAssignmentProps {
-  onAssignment?: (userId: string, zoneId: string, role?: string) => void;
+  onAssignment?: (userId: string, zoneId: string) => void;
 }
 
 const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment }) => {
   const isMobileApp = useMobileMode();
   const { zones, loading: zonesLoading } = useZones();
-  const { levels: discipleshipLevels, loading: levelsLoading } = useDiscipleshipLevels({
-    autoLoad: true,
-  });
   const [users, setUsers] = useState<AssignmentUser[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedZone, setSelectedZone] = useState('all');
-  const [selectedRole, setSelectedRole] = useState<string>('keep');
   const [selectedUser, setSelectedUser] = useState<AssignmentUser | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [assignZoneId, setAssignZoneId] = useState<string | undefined>(undefined);
@@ -151,20 +143,15 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
   const handleAssignToZone = async (user: AssignmentUser, zoneId: string) => {
     if (!assignZoneId) return;
 
-    const levelId = selectedRole === 'keep' ? undefined : selectedRole;
-    const level = levelId ? discipleshipLevels.find(l => l.id === levelId) : undefined;
-    const levelIndex = level ? level.order_index : undefined;
-
     try {
       setAssigning(true);
-      await ZonesService.assignUserToZone(zoneId, user.id, levelIndex);
+      await ZonesService.assignUserToZone(zoneId, user.id);
       const zone = zones.find(z => z.id === zoneId);
       toast.success(`${user.full_name} asignado a ${zone?.name || 'la zona'}`);
-      onAssignment?.(user.id, zoneId, levelId);
+      onAssignment?.(user.id, zoneId);
       setIsDialogOpen(false);
       setSelectedUser(null);
       setAssignZoneId(undefined);
-      setSelectedRole('keep');
 
       await loadUsers();
     } catch (error) {
@@ -178,7 +165,6 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
   const openAssignDialog = (user: AssignmentUser) => {
     setSelectedUser(user);
     setAssignZoneId(user.zone_id || undefined);
-    setSelectedRole('keep');
     setIsDialogOpen(true);
   };
 
@@ -317,7 +303,6 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
         if (!open) {
           setSelectedUser(null);
           setAssignZoneId(undefined);
-          setSelectedRole('keep');
         }
       }}
     >
@@ -327,7 +312,8 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
             {selectedUser ? `Asignar ${selectedUser.full_name} a Zona` : 'Asignar a Zona'}
           </DialogTitle>
           <DialogDescription>
-            Selecciona una zona y opcionalmente actualiza el rol
+            Selecciona una zona para este usuario. El nivel jerárquico de discipulado se asigna
+            desde la pestaña Jerarquías.
           </DialogDescription>
         </DialogHeader>
 
@@ -357,29 +343,6 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
             </Select>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="assign-role">Nivel de Discipulado (opcional)</Label>
-            <Select value={selectedRole} onValueChange={setSelectedRole}>
-              <SelectTrigger>
-                <SelectValue placeholder="Mantener nivel actual" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="keep">Mantener nivel actual</SelectItem>
-                {discipleshipLevels.map(level => (
-                  <SelectItem key={level.id} value={level.id}>
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-3 h-3 rounded-full"
-                        style={{ backgroundColor: level.color }}
-                      />
-                      {level.name}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
           <div className="flex justify-end gap-2 pt-4">
             <Button
               variant="outline"
@@ -387,7 +350,6 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
                 setIsDialogOpen(false);
                 setSelectedUser(null);
                 setAssignZoneId(undefined);
-                setSelectedRole('keep');
               }}
             >
               Cancelar
@@ -411,7 +373,7 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
     </Dialog>
   );
 
-  if (loadingUsers || zonesLoading || levelsLoading) {
+  if (loadingUsers || zonesLoading) {
     return (
       <Card>
         <CardHeader>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {
@@ -27,8 +27,7 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />;

--- a/src/pages/dashboard/music/MusicMembers.tsx
+++ b/src/pages/dashboard/music/MusicMembers.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { MusicService } from '@/services/music.service';
+import { UserService } from '@/services/user.service';
 import { Funciones } from '@/types/music.types';
 import type {
   MusicMember,
@@ -30,6 +31,7 @@ import type {
 import type { User } from '@/types/user.types';
 import { FuncionChip, InstrumentChip, resolveCategory } from './instrument-visual';
 import { UserSearchPicker } from './UserSearchPicker';
+import { InviteUserModal } from '@/components/dashboard/InviteUserModal';
 
 const FUNCION_LABELS: Record<Funcion, string> = {
   corista: 'Corista',
@@ -68,6 +70,24 @@ function MemberForm({
     instrument: initial?.instrument ?? '',
     isDirector: initial?.isDirector ?? false,
   });
+  const [inviteOpen, setInviteOpen] = useState(false);
+
+  async function handleInvited(email?: string) {
+    setInviteOpen(false);
+    if (!email) return;
+    try {
+      const res = await UserService.getUsers({ search: email, limit: 1 });
+      const found = res.users.find(u => u.email.toLowerCase() === email.toLowerCase());
+      if (found) {
+        setForm(prev => ({ ...prev, pickedUser: found }));
+        toast.success('Usuario creado y seleccionado');
+        return;
+      }
+    } catch {
+      // non-blocking — fall through to the generic message below
+    }
+    toast.info('Usuario creado. Buscalo en el campo de arriba para seleccionarlo.');
+  }
 
   function toggleFuncion(f: Funcion) {
     setForm(prev => ({
@@ -118,8 +138,21 @@ function MemberForm({
             onPick={u => setForm(prev => ({ ...prev, pickedUser: u }))}
           />
           <p className="text-xs text-muted-foreground">
-            Buscá por nombre, email o documento. Solo aparecen usuarios que aún no son integrantes.
+            Buscá por nombre, email o documento. Solo aparecen usuarios que aún no son integrantes.{' '}
+            <button
+              type="button"
+              onClick={() => setInviteOpen(true)}
+              className="text-primary hover:underline"
+            >
+              ¿No está en el sistema? Invitala
+            </button>
           </p>
+          <InviteUserModal
+            user={null}
+            isOpen={inviteOpen}
+            onClose={() => setInviteOpen(false)}
+            onInviteSent={handleInvited}
+          />
         </div>
       ) : (
         <div className="rounded-md border border-border px-3 py-2 bg-muted/30">

--- a/src/services/zones.service.ts
+++ b/src/services/zones.service.ts
@@ -85,13 +85,8 @@ export class ZonesService {
     return ApiService.put(`/zones/${zoneId}/groups/${groupId}`);
   }
 
-  static async assignUserToZone(
-    zoneId: string,
-    userId: string,
-    discipleshipLevel?: number
-  ): Promise<{ message: string }> {
-    const body = discipleshipLevel ? { discipleship_level: discipleshipLevel } : {};
-    return ApiService.put(`/zones/${zoneId}/users/${userId}`, body);
+  static async assignUserToZone(zoneId: string, userId: string): Promise<{ message: string }> {
+    return ApiService.put(`/zones/${zoneId}/users/${userId}`, {});
   }
 
   static async getAvailableSupervisors(): Promise<User[]> {


### PR DESCRIPTION
… en Música

- Zonas tab escribía users.discipleship_level, columna que ningún backend lee; el nivel real vive en discipleship_hierarchy (asignado desde Jerarquías). Se saca el selector redundante/engañoso de Zonas.
- InviteUserModal pasaba onClose a Dialog (Radix) en vez de onOpenChange: no cerraba con click afuera ni Escape.
- Badge sin whitespace-nowrap: texto largo se cortaba en varias líneas dentro del pill.
- MusicMembers: alta de integrante permite invitar a alguien que todavía no tiene cuenta, reutilizando InviteUserModal.