### PR TITLE
fix(provider): alinea contract_version a "v1" esperado por BonDev

### DIFF
--- a/apps/backend-go/handlers/provider.go
+++ b/apps/backend-go/handlers/provider.go
@@ -56,7 +56,7 @@ type tenantHealthWire struct {
 	Meta              map[string]any  `json:"meta"`
 }
 
-const providerContractVersion = "1.0"
+const providerContractVersion = "v1"
 
 // ListTenants handles GET /provider/tenants.
 func (h *ProviderHandler) ListTenants(c echo.Context) error {


### PR DESCRIPTION
## Qué

El health payload de la Provider API declaraba `contract_version: "1.0"`, pero el adapter de BonDev (`internal/providers/sionerp`) exige `"v1"` con validación estricta (`TenantHealthContractVersion` + test que rechaza cualquier otra versión). Todo refresh de tenant en BonDev devolvía 500 ("unsupported contract_version").

## Detección

Prueba E2E real BonDev ↔ SionERP (2026-08-07): el provision creó el tenant correctamente (201), pero `POST /api/tenants/:id/refresh` fallaba hasta alinear la versión.

## Cambio

- `apps/backend-go/handlers/provider.go:59` — `providerContractVersion` de `"1.0"` → `"v1"`.

## Verificación

- `go build ./...` OK
- `go vet ./...` OK (hook lint-staged)
- E2E: refresh devuelve 200 con `SyncStatus: ok`, `ContractVersion: v1`, `ActiveUsers30d` propagado.