### PR TITLE
Rediseño mobile: Configuración, Roles, Módulos, Mapa y Música + fixes

### DIFF
--- a/scripts/seed-reports-attendance.mjs
+++ b/scripts/seed-reports-attendance.mjs
@@ -1,0 +1,139 @@
+/**
+ * seed-reports-attendance.mjs
+ * Rellena discipleship_reports (16 semanas) y discipleship_attendance (10 semanas)
+ * para todos los grupos activos, así las gráficas de Crecimiento, Salud del
+ * Sistema e Indicadores clave del dashboard pastoral tienen data real.
+ *
+ * SOLO LOCAL — apunta al Postgres de `supabase start` (127.0.0.1:54322).
+ * Idempotente: usa NOT EXISTS / ON CONFLICT DO NOTHING, se puede re-correr.
+ *
+ * Uso: node scripts/seed-reports-attendance.mjs
+ */
+
+import pg from 'pg';
+import { randomUUID } from 'crypto';
+
+const { Client } = pg;
+const DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+const REPORT_WEEKS = 16;
+const ATTENDANCE_WEEKS = 10;
+
+const rand = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+const chance = p => Math.random() < p;
+
+// Monday..Saturday of the ISO week `weeksAgo` weeks before today.
+function weekBounds(weeksAgo) {
+  const now = new Date();
+  const dow = (now.getDay() + 6) % 7; // Mon=0..Sun=6
+  const thisMonday = new Date(now);
+  thisMonday.setDate(now.getDate() - dow - weeksAgo * 7);
+  const monday = new Date(thisMonday);
+  const saturday = new Date(thisMonday);
+  saturday.setDate(monday.getDate() + 5);
+  const fmt = d => d.toISOString().slice(0, 10);
+  return { monday: fmt(monday), saturday: fmt(saturday) };
+}
+
+function buildReportData(groupId) {
+  return {
+    group_id: groupId,
+    attendance_nd: rand(8, 18),
+    attendance_dm: rand(3, 10),
+    attendance_friends: rand(0, 4),
+    attendance_kids: rand(0, 6),
+    group_discipleships: chance(0.8) ? 1 : 0,
+    group_evangelism: chance(0.6) ? 1 : 0,
+    leader_new_disciples_care: chance(0.7) ? 1 : 0,
+    leader_mature_disciples_care: chance(0.7) ? 1 : 0,
+    spiritual_journal_days: rand(2, 7),
+    leader_evangelism: chance(0.6) ? 1 : 0,
+    service_attendance_sunday: chance(0.9),
+    service_attendance_prayer: chance(0.7),
+    doctrine_attendance: chance(0.6),
+    baptisms: chance(0.1) ? 1 : 0,
+    is_multiplying: false,
+  };
+}
+
+async function main() {
+  const client = new Client({ connectionString: DB_URL });
+  await client.connect();
+
+  const { rows: groups } = await client.query(`
+    SELECT id, church_id, leader_id, supervisor_id
+    FROM discipleship_groups
+    WHERE status = 'active'
+  `);
+  console.log(`Grupos activos: ${groups.length}`);
+
+  let reportsCreated = 0;
+  for (const g of groups) {
+    if (!g.leader_id) continue;
+    for (let w = 1; w <= REPORT_WEEKS; w++) {
+      const { monday, saturday } = weekBounds(w);
+      const submittedAt = `${saturday}T18:${rand(0, 59)}:00Z`;
+      const { rowCount } = await client.query(
+        `
+        INSERT INTO discipleship_reports
+          (id, reporter_id, supervisor_id, report_level, report_type,
+           period_start, period_end, report_data, status, submitted_at, church_id)
+        SELECT $1, $2, $3, 1, 'weekly', $4, $5, $6, 'submitted', $7, $8
+        WHERE NOT EXISTS (
+          SELECT 1 FROM discipleship_reports
+          WHERE reporter_id = $2 AND period_start = $4
+        )
+        `,
+        [
+          randomUUID(),
+          g.leader_id,
+          g.supervisor_id,
+          monday,
+          saturday,
+          JSON.stringify(buildReportData(g.id)),
+          submittedAt,
+          g.church_id,
+        ]
+      );
+      reportsCreated += rowCount;
+    }
+  }
+  console.log(`Reportes insertados: ${reportsCreated}`);
+
+  let attendanceCreated = 0;
+  for (const g of groups) {
+    const { rows: members } = await client.query(
+      `SELECT user_id FROM discipleship_group_members WHERE group_id = $1 AND is_active = true`,
+      [g.id]
+    );
+    if (members.length === 0) continue;
+
+    for (let w = 1; w <= ATTENDANCE_WEEKS; w++) {
+      const { saturday } = weekBounds(w);
+      // Meeting day: mid-week (Wednesday of that ISO week).
+      const meetingDate = new Date(saturday);
+      meetingDate.setDate(meetingDate.getDate() - 3);
+      const meetingDateStr = meetingDate.toISOString().slice(0, 10);
+
+      for (const m of members) {
+        const { rowCount } = await client.query(
+          `
+          INSERT INTO discipleship_attendance (group_id, user_id, meeting_date, present, church_id)
+          VALUES ($1, $2, $3, $4, $5)
+          ON CONFLICT (group_id, user_id, meeting_date) DO NOTHING
+          `,
+          [g.id, m.user_id, meetingDateStr, chance(0.82), g.church_id]
+        );
+        attendanceCreated += rowCount;
+      }
+    }
+  }
+  console.log(`Asistencias insertadas: ${attendanceCreated}`);
+
+  await client.end();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/UserDetailSheet.tsx
+++ b/src/components/UserDetailSheet.tsx
@@ -127,18 +127,18 @@ export const UserDetailSheet = ({ user, isOpen, onClose, onEdit }: UserDetailShe
       <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
         <SheetHeader className="space-y-4">
           {/* Header con Avatar y Info Básica */}
-          <div className="flex items-start gap-4">
-            <Avatar className="h-16 w-16">
-              <AvatarFallback className="text-lg font-semibold bg-primary text-primary-foreground">
+          <div className="flex items-start gap-3 sm:gap-4">
+            <Avatar className="h-12 w-12 sm:h-16 sm:w-16 shrink-0">
+              <AvatarFallback className="text-base sm:text-lg font-semibold bg-primary text-primary-foreground">
                 {getInitials(user.first_name || '', user.last_name || '')}
               </AvatarFallback>
             </Avatar>
 
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-2">
-                <SheetTitle className="text-2xl">
-                  {user.first_name} {user.last_name}
-                </SheetTitle>
+            <div className="flex-1 min-w-0">
+              <SheetTitle className="text-lg sm:text-2xl truncate">
+                {user.first_name} {user.last_name}
+              </SheetTitle>
+              <div className="flex flex-wrap items-center gap-1.5 mt-1.5 mb-2">
                 <Badge variant={getRoleBadgeVariant(user.role)}>
                   {getRoleDisplayName(user.role)}
                 </Badge>
@@ -153,14 +153,14 @@ export const UserDetailSheet = ({ user, isOpen, onClose, onEdit }: UserDetailShe
                 )}
               </div>
 
-              <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                <div className="flex items-center gap-1">
-                  <Mail className="h-3 w-3" />
-                  <span>{user.email}</span>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                <div className="flex items-center gap-1 min-w-0">
+                  <Mail className="h-3 w-3 shrink-0" />
+                  <span className="truncate">{user.email}</span>
                 </div>
                 {user.phone && (
                   <div className="flex items-center gap-1">
-                    <Phone className="h-3 w-3" />
+                    <Phone className="h-3 w-3 shrink-0" />
                     <span>{user.phone}</span>
                   </div>
                 )}
@@ -173,7 +173,7 @@ export const UserDetailSheet = ({ user, isOpen, onClose, onEdit }: UserDetailShe
 
         {/* Tabs con toda la información */}
         <Tabs defaultValue="general" className="w-full">
-          <TabsList className="grid w-full grid-cols-4">
+          <TabsList className="flex w-full overflow-x-auto justify-start sm:grid sm:grid-cols-4">
             <TabsTrigger value="general">General</TabsTrigger>
             <TabsTrigger value="discipleship">Discipulado</TabsTrigger>
             <TabsTrigger value="metrics">Métricas</TabsTrigger>

--- a/src/components/dashboard/PersonalDashboard.tsx
+++ b/src/components/dashboard/PersonalDashboard.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { getAvatarColor } from '@/lib/utils';
 import {
   MapPin,
   Users,
@@ -49,6 +50,13 @@ interface PersonalDashboardProps {
   subtitle?: string;
 }
 
+// El user de useAuth() no tipa estos campos extendidos que sí vienen del backend.
+interface ExtendedUserFields {
+  zone_name?: string;
+  cell_group?: string;
+  full_name?: string;
+}
+
 const PersonalDashboard: React.FC<PersonalDashboardProps> = ({
   title = 'Mi Dashboard Personal',
   subtitle = 'Información sobre tu participación en el discipulado',
@@ -57,8 +65,8 @@ const PersonalDashboard: React.FC<PersonalDashboardProps> = ({
 
   // Mock user data with discipleship information
   const userInfo = {
-    zone: (user as any)?.zone_name || 'Zona Norte',
-    group: (user as any)?.cell_group || 'Célula Esperanza',
+    zone: (user as ExtendedUserFields | null)?.zone_name || 'Zona Norte',
+    group: (user as ExtendedUserFields | null)?.cell_group || 'Célula Esperanza',
     role: user?.role || 'member',
     supervisor: 'María González',
     leader: 'Roberto Silva',
@@ -70,7 +78,8 @@ const PersonalDashboard: React.FC<PersonalDashboardProps> = ({
     nextMeeting: '2024-09-25',
   };
 
-  const [notifications, setNotifications] = React.useState<DashboardNotification[]>(initialNotifications);
+  const [notifications, setNotifications] =
+    React.useState<DashboardNotification[]>(initialNotifications);
 
   const handleMarkAsRead = (id: string) => {
     setNotifications(prev => prev.map(n => (n.id === id ? { ...n, read: true } : n)));
@@ -106,9 +115,7 @@ const PersonalDashboard: React.FC<PersonalDashboardProps> = ({
       {/* Header */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3 sm:gap-4">
         <div className="min-w-0">
-          <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
-            {title}
-          </h1>
+          <h1 className="text-2xl sm:text-3xl font-bold text-foreground">{title}</h1>
           <p className="text-sm sm:text-base text-muted-foreground mt-1">{subtitle}</p>
         </div>
       </div>
@@ -127,11 +134,12 @@ const PersonalDashboard: React.FC<PersonalDashboardProps> = ({
               {/* Profile Section */}
               <div className="flex flex-col sm:flex-row items-center sm:items-start text-center sm:text-left gap-3 sm:gap-4">
                 <Avatar className="w-16 h-16 shrink-0">
-                  <AvatarImage
-                    src={`https://api.dicebear.com/7.x/initials/svg?seed=${(user as any)?.full_name || user?.email}`}
-                  />
-                  <AvatarFallback>
-                    {((user as any)?.full_name || user?.email || 'U')
+                  <AvatarFallback
+                    className={getAvatarColor(
+                      (user as ExtendedUserFields | null)?.full_name || user?.email || 'U'
+                    )}
+                  >
+                    {((user as ExtendedUserFields | null)?.full_name || user?.email || 'U')
                       ?.split(' ')
                       .map((n: string) => n[0])
                       .join('')}
@@ -139,7 +147,7 @@ const PersonalDashboard: React.FC<PersonalDashboardProps> = ({
                 </Avatar>
                 <div className="flex-1 min-w-0">
                   <h3 className="text-lg sm:text-xl font-semibold truncate">
-                    {(user as any)?.full_name || user?.email}
+                    {(user as ExtendedUserFields | null)?.full_name || user?.email}
                   </h3>
                   <div className="flex flex-wrap justify-center sm:justify-start items-center gap-2 mt-1">
                     <Badge className={`${roleInfo.color} text-white`}>

--- a/src/components/discipleship/DiscipleshipMap.tsx
+++ b/src/components/discipleship/DiscipleshipMap.tsx
@@ -1,9 +1,17 @@
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from '@/components/ui/drawer';
 import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
+import { useMobileMode } from '@/hooks/useMobileMode';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import { ZonesService } from '@/services/zones.service';
 import type {
@@ -16,7 +24,6 @@ import type {
 import { Calendar, Layers, MapPin, Search, User as UserIcon, Users } from 'lucide-react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import { useTheme } from 'next-themes';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   MapContainer,
@@ -64,6 +71,14 @@ interface DiscipleshipMapProps {
 
 const DEFAULT_CENTER: [number, number] = [11.4045, -69.6734];
 const DEFAULT_ZOOM = 13;
+
+// Tiles estándar de OpenStreetMap: calles, etiquetas y manzanas/edificios
+// visibles — el look "mapa real" (tipo Google Maps), no el estilo minimalista
+// de CARTO que se usaba antes. Sin API key, gratis, mismo para ambos temas
+// (igual que Google Maps, que no tiene un modo oscuro propio del mapa base).
+const TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const TILE_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
 // ── SVG Markers (as HTML strings for divIcon) ──────────────
 
@@ -278,8 +293,7 @@ export default function DiscipleshipMap({
   onZoneSelect,
   heightClassName = 'h-[620px]',
 }: DiscipleshipMapProps) {
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
+  const isMobileApp = useMobileMode();
   const mapRef = useRef<L.Map | null>(null);
   const [zoneData, setZoneData] = useState<ZoneMapData[]>([]);
   const [mapUsers, setMapUsers] = useState<MapUser[]>([]);
@@ -291,6 +305,9 @@ export default function DiscipleshipMap({
   // Toggles
   const [showGroups, setShowGroups] = useState(true);
   const [showPeople, setShowPeople] = useState(false);
+
+  // Mobile: hoja inferior con la lista de zonas (reemplaza al sidebar de escritorio)
+  const [mobileListOpen, setMobileListOpen] = useState(false);
 
   // Popups
   const [selectedGroup, setSelectedGroup] = useState<ZoneMapGroup | null>(null);
@@ -441,8 +458,9 @@ export default function DiscipleshipMap({
       setSelectedPerson(null);
       onZoneSelect?.(nextZoneId, zone?.groups ?? []);
       if (nextZoneId) fitToZone(nextZoneId);
+      if (isMobileApp) setMobileListOpen(false);
     },
-    [onZoneSelect, fitToZone]
+    [onZoneSelect, fitToZone, isMobileApp]
   );
 
   // Pre-compute all polygon data for rendering
@@ -468,6 +486,455 @@ export default function DiscipleshipMap({
       .filter((l): l is NonNullable<typeof l> => l !== null);
   }, [zoneFeatures, internalSelectedZoneId]);
 
+  // ── Capas del mapa (compartidas entre el layout de escritorio y el mobile) ──
+  const mapLayers = (
+    <>
+      <ZoomControl position="topright" />
+      <TileLayer attribution={TILE_ATTRIBUTION} url={TILE_URL} />
+
+      {/* Zona polygons (fill + border) */}
+      {allZonePolygons.map((poly, idx) => (
+        <Polygon
+          key={`zone-poly-${idx}`}
+          positions={poly.positions}
+          pathOptions={{
+            color: poly.color,
+            fillColor: poly.color,
+            fillOpacity: poly.isSelected ? 0.3 : 0.14,
+            weight: poly.isSelected ? 3 : 1.5,
+            dashArray: poly.isSelected ? undefined : '5 5',
+            lineCap: 'round',
+          }}
+        />
+      ))}
+
+      {/* Etiquetas de nombre de zona, centradas en su área */}
+      {zoneLabels.map(label => (
+        <Marker
+          key={`zone-label-${label.zoneId}`}
+          position={label.center}
+          icon={createZoneLabelIcon(label.name, label.color, label.isSelected)}
+          interactive={false}
+          zIndexOffset={-1000}
+        />
+      ))}
+
+      {/* FitToBounds helper */}
+      {fitToBounds && <FitToBounds bounds={fitToBounds.bounds} trigger={fitToBounds.key} />}
+      {flyTo && <FlyTo position={flyTo.position} zoom={flyTo.zoom} trigger={flyTo.key} />}
+      <PopupCloseHandler
+        onClose={() => {
+          setSelectedGroup(null);
+          setSelectedPerson(null);
+        }}
+      />
+
+      {/* Marcadores de Grupos (casitas) */}
+      {showGroups &&
+        visibleGroups.map(group => {
+          const lat = Number(group.latitude);
+          const lng = Number(group.longitude);
+          if (isNaN(lat) || isNaN(lng) || !isFinite(lat) || !isFinite(lng)) return null;
+          const zoneColor = getGroupZoneColor(group);
+          const isSelected = selectedGroup?.id === group.id;
+          return (
+            <Marker
+              key={`group-${group.id}`}
+              position={[lat, lng]}
+              icon={createHouseIcon(zoneColor, isSelected ? 30 : 22, isSelected)}
+              zIndexOffset={isSelected ? 1000 : 0}
+              eventHandlers={{
+                click: () => {
+                  setSelectedPerson(null);
+                  setSelectedGroup(group);
+                },
+              }}
+            />
+          );
+        })}
+
+      {/* Marcadores de Personas */}
+      {showPeople &&
+        visiblePeople.map(person => (
+          <Marker
+            key={`person-${person.id}`}
+            position={[person.latitude, person.longitude]}
+            icon={createPersonIcon(15)}
+            eventHandlers={{
+              click: () => {
+                setSelectedGroup(null);
+                setSelectedPerson(person);
+              },
+            }}
+          />
+        ))}
+
+      {/* Popup de Grupo */}
+      {selectedGroup && selectedGroup.latitude && selectedGroup.longitude && (
+        <Popup
+          position={[Number(selectedGroup.latitude), Number(selectedGroup.longitude)]}
+          closeOnClick={false}
+          autoClose={false}
+          maxWidth={300}
+        >
+          <div className="p-3 min-w-[220px] bg-background rounded-xl shadow-2xl border border-border overflow-hidden">
+            <div className="flex items-center gap-2 mb-3 pb-2 border-b border-border/50">
+              <div className="p-1.5 bg-blue-500/10 rounded-lg">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
+                    fill="#3b82f6"
+                    fillOpacity="0.85"
+                    stroke="#3b82f6"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M9 21V13H15V21"
+                    fill="white"
+                    fillOpacity="0.9"
+                    stroke="#3b82f6"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <p className="font-bold text-sm tracking-tight truncate">
+                {selectedGroup.group_name}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <UserIcon className="w-3.5 h-3.5 text-muted-foreground" />
+                <p className="text-xs text-muted-foreground">
+                  <span className="font-semibold text-foreground">Líder:</span>{' '}
+                  {selectedGroup.leader_name || 'Sin asignar'}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Users className="w-3.5 h-3.5 text-muted-foreground" />
+                <p className="text-xs text-muted-foreground">
+                  <span className="font-semibold text-foreground">Miembros:</span>{' '}
+                  {selectedGroup.active_members || 0}/{selectedGroup.member_count || 0}
+                </p>
+              </div>
+              {selectedGroup.meeting_location && (
+                <div className="flex items-center gap-2">
+                  <MapPin className="w-3.5 h-3.5 text-muted-foreground" />
+                  <p className="text-xs text-muted-foreground line-clamp-1">
+                    <span className="font-semibold text-foreground">Ubicación:</span>{' '}
+                    {selectedGroup.meeting_location}
+                  </p>
+                </div>
+              )}
+              {selectedGroup.meeting_day && (
+                <div className="flex items-center gap-2">
+                  <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
+                  <p className="text-xs text-muted-foreground">
+                    <span className="font-semibold text-foreground">Reunión:</span>{' '}
+                    {selectedGroup.meeting_day}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </Popup>
+      )}
+
+      {/* Popup de Persona */}
+      {selectedPerson && (
+        <Popup
+          position={[selectedPerson.latitude, selectedPerson.longitude]}
+          closeOnClick={false}
+          autoClose={false}
+          maxWidth={260}
+        >
+          <div className="p-3 min-w-[180px] bg-background rounded-xl shadow-2xl border border-border">
+            <div className="flex items-center gap-2 mb-2 pb-2 border-b border-border/50">
+              <div className="p-1.5 bg-indigo-500/10 rounded-lg">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                  <circle cx="12" cy="7" r="4" fill="#6366f1" stroke="#4f46e5" strokeWidth="1.5" />
+                  <path
+                    d="M5.5 21C5.5 17.41 8.41 14.5 12 14.5C15.59 14.5 18.5 17.41 18.5 21"
+                    fill="#6366f1"
+                    fillOpacity="0.6"
+                    stroke="#4f46e5"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </div>
+              <p className="font-bold text-sm tracking-tight truncate">
+                {selectedPerson.first_name} {selectedPerson.last_name}
+              </p>
+            </div>
+            <div className="space-y-1.5">
+              {selectedPerson.email && (
+                <p className="text-xs text-muted-foreground truncate">{selectedPerson.email}</p>
+              )}
+              {selectedPerson.zone_name && (
+                <div className="flex items-center gap-2 mt-1">
+                  <MapPin className="w-3 h-3 text-muted-foreground" />
+                  <p className="text-[10px] font-medium text-muted-foreground">
+                    {selectedPerson.zone_name}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </Popup>
+      )}
+    </>
+  );
+
+  // ── Lista de zonas (compartida: Card de escritorio / Drawer de mobile) ──
+  const zoneListBody = (
+    <div className="space-y-3">
+      {/* Botón "Todas las zonas" */}
+      <button
+        type="button"
+        onClick={() => handleSelectZone(null)}
+        className={cn(
+          'w-full rounded-2xl border p-4 text-left transition-all duration-300 relative overflow-hidden group/all',
+          !internalSelectedZoneId
+            ? 'bg-blue-600 text-white border-blue-500 shadow-lg'
+            : 'bg-card border-border hover:border-blue-300 hover:bg-blue-50/50 dark:hover:bg-blue-900/10'
+        )}
+      >
+        {!internalSelectedZoneId && (
+          <div className="absolute -right-4 -top-4 w-16 h-16 bg-white/10 rounded-full blur-2xl" />
+        )}
+        <div className="flex items-center justify-between relative z-10">
+          <div>
+            <p className="font-bold text-sm tracking-tight">Todas las zonas</p>
+            <p
+              className={cn(
+                'text-xs mt-0.5 font-medium',
+                !internalSelectedZoneId ? 'text-blue-100' : 'text-muted-foreground'
+              )}
+            >
+              {zoneData.reduce((acc, item) => acc + item.groups.length, 0)} grupos totales
+            </p>
+          </div>
+          <div
+            className={cn(
+              'p-2 rounded-xl transition-colors',
+              !internalSelectedZoneId ? 'bg-white/20' : 'bg-muted'
+            )}
+          >
+            <Search className="w-4 h-4" />
+          </div>
+        </div>
+      </button>
+
+      {loading && (
+        <div className="space-y-2 p-4">
+          <div className="h-4 w-3/4 bg-muted animate-pulse rounded" />
+          <div className="h-3 w-1/2 bg-muted animate-pulse rounded" />
+        </div>
+      )}
+
+      {/* Lista de zonas */}
+      {zoneData.map(item => {
+        const isSelected = item.zone.id === internalSelectedZoneId;
+        return (
+          <div
+            key={item.zone.id}
+            className={cn(
+              'rounded-2xl border transition-all duration-300 group/item overflow-hidden',
+              isSelected
+                ? 'bg-blue-500/5 border-blue-200 dark:border-blue-900 shadow-md ring-1 ring-blue-500/20'
+                : 'border-border/50 hover:border-blue-200 dark:hover:border-blue-800 hover:bg-muted/30 hover:shadow-sm'
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => handleSelectZone(item)}
+              className="w-full text-left p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-bold text-sm tracking-tight group-hover/item:text-blue-600 transition-colors">
+                    {item.zone.name}
+                  </p>
+                  <div className="flex items-center gap-3 mt-1.5">
+                    <div className="flex items-center gap-1">
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+                        <path
+                          d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
+                          fill={isSelected ? '#3b82f6' : '#94a3b8'}
+                          fillOpacity="0.85"
+                          stroke={isSelected ? '#3b82f6' : '#94a3b8'}
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                        <path
+                          d="M9 21V13H15V21"
+                          fill="white"
+                          fillOpacity="0.9"
+                          stroke={isSelected ? '#3b82f6' : '#94a3b8'}
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                      <span className="text-[10px] font-bold text-muted-foreground">
+                        {item.groups.length}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Users className="w-3 h-3 text-muted-foreground" />
+                      <span className="text-[10px] font-bold text-muted-foreground">
+                        {item.zone.total_members || 0}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="h-4 w-4 rounded-full border-2 border-white dark:border-gray-800 shadow-sm flex-shrink-0 mt-0.5"
+                  style={{ backgroundColor: item.zone.color }}
+                />
+              </div>
+            </button>
+
+            {/* Grupos expandidos cuando la zona está seleccionada */}
+            {isSelected && item.groups.length > 0 && (
+              <div className="px-3 pb-3 space-y-2">
+                <div className="border-t border-blue-200/50 dark:border-blue-800/50 pt-3 flex items-center gap-2 mb-1 px-1">
+                  <div className="h-1 w-1 rounded-full bg-blue-500" />
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-blue-600/70">
+                    Células en zona
+                  </span>
+                </div>
+                {item.groups.map(group => (
+                  <button
+                    type="button"
+                    key={group.id}
+                    className="w-full text-left rounded-xl border border-blue-200/30 dark:border-blue-800/30 p-2.5 hover:bg-blue-500/10 hover:border-blue-500/30 transition-all group/cell"
+                    onClick={() => {
+                      if (group.latitude && group.longitude) {
+                        setSelectedGroup(group);
+                        flyToGroup(Number(group.latitude), Number(group.longitude));
+                        if (isMobileApp) setMobileListOpen(false);
+                      }
+                    }}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="p-1.5 bg-background rounded-lg shadow-sm border border-border/50 group-hover/cell:border-blue-500/30 transition-colors">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                          <path
+                            d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
+                            fill={item.zone.color}
+                            fillOpacity="0.85"
+                            stroke={item.zone.color}
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <path
+                            d="M9 21V13H15V21"
+                            fill="white"
+                            fillOpacity="0.9"
+                            stroke={item.zone.color}
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-bold truncate group-hover/cell:text-blue-600 transition-colors">
+                          {group.group_name}
+                        </p>
+                        <p className="text-[10px] text-muted-foreground truncate font-medium">
+                          {group.leader_name || 'Sin líder'}
+                        </p>
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  // ── Layout mobile: mapa a pantalla completa + toggles flotantes + hoja inferior ──
+  if (isMobileApp) {
+    const totalGroups = zoneData.reduce((acc, item) => acc + item.groups.length, 0);
+    return (
+      <div className="relative w-full h-[calc(100dvh-172px)] rounded-2xl overflow-hidden border border-border">
+        <MapContainer
+          center={DEFAULT_CENTER}
+          zoom={DEFAULT_ZOOM}
+          className="w-full h-full"
+          zoomControl={false}
+          ref={map => {
+            mapRef.current = map;
+          }}
+        >
+          {mapLayers}
+        </MapContainer>
+
+        {/* Toggles flotantes, interactivos (reemplazan la leyenda estática) */}
+        <div className="absolute top-3 left-3 right-3 z-[1000] flex gap-2">
+          <button
+            type="button"
+            onClick={() => setShowGroups(v => !v)}
+            className={cn(
+              'flex-1 flex items-center justify-center gap-1.5 rounded-full px-3 py-2 text-xs font-semibold shadow-lg backdrop-blur-md border transition-colors',
+              showGroups
+                ? 'bg-blue-600 text-white border-blue-500'
+                : 'bg-background/90 text-muted-foreground border-border/50'
+            )}
+          >
+            <MapPin className="w-3.5 h-3.5" />
+            Grupos
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowPeople(v => !v)}
+            className={cn(
+              'flex-1 flex items-center justify-center gap-1.5 rounded-full px-3 py-2 text-xs font-semibold shadow-lg backdrop-blur-md border transition-colors',
+              showPeople
+                ? 'bg-indigo-600 text-white border-indigo-500'
+                : 'bg-background/90 text-muted-foreground border-border/50'
+            )}
+          >
+            <Users className="w-3.5 h-3.5" />
+            Personas
+          </button>
+        </div>
+
+        {/* Botón flotante: abre la hoja inferior con la lista/filtro de zonas */}
+        <button
+          type="button"
+          onClick={() => setMobileListOpen(true)}
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[1000] flex items-center gap-2 rounded-full bg-background/95 backdrop-blur-md border border-border shadow-xl px-4 py-2.5 text-xs font-bold"
+        >
+          <Layers className="w-4 h-4 text-blue-500" />
+          {selectedZone ? selectedZone.zone.name : `Zonas · ${totalGroups} grupos`}
+        </button>
+
+        <Drawer open={mobileListOpen} onOpenChange={setMobileListOpen}>
+          <DrawerContent className="max-h-[75vh]">
+            <DrawerHeader>
+              <DrawerTitle>Zonas</DrawerTitle>
+              <DrawerDescription>Filtrá el mapa por zona o entrá a un grupo</DrawerDescription>
+            </DrawerHeader>
+            <div className="overflow-y-auto px-4 pb-4">{zoneListBody}</div>
+          </DrawerContent>
+        </Drawer>
+      </div>
+    );
+  }
+
+  // ── Layout de escritorio ──
   return (
     <div className="grid gap-6 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_380px]">
       {/* ── Mapa ── */}
@@ -483,16 +950,7 @@ export default function DiscipleshipMap({
                 mapRef.current = map;
               }}
             >
-              <ZoomControl position="topright" />
-              <TileLayer
-                key={isDark ? 'dark' : 'light'}
-                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>'
-                url={
-                  isDark
-                    ? 'https://{s}.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}{r}.png'
-                    : 'https://{s}.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}{r}.png'
-                }
-              />
+              {mapLayers}
 
               {/* Floating Toolbar Top Left */}
               <div
@@ -555,210 +1013,6 @@ export default function DiscipleshipMap({
                   </div>
                 </div>
               </div>
-
-              {/* Zona polygons (fill + border) */}
-              {allZonePolygons.map((poly, idx) => (
-                <Polygon
-                  key={`zone-poly-${idx}`}
-                  positions={poly.positions}
-                  pathOptions={{
-                    color: poly.color,
-                    fillColor: poly.color,
-                    fillOpacity: poly.isSelected ? 0.3 : 0.14,
-                    weight: poly.isSelected ? 3 : 1.5,
-                    dashArray: poly.isSelected ? undefined : '5 5',
-                    lineCap: 'round',
-                  }}
-                />
-              ))}
-
-              {/* Etiquetas de nombre de zona, centradas en su área */}
-              {zoneLabels.map(label => (
-                <Marker
-                  key={`zone-label-${label.zoneId}`}
-                  position={label.center}
-                  icon={createZoneLabelIcon(label.name, label.color, label.isSelected)}
-                  interactive={false}
-                  zIndexOffset={-1000}
-                />
-              ))}
-
-              {/* FitToBounds helper */}
-              {fitToBounds && <FitToBounds bounds={fitToBounds.bounds} trigger={fitToBounds.key} />}
-              {flyTo && <FlyTo position={flyTo.position} zoom={flyTo.zoom} trigger={flyTo.key} />}
-              <PopupCloseHandler
-                onClose={() => {
-                  setSelectedGroup(null);
-                  setSelectedPerson(null);
-                }}
-              />
-
-              {/* Marcadores de Grupos (casitas) */}
-              {showGroups &&
-                visibleGroups.map(group => {
-                  const lat = Number(group.latitude);
-                  const lng = Number(group.longitude);
-                  if (isNaN(lat) || isNaN(lng) || !isFinite(lat) || !isFinite(lng)) return null;
-                  const zoneColor = getGroupZoneColor(group);
-                  const isSelected = selectedGroup?.id === group.id;
-                  return (
-                    <Marker
-                      key={`group-${group.id}`}
-                      position={[lat, lng]}
-                      icon={createHouseIcon(zoneColor, isSelected ? 30 : 22, isSelected)}
-                      zIndexOffset={isSelected ? 1000 : 0}
-                      eventHandlers={{
-                        click: () => {
-                          setSelectedPerson(null);
-                          setSelectedGroup(group);
-                        },
-                      }}
-                    />
-                  );
-                })}
-
-              {/* Marcadores de Personas */}
-              {showPeople &&
-                visiblePeople.map(person => (
-                  <Marker
-                    key={`person-${person.id}`}
-                    position={[person.latitude, person.longitude]}
-                    icon={createPersonIcon(15)}
-                    eventHandlers={{
-                      click: () => {
-                        setSelectedGroup(null);
-                        setSelectedPerson(person);
-                      },
-                    }}
-                  />
-                ))}
-
-              {/* Popup de Grupo */}
-              {selectedGroup && selectedGroup.latitude && selectedGroup.longitude && (
-                <Popup
-                  position={[Number(selectedGroup.latitude), Number(selectedGroup.longitude)]}
-                  closeOnClick={false}
-                  autoClose={false}
-                  maxWidth={300}
-                >
-                  <div className="p-3 min-w-[220px] bg-background rounded-xl shadow-2xl border border-border overflow-hidden">
-                    <div className="flex items-center gap-2 mb-3 pb-2 border-b border-border/50">
-                      <div className="p-1.5 bg-blue-500/10 rounded-lg">
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                          <path
-                            d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
-                            fill="#3b82f6"
-                            fillOpacity="0.85"
-                            stroke="#3b82f6"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                          <path
-                            d="M9 21V13H15V21"
-                            fill="white"
-                            fillOpacity="0.9"
-                            stroke="#3b82f6"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                        </svg>
-                      </div>
-                      <p className="font-bold text-sm tracking-tight truncate">
-                        {selectedGroup.group_name}
-                      </p>
-                    </div>
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-2">
-                        <UserIcon className="w-3.5 h-3.5 text-muted-foreground" />
-                        <p className="text-xs text-muted-foreground">
-                          <span className="font-semibold text-foreground">Líder:</span>{' '}
-                          {selectedGroup.leader_name || 'Sin asignar'}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Users className="w-3.5 h-3.5 text-muted-foreground" />
-                        <p className="text-xs text-muted-foreground">
-                          <span className="font-semibold text-foreground">Miembros:</span>{' '}
-                          {selectedGroup.active_members || 0}/{selectedGroup.member_count || 0}
-                        </p>
-                      </div>
-                      {selectedGroup.meeting_location && (
-                        <div className="flex items-center gap-2">
-                          <MapPin className="w-3.5 h-3.5 text-muted-foreground" />
-                          <p className="text-xs text-muted-foreground line-clamp-1">
-                            <span className="font-semibold text-foreground">Ubicación:</span>{' '}
-                            {selectedGroup.meeting_location}
-                          </p>
-                        </div>
-                      )}
-                      {selectedGroup.meeting_day && (
-                        <div className="flex items-center gap-2">
-                          <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
-                          <p className="text-xs text-muted-foreground">
-                            <span className="font-semibold text-foreground">Reunión:</span>{' '}
-                            {selectedGroup.meeting_day}
-                          </p>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </Popup>
-              )}
-
-              {/* Popup de Persona */}
-              {selectedPerson && (
-                <Popup
-                  position={[selectedPerson.latitude, selectedPerson.longitude]}
-                  closeOnClick={false}
-                  autoClose={false}
-                  maxWidth={260}
-                >
-                  <div className="p-3 min-w-[180px] bg-background rounded-xl shadow-2xl border border-border">
-                    <div className="flex items-center gap-2 mb-2 pb-2 border-b border-border/50">
-                      <div className="p-1.5 bg-indigo-500/10 rounded-lg">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                          <circle
-                            cx="12"
-                            cy="7"
-                            r="4"
-                            fill="#6366f1"
-                            stroke="#4f46e5"
-                            strokeWidth="1.5"
-                          />
-                          <path
-                            d="M5.5 21C5.5 17.41 8.41 14.5 12 14.5C15.59 14.5 18.5 17.41 18.5 21"
-                            fill="#6366f1"
-                            fillOpacity="0.6"
-                            stroke="#4f46e5"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                          />
-                        </svg>
-                      </div>
-                      <p className="font-bold text-sm tracking-tight truncate">
-                        {selectedPerson.first_name} {selectedPerson.last_name}
-                      </p>
-                    </div>
-                    <div className="space-y-1.5">
-                      {selectedPerson.email && (
-                        <p className="text-xs text-muted-foreground truncate">
-                          {selectedPerson.email}
-                        </p>
-                      )}
-                      {selectedPerson.zone_name && (
-                        <div className="flex items-center gap-2 mt-1">
-                          <MapPin className="w-3 h-3 text-muted-foreground" />
-                          <p className="text-[10px] font-medium text-muted-foreground">
-                            {selectedPerson.zone_name}
-                          </p>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </Popup>
-              )}
             </MapContainer>
           </div>
         </CardContent>
@@ -856,178 +1110,7 @@ export default function DiscipleshipMap({
         </CardHeader>
 
         <CardContent className="pt-0">
-          <ScrollArea className="h-[460px] pr-4">
-            <div className="space-y-3">
-              {/* Botón "Todas las zonas" */}
-              <button
-                type="button"
-                onClick={() => handleSelectZone(null)}
-                className={cn(
-                  'w-full rounded-2xl border p-4 text-left transition-all duration-300 relative overflow-hidden group/all',
-                  !internalSelectedZoneId
-                    ? 'bg-blue-600 text-white border-blue-500 shadow-lg'
-                    : 'bg-card border-border hover:border-blue-300 hover:bg-blue-50/50 dark:hover:bg-blue-900/10'
-                )}
-              >
-                {!internalSelectedZoneId && (
-                  <div className="absolute -right-4 -top-4 w-16 h-16 bg-white/10 rounded-full blur-2xl" />
-                )}
-                <div className="flex items-center justify-between relative z-10">
-                  <div>
-                    <p className="font-bold text-sm tracking-tight">Todas las zonas</p>
-                    <p
-                      className={cn(
-                        'text-xs mt-0.5 font-medium',
-                        !internalSelectedZoneId ? 'text-blue-100' : 'text-muted-foreground'
-                      )}
-                    >
-                      {zoneData.reduce((acc, item) => acc + item.groups.length, 0)} grupos totales
-                    </p>
-                  </div>
-                  <div
-                    className={cn(
-                      'p-2 rounded-xl transition-colors',
-                      !internalSelectedZoneId ? 'bg-white/20' : 'bg-muted'
-                    )}
-                  >
-                    <Search className="w-4 h-4" />
-                  </div>
-                </div>
-              </button>
-
-              {loading && (
-                <div className="space-y-2 p-4">
-                  <div className="h-4 w-3/4 bg-muted animate-pulse rounded" />
-                  <div className="h-3 w-1/2 bg-muted animate-pulse rounded" />
-                </div>
-              )}
-
-              {/* Lista de zonas */}
-              {zoneData.map(item => {
-                const isSelected = item.zone.id === internalSelectedZoneId;
-                return (
-                  <div
-                    key={item.zone.id}
-                    className={cn(
-                      'rounded-2xl border transition-all duration-300 group/item overflow-hidden',
-                      isSelected
-                        ? 'bg-blue-500/5 border-blue-200 dark:border-blue-900 shadow-md ring-1 ring-blue-500/20'
-                        : 'border-border/50 hover:border-blue-200 dark:hover:border-blue-800 hover:bg-muted/30 hover:shadow-sm'
-                    )}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => handleSelectZone(item)}
-                      className="w-full text-left p-4"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="font-bold text-sm tracking-tight group-hover/item:text-blue-600 transition-colors">
-                            {item.zone.name}
-                          </p>
-                          <div className="flex items-center gap-3 mt-1.5">
-                            <div className="flex items-center gap-1">
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                <path
-                                  d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
-                                  fill={isSelected ? '#3b82f6' : '#94a3b8'}
-                                  fillOpacity="0.85"
-                                  stroke={isSelected ? '#3b82f6' : '#94a3b8'}
-                                  strokeWidth="1.5"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                />
-                                <path
-                                  d="M9 21V13H15V21"
-                                  fill="white"
-                                  fillOpacity="0.9"
-                                  stroke={isSelected ? '#3b82f6' : '#94a3b8'}
-                                  strokeWidth="1.5"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                />
-                              </svg>
-                              <span className="text-[10px] font-bold text-muted-foreground">
-                                {item.groups.length}
-                              </span>
-                            </div>
-                            <div className="flex items-center gap-1">
-                              <Users className="w-3 h-3 text-muted-foreground" />
-                              <span className="text-[10px] font-bold text-muted-foreground">
-                                {item.zone.total_members || 0}
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          className="h-4 w-4 rounded-full border-2 border-white dark:border-gray-800 shadow-sm flex-shrink-0 mt-0.5"
-                          style={{ backgroundColor: item.zone.color }}
-                        />
-                      </div>
-                    </button>
-
-                    {/* Grupos expandidos cuando la zona está seleccionada */}
-                    {isSelected && item.groups.length > 0 && (
-                      <div className="px-3 pb-3 space-y-2">
-                        <div className="border-t border-blue-200/50 dark:border-blue-800/50 pt-3 flex items-center gap-2 mb-1 px-1">
-                          <div className="h-1 w-1 rounded-full bg-blue-500" />
-                          <span className="text-[10px] font-bold uppercase tracking-widest text-blue-600/70">
-                            Células en zona
-                          </span>
-                        </div>
-                        {item.groups.map(group => (
-                          <button
-                            type="button"
-                            key={group.id}
-                            className="w-full text-left rounded-xl border border-blue-200/30 dark:border-blue-800/30 p-2.5 hover:bg-blue-500/10 hover:border-blue-500/30 transition-all group/cell"
-                            onClick={() => {
-                              if (group.latitude && group.longitude) {
-                                setSelectedGroup(group);
-                                flyToGroup(Number(group.latitude), Number(group.longitude));
-                              }
-                            }}
-                          >
-                            <div className="flex items-center gap-3">
-                              <div className="p-1.5 bg-background rounded-lg shadow-sm border border-border/50 group-hover/cell:border-blue-500/30 transition-colors">
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                                  <path
-                                    d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
-                                    fill={item.zone.color}
-                                    fillOpacity="0.85"
-                                    stroke={item.zone.color}
-                                    strokeWidth="1.5"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                  />
-                                  <path
-                                    d="M9 21V13H15V21"
-                                    fill="white"
-                                    fillOpacity="0.9"
-                                    stroke={item.zone.color}
-                                    strokeWidth="1.5"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                  />
-                                </svg>
-                              </div>
-                              <div className="min-w-0">
-                                <p className="text-xs font-bold truncate group-hover/cell:text-blue-600 transition-colors">
-                                  {group.group_name}
-                                </p>
-                                <p className="text-[10px] text-muted-foreground truncate font-medium">
-                                  {group.leader_name || 'Sin líder'}
-                                </p>
-                              </div>
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </ScrollArea>
+          <ScrollArea className="h-[460px] pr-4">{zoneListBody}</ScrollArea>
         </CardContent>
       </Card>
     </div>

--- a/src/components/discipleship/GroupMembers.tsx
+++ b/src/components/discipleship/GroupMembers.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import {
   Dialog,
   DialogContent,
@@ -15,6 +15,14 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
 import {
   Select,
   SelectContent,
@@ -29,7 +37,8 @@ import type {
   RecordAttendanceRequest,
   AddGroupMemberRequest,
 } from '@/types/discipleship.types';
-import { normalizeNullString } from '@/lib/utils';
+import { normalizeNullString, getAvatarColor } from '@/lib/utils';
+import { useMobileMode } from '@/hooks/useMobileMode';
 import {
   Users,
   UserPlus,
@@ -60,6 +69,7 @@ interface User {
 }
 
 export function GroupMembers({ groupId, groupName }: GroupMembersProps) {
+  const isMobileApp = useMobileMode();
   const [members, setMembers] = useState<GroupMemberWithDetails[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -68,7 +78,7 @@ export function GroupMembers({ groupId, groupName }: GroupMembersProps) {
   const [isAttendanceDialogOpen, setIsAttendanceDialogOpen] = useState(false);
   const [users, setUsers] = useState<User[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(false);
-  const [selectedUserId, setSelectedUserId] = useState<string>('');
+  const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(new Set());
   const [selectedRole, setSelectedRole] = useState<string>('member');
   const [attendanceDate, setAttendanceDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [attendanceList, setAttendanceList] = useState<Map<string, boolean>>(new Map());
@@ -138,22 +148,42 @@ export function GroupMembers({ groupId, groupName }: GroupMembersProps) {
         u.email.toLowerCase().includes(searchTerm.toLowerCase()))
   );
 
+  const toggleSelectedUser = (userId: string) => {
+    setSelectedUserIds(prev => {
+      const next = new Set(prev);
+      if (next.has(userId)) {
+        next.delete(userId);
+      } else {
+        next.add(userId);
+      }
+      return next;
+    });
+  };
+
   const handleAddMember = async () => {
-    if (!selectedUserId) {
-      toast.error('Selecciona un usuario');
+    if (selectedUserIds.size === 0) {
+      toast.error('Selecciona al menos un usuario');
       return;
     }
 
     try {
       setSaving(true);
-      const data: AddGroupMemberRequest = {
-        user_id: selectedUserId,
-        role_in_group: selectedRole,
-      };
-      await DiscipleshipService.addGroupMember(groupId, data);
-      toast.success('Miembro agregado');
+      const results = await Promise.allSettled(
+        Array.from(selectedUserIds).map(userId => {
+          const data: AddGroupMemberRequest = { user_id: userId, role_in_group: selectedRole };
+          return DiscipleshipService.addGroupMember(groupId, data);
+        })
+      );
+      const failed = results.filter(r => r.status === 'rejected').length;
+      if (failed > 0) {
+        toast.error(`${failed} de ${results.length} no se pudieron agregar`);
+      } else {
+        toast.success(
+          results.length === 1 ? 'Miembro agregado' : `${results.length} miembros agregados`
+        );
+      }
       setIsAddDialogOpen(false);
-      setSelectedUserId('');
+      setSelectedUserIds(new Set());
       setSelectedRole('member');
       await loadMembers();
     } catch (error) {
@@ -232,6 +262,321 @@ export function GroupMembers({ groupId, groupName }: GroupMembersProps) {
     return <Badge variant={c.variant}>{c.label}</Badge>;
   };
 
+  const openAttendanceDialog = () => {
+    setAttendanceList(new Map());
+    members
+      .filter(m => m.is_active)
+      .forEach(m => {
+        attendanceList.set(m.user_id, true);
+      });
+    setIsAttendanceDialogOpen(true);
+  };
+
+  const openAddDialog = () => {
+    loadUsers();
+    setSelectedUserIds(new Set());
+    setSearchTerm('');
+    setIsAddDialogOpen(true);
+  };
+
+  const emptyState = (
+    <div className="text-center py-10 text-muted-foreground">
+      <Users className="w-10 h-10 mx-auto mb-3 opacity-40" />
+      <p className="text-sm px-6">Los miembros de este grupo todavía no están registrados</p>
+      <Button variant="outline" className="mt-4" onClick={openAddDialog}>
+        <UserPlus className="w-4 h-4 mr-2" />
+        Agregar primer miembro
+      </Button>
+    </div>
+  );
+
+  const addMemberBody = (
+    <div className="space-y-4">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <Input
+          placeholder="Buscar usuario..."
+          value={searchTerm}
+          onChange={e => setSearchTerm(e.target.value)}
+          className="pl-10"
+        />
+      </div>
+      <div className="max-h-64 overflow-y-auto space-y-2">
+        {loadingUsers ? (
+          <div className="text-center py-4">
+            <Loader2 className="w-6 h-6 animate-spin mx-auto" />
+          </div>
+        ) : filteredUsers.length === 0 ? (
+          <div className="text-center py-4 text-muted-foreground">No hay usuarios disponibles</div>
+        ) : (
+          filteredUsers.map(user => (
+            <div
+              key={user.id}
+              className={`flex items-center justify-between p-2 border rounded-lg cursor-pointer hover:bg-muted ${
+                selectedUserIds.has(user.id) ? 'bg-primary/10 border-primary' : ''
+              }`}
+              onClick={() => toggleSelectedUser(user.id)}
+            >
+              <div className="flex items-center gap-2">
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback className={getAvatarColor(user.full_name)}>
+                    {getInitials(user.full_name)}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <div className="text-sm font-medium">{user.full_name}</div>
+                  <div className="text-xs text-muted-foreground">{user.email}</div>
+                </div>
+              </div>
+              <Checkbox checked={selectedUserIds.has(user.id)} className="pointer-events-none" />
+            </div>
+          ))
+        )}
+      </div>
+      <div className="space-y-2">
+        <Label>Rol en el grupo</Label>
+        <Select value={selectedRole} onValueChange={setSelectedRole}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="member">Miembro</SelectItem>
+            <SelectItem value="helper">Ayudante</SelectItem>
+            <SelectItem value="visitor">Visitante</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+
+  const addMemberActions = (
+    <>
+      <Button variant="outline" onClick={() => setIsAddDialogOpen(false)}>
+        Cancelar
+      </Button>
+      <Button onClick={handleAddMember} disabled={selectedUserIds.size === 0 || saving}>
+        {saving ? (
+          <Loader2 className="w-4 h-4 animate-spin mr-2" />
+        ) : (
+          <Plus className="w-4 h-4 mr-2" />
+        )}
+        {selectedUserIds.size > 1 ? `Agregar (${selectedUserIds.size})` : 'Agregar'}
+      </Button>
+    </>
+  );
+
+  const attendanceBody = (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>Fecha de reunión</Label>
+        <Input
+          type="date"
+          value={attendanceDate}
+          onChange={e => setAttendanceDate(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        <div className="flex justify-between items-center">
+          <Label>Miembros ({members.filter(m => m.is_active).length})</Label>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              const allPresent = members
+                .filter(m => m.is_active)
+                .every(m => attendanceList.get(m.user_id) === true);
+              const newList = new Map(attendanceList);
+              members
+                .filter(m => m.is_active)
+                .forEach(m => {
+                  newList.set(m.user_id, !allPresent);
+                });
+              setAttendanceList(newList);
+            }}
+          >
+            {members.filter(m => m.is_active).every(m => attendanceList.get(m.user_id))
+              ? 'Desmarcar todos'
+              : 'Marcar todos'}
+          </Button>
+        </div>
+        <div className="max-h-64 overflow-y-auto space-y-2">
+          {members
+            .filter(m => m.is_active)
+            .map(member => (
+              <div
+                key={member.id}
+                className="flex items-center justify-between p-2 border rounded-lg"
+              >
+                <div className="flex items-center gap-2">
+                  <Avatar className="h-8 w-8">
+                    <AvatarFallback className={getAvatarColor(member.user_name)}>
+                      {getInitials(member.user_name)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-sm">{member.user_name}</span>
+                </div>
+                <Checkbox
+                  checked={attendanceList.get(member.user_id) ?? true}
+                  onCheckedChange={checked => {
+                    const newList = new Map(attendanceList);
+                    newList.set(member.user_id, checked === true);
+                    setAttendanceList(newList);
+                  }}
+                />
+              </div>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+
+  const attendanceActions = (
+    <>
+      <Button variant="outline" onClick={() => setIsAttendanceDialogOpen(false)}>
+        Cancelar
+      </Button>
+      <Button onClick={handleSaveAttendance} disabled={saving}>
+        {saving ? (
+          <Loader2 className="w-4 h-4 animate-spin mr-2" />
+        ) : (
+          <Check className="w-4 h-4 mr-2" />
+        )}
+        Guardar
+      </Button>
+    </>
+  );
+
+  const dialogs = (
+    <>
+      <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Agregar Miembro</DialogTitle>
+            <DialogDescription>
+              Busca y selecciona un usuario para agregar al grupo
+            </DialogDescription>
+          </DialogHeader>
+          {addMemberBody}
+          <div className="flex justify-end gap-2">{addMemberActions}</div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isAttendanceDialogOpen} onOpenChange={setIsAttendanceDialogOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>Registrar Asistencia</DialogTitle>
+            <DialogDescription>Registra la asistencia de los miembros del grupo</DialogDescription>
+          </DialogHeader>
+          {attendanceBody}
+          <div className="flex justify-end gap-2">{attendanceActions}</div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+
+  const mobileDialogs = (
+    <>
+      <Drawer open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Agregar Miembro</DrawerTitle>
+            <DrawerDescription>
+              Busca y selecciona un usuario para agregar al grupo
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="px-4">{addMemberBody}</div>
+          <DrawerFooter className="flex-row justify-end gap-2">{addMemberActions}</DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      <Drawer open={isAttendanceDialogOpen} onOpenChange={setIsAttendanceDialogOpen}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Registrar Asistencia</DrawerTitle>
+            <DrawerDescription>Registra la asistencia de los miembros del grupo</DrawerDescription>
+          </DrawerHeader>
+          <div className="px-4">{attendanceBody}</div>
+          <DrawerFooter className="flex-row justify-end gap-2">{attendanceActions}</DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+
+  const memberRow = (member: GroupMemberWithDetails, compact: boolean) => (
+    <div
+      key={member.id}
+      className={
+        compact
+          ? `flex items-center gap-3 px-4 py-3 ${!member.is_active ? 'opacity-50' : ''}`
+          : `flex items-center justify-between p-3 border rounded-lg ${
+              !member.is_active ? 'opacity-50' : ''
+            }`
+      }
+    >
+      <Avatar className={compact ? 'h-9 w-9 shrink-0' : undefined}>
+        <AvatarFallback className={getAvatarColor(member.user_name)}>
+          {getInitials(member.user_name)}
+        </AvatarFallback>
+      </Avatar>
+      <div className={compact ? 'min-w-0 flex-1' : undefined}>
+        <div className={compact ? 'font-medium text-sm truncate' : 'font-medium'}>
+          {member.user_name}
+        </div>
+        <div className="text-xs text-muted-foreground truncate">{member.user_email}</div>
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {getRoleBadge(member.role_in_group)}
+        {member.is_active && member.role_in_group !== 'leader' && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-destructive"
+            onClick={() => handleRemoveMember(member.id)}
+          >
+            <X className="w-4 h-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+
+  if (isMobileApp) {
+    if (loading) {
+      return (
+        <div className="px-4 pt-3 space-y-2">
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-14 w-full rounded-2xl" />
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <div className="px-4 pt-3 pb-2 flex gap-2">
+          <Button variant="outline" size="sm" className="flex-1" onClick={openAttendanceDialog}>
+            <Calendar className="w-4 h-4 mr-1.5" />
+            Asistencia
+          </Button>
+          <Button size="sm" className="flex-1" onClick={openAddDialog}>
+            <UserPlus className="w-4 h-4 mr-1.5" />
+            Agregar
+          </Button>
+        </div>
+
+        {members.length === 0 ? (
+          emptyState
+        ) : (
+          <div className="mx-4 rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+            {members.map(member => memberRow(member, true))}
+          </div>
+        )}
+
+        {mobileDialogs}
+      </>
+    );
+  }
+
   if (loading) {
     return (
       <Card>
@@ -251,270 +596,36 @@ export function GroupMembers({ groupId, groupName }: GroupMembersProps) {
   }
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0">
-        <div>
-          <CardTitle className="flex items-center gap-2">
-            <Users className="w-5 h-5" />
-            Miembros del Grupo
-          </CardTitle>
-          <CardDescription>{groupName}</CardDescription>
-        </div>
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setAttendanceList(new Map());
-              members
-                .filter(m => m.is_active)
-                .forEach(m => {
-                  attendanceList.set(m.user_id, true);
-                });
-              setIsAttendanceDialogOpen(true);
-            }}
-          >
-            <Calendar className="w-4 h-4 mr-1" />
-            Asistencia
-          </Button>
-          <Button
-            size="sm"
-            onClick={() => {
-              loadUsers();
-              setIsAddDialogOpen(true);
-            }}
-          >
-            <UserPlus className="w-4 h-4 mr-1" />
-            Agregar
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent>
-        {members.length === 0 ? (
-          <div className="text-center py-8 text-muted-foreground">
-            <Users className="w-12 h-12 mx-auto mb-4 opacity-50" />
-            <p>Los miembros de este grupo todavía no están registrados en el sistema</p>
-            <Button
-              variant="outline"
-              className="mt-4"
-              onClick={() => {
-                loadUsers();
-                setIsAddDialogOpen(true);
-              }}
-            >
-              <UserPlus className="w-4 h-4 mr-2" />
-              Agregar primer miembro
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="w-5 h-5" />
+              Miembros del Grupo
+            </CardTitle>
+            <CardDescription>{groupName}</CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={openAttendanceDialog}>
+              <Calendar className="w-4 h-4 mr-1" />
+              Asistencia
             </Button>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {members.map(member => (
-              <div
-                key={member.id}
-                className={`flex items-center justify-between p-3 border rounded-lg ${
-                  !member.is_active ? 'opacity-50' : ''
-                }`}
-              >
-                <div className="flex items-center gap-3">
-                  <Avatar>
-                    <AvatarImage
-                      src={`https://api.dicebear.com/7.x/initials/svg?seed=${member.user_name}`}
-                    />
-                    <AvatarFallback>{getInitials(member.user_name)}</AvatarFallback>
-                  </Avatar>
-                  <div>
-                    <div className="font-medium">{member.user_name}</div>
-                    <div className="text-xs text-muted-foreground">{member.user_email}</div>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  {getRoleBadge(member.role_in_group)}
-                  {member.is_active && member.role_in_group !== 'leader' && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 text-destructive"
-                      onClick={() => handleRemoveMember(member.id)}
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </CardContent>
-
-      {/* Dialog agregar miembro */}
-      <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
-            <DialogTitle>Agregar Miembro</DialogTitle>
-            <DialogDescription>
-              Busca y selecciona un usuario para agregar al grupo
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-              <Input
-                placeholder="Buscar usuario..."
-                value={searchTerm}
-                onChange={e => setSearchTerm(e.target.value)}
-                className="pl-10"
-              />
-            </div>
-            <div className="max-h-64 overflow-y-auto space-y-2">
-              {loadingUsers ? (
-                <div className="text-center py-4">
-                  <Loader2 className="w-6 h-6 animate-spin mx-auto" />
-                </div>
-              ) : filteredUsers.length === 0 ? (
-                <div className="text-center py-4 text-muted-foreground">
-                  No hay usuarios disponibles
-                </div>
-              ) : (
-                filteredUsers.map(user => (
-                  <div
-                    key={user.id}
-                    className={`flex items-center justify-between p-2 border rounded-lg cursor-pointer hover:bg-muted ${
-                      selectedUserId === user.id ? 'bg-primary/10 border-primary' : ''
-                    }`}
-                    onClick={() => setSelectedUserId(user.id)}
-                  >
-                    <div className="flex items-center gap-2">
-                      <Avatar className="h-8 w-8">
-                        <AvatarImage
-                          src={`https://api.dicebear.com/7.x/initials/svg?seed=${user.full_name}`}
-                        />
-                        <AvatarFallback>{getInitials(user.full_name)}</AvatarFallback>
-                      </Avatar>
-                      <div>
-                        <div className="text-sm font-medium">{user.full_name}</div>
-                        <div className="text-xs text-muted-foreground">{user.email}</div>
-                      </div>
-                    </div>
-                    {selectedUserId === user.id && <Check className="w-4 h-4 text-primary" />}
-                  </div>
-                ))
-              )}
-            </div>
-            <div className="space-y-2">
-              <Label>Rol en el grupo</Label>
-              <Select value={selectedRole} onValueChange={setSelectedRole}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="member">Miembro</SelectItem>
-                  <SelectItem value="helper">Ayudante</SelectItem>
-                  <SelectItem value="visitor">Visitante</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-          <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={() => setIsAddDialogOpen(false)}>
-              Cancelar
-            </Button>
-            <Button onClick={handleAddMember} disabled={!selectedUserId || saving}>
-              {saving ? (
-                <Loader2 className="w-4 h-4 animate-spin mr-2" />
-              ) : (
-                <Plus className="w-4 h-4 mr-2" />
-              )}
+            <Button size="sm" onClick={openAddDialog}>
+              <UserPlus className="w-4 h-4 mr-1" />
               Agregar
             </Button>
           </div>
-        </DialogContent>
-      </Dialog>
-
-      {/* Dialog registrar asistencia */}
-      <Dialog open={isAttendanceDialogOpen} onOpenChange={setIsAttendanceDialogOpen}>
-        <DialogContent className="sm:max-w-[500px]">
-          <DialogHeader>
-            <DialogTitle>Registrar Asistencia</DialogTitle>
-            <DialogDescription>Registra la asistencia de los miembros del grupo</DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label>Fecha de reunión</Label>
-              <Input
-                type="date"
-                value={attendanceDate}
-                onChange={e => setAttendanceDate(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <div className="flex justify-between items-center">
-                <Label>Miembros ({members.filter(m => m.is_active).length})</Label>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    const allPresent = members
-                      .filter(m => m.is_active)
-                      .every(m => attendanceList.get(m.user_id) === true);
-                    const newList = new Map(attendanceList);
-                    members
-                      .filter(m => m.is_active)
-                      .forEach(m => {
-                        newList.set(m.user_id, !allPresent);
-                      });
-                    setAttendanceList(newList);
-                  }}
-                >
-                  {members.filter(m => m.is_active).every(m => attendanceList.get(m.user_id))
-                    ? 'Desmarcar todos'
-                    : 'Marcar todos'}
-                </Button>
-              </div>
-              <div className="max-h-64 overflow-y-auto space-y-2">
-                {members
-                  .filter(m => m.is_active)
-                  .map(member => (
-                    <div
-                      key={member.id}
-                      className="flex items-center justify-between p-2 border rounded-lg"
-                    >
-                      <div className="flex items-center gap-2">
-                        <Avatar className="h-8 w-8">
-                          <AvatarImage
-                            src={`https://api.dicebear.com/7.x/initials/svg?seed=${member.user_name}`}
-                          />
-                          <AvatarFallback>{getInitials(member.user_name)}</AvatarFallback>
-                        </Avatar>
-                        <span className="text-sm">{member.user_name}</span>
-                      </div>
-                      <Checkbox
-                        checked={attendanceList.get(member.user_id) ?? true}
-                        onCheckedChange={checked => {
-                          const newList = new Map(attendanceList);
-                          newList.set(member.user_id, checked === true);
-                          setAttendanceList(newList);
-                        }}
-                      />
-                    </div>
-                  ))}
-              </div>
-            </div>
-          </div>
-          <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={() => setIsAttendanceDialogOpen(false)}>
-              Cancelar
-            </Button>
-            <Button onClick={handleSaveAttendance} disabled={saving}>
-              {saving ? (
-                <Loader2 className="w-4 h-4 animate-spin mr-2" />
-              ) : (
-                <Check className="w-4 h-4 mr-2" />
-              )}
-              Guardar
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-    </Card>
+        </CardHeader>
+        <CardContent>
+          {members.length === 0 ? (
+            emptyState
+          ) : (
+            <div className="space-y-2">{members.map(member => memberRow(member, false))}</div>
+          )}
+        </CardContent>
+      </Card>
+      {dialogs}
+    </>
   );
 }

--- a/src/components/discipleship/UserZoneAssignment.tsx
+++ b/src/components/discipleship/UserZoneAssignment.tsx
@@ -19,7 +19,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { DataTable, Column } from '@/components/ui/DataTable';
 import { MobileListItem } from '@/components/mobile/MobileListItem';
 import { useMobileMode } from '@/hooks/useMobileMode';
@@ -28,7 +28,7 @@ import { toast } from 'sonner';
 import { useZones } from '@/hooks/useZones';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import { ZonesService } from '@/services/zones.service';
-import { normalizeNullString } from '@/lib/utils';
+import { normalizeNullString, getAvatarColor } from '@/lib/utils';
 import { getDiscipleshipLevelConfig } from '@/lib/discipleship';
 
 interface AssignmentUser {
@@ -203,8 +203,7 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
       render: user => (
         <div className="flex items-center gap-3">
           <Avatar className="h-8 w-8">
-            <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${user.full_name}`} />
-            <AvatarFallback>
+            <AvatarFallback className={getAvatarColor(user.full_name)}>
               {user.full_name
                 .split(' ')
                 .map(n => n[0])
@@ -259,8 +258,7 @@ const UserZoneAssignment: React.FC<UserZoneAssignmentProps> = ({ onAssignment })
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-3">
           <Avatar>
-            <AvatarImage src={`https://api.dicebear.com/7.x/initials/svg?seed=${user.full_name}`} />
-            <AvatarFallback>
+            <AvatarFallback className={getAvatarColor(user.full_name)}>
               {user.full_name
                 .split(' ')
                 .map(n => n[0])

--- a/src/components/mobile/MobileScreen.tsx
+++ b/src/components/mobile/MobileScreen.tsx
@@ -62,6 +62,7 @@ export function MobileScreen({
           <div className="flex items-center gap-2 h-14 px-3">
             {isDetail && (
               <button
+                type="button"
                 onClick={handleBack}
                 aria-label="Volver"
                 className={cn(

--- a/src/components/mobile/MobileSectionHeader.tsx
+++ b/src/components/mobile/MobileSectionHeader.tsx
@@ -33,6 +33,7 @@ export function MobileSectionHeader({
       {action ??
         (to && (
           <button
+            type="button"
             onClick={() => navigate(to)}
             className="flex items-center gap-0.5 text-xs font-semibold text-primary cursor-pointer"
           >

--- a/src/components/mobile/MobileSegment.tsx
+++ b/src/components/mobile/MobileSegment.tsx
@@ -33,6 +33,7 @@ export function MobileSegment({
         {options.map(opt => (
           <button
             key={opt.value}
+            type="button"
             onClick={() => onChange(opt.value)}
             className={cn(
               'snap-start shrink-0 py-1.5 px-3.5 rounded-full text-xs font-medium transition-all cursor-pointer border',

--- a/src/components/mobile/screens/UsersScreen.tsx
+++ b/src/components/mobile/screens/UsersScreen.tsx
@@ -1,5 +1,6 @@
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Input } from '@/components/ui/input';
+import { getAvatarColor } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { User } from '@/types/user.types';
 import { Loader2, Plus, Search, Upload } from 'lucide-react';
@@ -124,7 +125,9 @@ export function MobileUsersScreen({
                 key={user.id}
                 leading={
                   <Avatar className="w-9 h-9">
-                    <AvatarFallback className="bg-primary/10 text-primary text-xs font-semibold">
+                    <AvatarFallback
+                      className={`${getAvatarColor(`${user.first_name ?? ''} ${user.last_name ?? ''}`)} text-xs font-semibold`}
+                    >
                       {(user.first_name?.[0] ?? '') + (user.last_name?.[0] ?? '')}
                     </AvatarFallback>
                   </Avatar>

--- a/src/components/zones/ZoneMapView.tsx
+++ b/src/components/zones/ZoneMapView.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Polygon, useMap } from 'react-leaflet';
 import L from 'leaflet';
-import { useTheme } from 'next-themes';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -150,8 +149,6 @@ function ZoneListItem({
 // ── Main component ──
 export default function ZoneMapView() {
   const { zones, loading, error } = useZones({ onlyActive: true });
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
   const isMobileApp = useMobileMode();
   const [selectedZoneId, setSelectedZoneId] = useState<string | null>(null);
   // On mobile the 288px sidebar would squash the map, so start it collapsed
@@ -256,13 +253,8 @@ export default function ZoneMapView() {
             zoomControl={true}
           >
             <TileLayer
-              key={isDark ? 'dark' : 'light'}
-              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>'
-              url={
-                isDark
-                  ? 'https://{s}.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}{r}.png'
-                  : 'https://{s}.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}{r}.png'
-              }
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
             <FitBounds zones={validZones} />
             {validZones.map(zone => (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,29 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+const AVATAR_COLORS = [
+  'bg-red-500/15 text-red-600',
+  'bg-orange-500/15 text-orange-600',
+  'bg-amber-500/15 text-amber-600',
+  'bg-emerald-500/15 text-emerald-600',
+  'bg-teal-500/15 text-teal-600',
+  'bg-cyan-500/15 text-cyan-600',
+  'bg-blue-500/15 text-blue-600',
+  'bg-indigo-500/15 text-indigo-600',
+  'bg-violet-500/15 text-violet-600',
+  'bg-pink-500/15 text-pink-600',
+];
+
+/** Color determinístico por seed (nombre/id) — mismo usuario, mismo color en toda la app. */
+export function getAvatarColor(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i);
+    hash |= 0;
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
 export const normalizeNullString = (value: unknown): string | null => {
   if (value === null || value === undefined) return null;
   if (typeof value === 'string') return value;

--- a/src/pages/dashboard/ModulesManagementPage.tsx
+++ b/src/pages/dashboard/ModulesManagementPage.tsx
@@ -11,6 +11,8 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
+import { MobileScreen } from '@/components/mobile/MobileScreen';
+import { useMobileMode } from '@/hooks/useMobileMode';
 import { useSystem } from '@/contexts/SystemContext';
 import { getModuleMeta } from '@/lib/modules-meta';
 import { ApiService } from '@/services/api.service';
@@ -27,6 +29,7 @@ interface Module {
 }
 
 export default function ModulesManagementPage() {
+  const isMobileApp = useMobileMode();
   const [modules, setModules] = useState<Module[]>([]);
   const [loading, setLoading] = useState(true);
   const [updating, setUpdating] = useState<string | null>(null);
@@ -63,8 +66,8 @@ export default function ModulesManagementPage() {
       toast.success(`Módulo ${newStatus ? 'habilitado' : 'deshabilitado'} exitosamente`);
       await fetchModules();
       await refreshModules();
-    } catch (error: any) {
-      toast.error(error.message || 'Error al actualizar módulo');
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : 'Error al actualizar módulo');
     } finally {
       setUpdating(null);
     }
@@ -80,10 +83,163 @@ export default function ModulesManagementPage() {
     );
   }
 
+  const moduleGrid = (
+    <>
+      {/* ── Module grid ── */}
+      <div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
+        {modules.map(module => {
+          const meta = getModuleMeta(module.key);
+          const Icon = meta.icon;
+          const isUpdating = updating === module.key;
+
+          return (
+            <Card
+              key={module.key}
+              className={`relative overflow-hidden transition-all duration-300 ${
+                module.is_installed ? 'border-border shadow-sm' : 'border-border/40 bg-muted/20'
+              }`}
+            >
+              {/* Color accent top bar */}
+              <div
+                className={`absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r ${meta.gradient}`}
+              />
+
+              <CardHeader className="px-4 sm:px-5 pt-5 pb-3">
+                <div className="flex items-start justify-between gap-3">
+                  {/* Icon + name block */}
+                  <div className="flex items-start gap-3 min-w-0">
+                    <div
+                      className={`w-11 h-11 rounded-xl ${meta.bg} flex items-center justify-center flex-shrink-0 border border-white/10`}
+                    >
+                      <Icon className={`w-5 h-5 ${meta.text}`} />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap mb-0.5">
+                        <h3 className="text-sm font-semibold leading-tight">{module.name}</h3>
+                        {module.is_installed ? (
+                          <span className="inline-flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20">
+                            <CheckCircle2 className="w-2.5 h-2.5" />
+                            Activo
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full bg-muted text-muted-foreground border border-border/50">
+                            <XCircle className="w-2.5 h-2.5" />
+                            Inactivo
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground leading-snug">
+                        {module.description}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Toggle */}
+                  <div className="flex items-center gap-2 flex-shrink-0 pt-0.5">
+                    {isUpdating && (
+                      <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />
+                    )}
+                    <Switch
+                      checked={module.is_installed}
+                      onCheckedChange={() => handleToggle(module)}
+                      disabled={isUpdating}
+                      aria-label={`${module.is_installed ? 'Deshabilitar' : 'Habilitar'} ${module.name}`}
+                    />
+                  </div>
+                </div>
+              </CardHeader>
+
+              <CardContent className="px-4 sm:px-5 pb-4 pt-0">
+                {/* Features */}
+                {meta.features.length > 0 && (
+                  <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 mb-3">
+                    {meta.features.map(feature => (
+                      <li
+                        key={feature}
+                        className="flex items-center gap-2 text-xs text-muted-foreground"
+                      >
+                        <div
+                          className={`w-1.5 h-1.5 rounded-full flex-shrink-0 bg-gradient-to-br ${meta.gradient}`}
+                        />
+                        {feature}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {/* Installed date */}
+                {module.is_installed && module.installed_at && (
+                  <p className="text-[11px] text-muted-foreground/60 border-t border-border/30 pt-2.5 mt-1">
+                    Habilitado el{' '}
+                    {new Date(module.installed_at).toLocaleDateString('es-ES', {
+                      day: 'numeric',
+                      month: 'long',
+                      year: 'numeric',
+                    })}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* ── Base module note ── */}
+      <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/40 border border-border/40">
+        <div className="w-8 h-8 rounded-lg bg-slate-500/10 flex items-center justify-center flex-shrink-0">
+          <Shield className="w-4 h-4 text-slate-500" />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          El módulo <strong className="text-foreground">Base</strong> — Usuarios, Roles y
+          Configuración — siempre está activo y no puede deshabilitarse.
+        </p>
+      </div>
+    </>
+  );
+
+  const confirmDialog = (
+    <AlertDialog open={!!confirmDisable} onOpenChange={open => !open && setConfirmDisable(null)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>¿Deshabilitar {confirmDisable?.name}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Al deshabilitarlo, sus rutas y funcionalidades dejarán de estar accesibles para todos
+            los usuarios. Podés volver a habilitarlo en cualquier momento sin perder datos.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => setConfirmDisable(null)}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={() => {
+              if (confirmDisable) doToggle(confirmDisable.key, false);
+              setConfirmDisable(null);
+            }}
+          >
+            Sí, deshabilitar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  if (isMobileApp) {
+    return (
+      <>
+        <MobileScreen
+          title="Gestión de Módulos"
+          subtitle={`${activeCount}/${modules.length} activos`}
+        >
+          <div className="px-4 pt-3 space-y-4">{moduleGrid}</div>
+        </MobileScreen>
+        {confirmDialog}
+      </>
+    );
+  }
+
   return (
     <>
       <div className="space-y-6 p-3 sm:p-4 md:p-6 max-w-5xl">
-
         {/* ── Header ── */}
         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           <div>
@@ -100,147 +256,24 @@ export default function ModulesManagementPage() {
 
           {/* Shortcut hint */}
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground bg-muted/50 border border-border/50 px-3 py-2 rounded-lg self-start whitespace-nowrap">
-            <kbd className="font-mono bg-background border border-border px-1.5 py-0.5 rounded text-[10px]">Ctrl</kbd>
+            <kbd className="font-mono bg-background border border-border px-1.5 py-0.5 rounded text-[10px]">
+              Ctrl
+            </kbd>
             <span>+</span>
-            <kbd className="font-mono bg-background border border-border px-1.5 py-0.5 rounded text-[10px]">⇧</kbd>
+            <kbd className="font-mono bg-background border border-border px-1.5 py-0.5 rounded text-[10px]">
+              ⇧
+            </kbd>
             <span>+</span>
-            <kbd className="font-mono bg-background border border-border px-1.5 py-0.5 rounded text-[10px]">S</kbd>
+            <kbd className="font-mono bg-background border border-border px-1.5 py-0.5 rounded text-[10px]">
+              S
+            </kbd>
             <span className="ml-1">Panel rápido</span>
           </div>
         </div>
 
-        {/* ── Module grid ── */}
-        <div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
-          {modules.map(module => {
-            const meta = getModuleMeta(module.key);
-            const Icon = meta.icon;
-            const isUpdating = updating === module.key;
-
-            return (
-              <Card
-                key={module.key}
-                className={`relative overflow-hidden transition-all duration-300 ${
-                  module.is_installed
-                    ? 'border-border shadow-sm'
-                    : 'border-border/40 bg-muted/20'
-                }`}
-              >
-                {/* Color accent top bar */}
-                <div className={`absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r ${meta.gradient}`} />
-
-                <CardHeader className="px-4 sm:px-5 pt-5 pb-3">
-                  <div className="flex items-start justify-between gap-3">
-                    {/* Icon + name block */}
-                    <div className="flex items-start gap-3 min-w-0">
-                      <div
-                        className={`w-11 h-11 rounded-xl ${meta.bg} flex items-center justify-center flex-shrink-0 border border-white/10`}
-                      >
-                        <Icon className={`w-5 h-5 ${meta.text}`} />
-                      </div>
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2 flex-wrap mb-0.5">
-                          <h3 className="text-sm font-semibold leading-tight">{module.name}</h3>
-                          {module.is_installed ? (
-                            <span className="inline-flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20">
-                              <CheckCircle2 className="w-2.5 h-2.5" />
-                              Activo
-                            </span>
-                          ) : (
-                            <span className="inline-flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full bg-muted text-muted-foreground border border-border/50">
-                              <XCircle className="w-2.5 h-2.5" />
-                              Inactivo
-                            </span>
-                          )}
-                        </div>
-                        <p className="text-xs text-muted-foreground leading-snug">
-                          {module.description}
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Toggle */}
-                    <div className="flex items-center gap-2 flex-shrink-0 pt-0.5">
-                      {isUpdating && (
-                        <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />
-                      )}
-                      <Switch
-                        checked={module.is_installed}
-                        onCheckedChange={() => handleToggle(module)}
-                        disabled={isUpdating}
-                        aria-label={`${module.is_installed ? 'Deshabilitar' : 'Habilitar'} ${module.name}`}
-                      />
-                    </div>
-                  </div>
-                </CardHeader>
-
-                <CardContent className="px-4 sm:px-5 pb-4 pt-0">
-                  {/* Features */}
-                  {meta.features.length > 0 && (
-                    <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 mb-3">
-                      {meta.features.map(feature => (
-                        <li key={feature} className="flex items-center gap-2 text-xs text-muted-foreground">
-                          <div
-                            className={`w-1.5 h-1.5 rounded-full flex-shrink-0 bg-gradient-to-br ${meta.gradient}`}
-                          />
-                          {feature}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-
-                  {/* Installed date */}
-                  {module.is_installed && module.installed_at && (
-                    <p className="text-[11px] text-muted-foreground/60 border-t border-border/30 pt-2.5 mt-1">
-                      Habilitado el{' '}
-                      {new Date(module.installed_at).toLocaleDateString('es-ES', {
-                        day: 'numeric',
-                        month: 'long',
-                        year: 'numeric',
-                      })}
-                    </p>
-                  )}
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
-
-        {/* ── Base module note ── */}
-        <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/40 border border-border/40">
-          <div className="w-8 h-8 rounded-lg bg-slate-500/10 flex items-center justify-center flex-shrink-0">
-            <Shield className="w-4 h-4 text-slate-500" />
-          </div>
-          <p className="text-xs text-muted-foreground">
-            El módulo <strong className="text-foreground">Base</strong> — Usuarios, Roles y
-            Configuración — siempre está activo y no puede deshabilitarse.
-          </p>
-        </div>
+        {moduleGrid}
       </div>
-
-      {/* ── Confirm disable dialog ── */}
-      <AlertDialog open={!!confirmDisable} onOpenChange={open => !open && setConfirmDisable(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>¿Deshabilitar {confirmDisable?.name}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Al deshabilitarlo, sus rutas y funcionalidades dejarán de estar accesibles para todos
-              los usuarios. Podés volver a habilitarlo en cualquier momento sin perder datos.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setConfirmDisable(null)}>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={() => {
-                if (confirmDisable) doToggle(confirmDisable.key, false);
-                setConfirmDisable(null);
-              }}
-            >
-              Sí, deshabilitar
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {confirmDialog}
     </>
   );
 }

--- a/src/pages/dashboard/MusicPage.tsx
+++ b/src/pages/dashboard/MusicPage.tsx
@@ -7,6 +7,7 @@ import {
   Calendar as CalendarIcon,
   CalendarDays,
   CalendarOff,
+  Guitar,
   Home,
   List,
   ListMusic,
@@ -1069,18 +1070,21 @@ function ServidorMobile() {
 // DIRECTOR mobile — app-like nav (sticky scrollable pills + dedicated screens)
 // ─────────────────────────────────────────────
 function DirectorMobile({ onOpenEvent }: { onOpenEvent: (e: MusicEvent) => void }) {
-  const [screen, setScreen] = useState<'inicio' | 'cronograma' | 'cultos' | 'equipo' | 'canciones'>(
-    'inicio'
-  );
+  const [screen, setScreen] = useState<
+    'inicio' | 'cronograma' | 'cultos' | 'integrantes' | 'instrumentos' | 'canciones'
+  >('inicio');
   const [createOpen, setCreateOpen] = useState(false);
 
   const tabs = [
     { key: 'inicio' as const, label: 'Inicio', Icon: Home },
     { key: 'cronograma' as const, label: 'Cronograma', Icon: CalendarDays },
     { key: 'cultos' as const, label: 'Cultos', Icon: CalendarIcon },
-    { key: 'equipo' as const, label: 'Equipo', Icon: Users },
+    { key: 'integrantes' as const, label: 'Integrantes', Icon: Users },
+    { key: 'instrumentos' as const, label: 'Instrumentos', Icon: Guitar },
     { key: 'canciones' as const, label: 'Canciones', Icon: ListMusic },
   ];
+
+  const showCreateFab = screen === 'inicio' || screen === 'cronograma' || screen === 'cultos';
 
   return (
     <div className="space-y-4">
@@ -1108,15 +1112,13 @@ function DirectorMobile({ onOpenEvent }: { onOpenEvent: (e: MusicEvent) => void 
       {screen === 'inicio' && <DirectorMusicHero onOpenEvent={onOpenEvent} />}
       {screen === 'cronograma' && <CronogramaTab isDirector onOpenEvent={onOpenEvent} />}
       {screen === 'cultos' && <CultosTab isDirector onOpenEvent={onOpenEvent} />}
-      {screen === 'equipo' && (
-        <div className="space-y-4">
-          <MusicMembers isDirector />
-          <MusicInstruments isDirector />
-        </div>
-      )}
+      {screen === 'integrantes' && <MusicMembers isDirector />}
+      {screen === 'instrumentos' && <MusicInstruments isDirector />}
       {screen === 'canciones' && <CancionesTab />}
 
-      <MusicFab icon={Plus} label="Nuevo culto" onClick={() => setCreateOpen(true)} />
+      {showCreateFab && (
+        <MusicFab icon={Plus} label="Nuevo culto" onClick={() => setCreateOpen(true)} />
+      )}
       <CreateEventDialog open={createOpen} onOpenChange={setCreateOpen} />
     </div>
   );

--- a/src/pages/dashboard/RoleManagementPage.tsx
+++ b/src/pages/dashboard/RoleManagementPage.tsx
@@ -18,8 +18,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { MobileScreen } from '@/components/mobile/MobileScreen';
+import { useMobileMode } from '@/hooks/useMobileMode';
 import {
   Select,
   SelectContent,
@@ -370,6 +380,7 @@ function initials(u: User) {
 // ── Main component ─────────────────────────────────────────────────────────────
 
 export default function RoleManagementPage() {
+  const isMobileApp = useMobileMode();
   const { currentUser } = useAuth();
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
@@ -460,325 +471,327 @@ export default function RoleManagementPage() {
     );
   }
 
-  return (
+  const bodyContent = (
     <>
-      <div className="space-y-6 p-3 sm:p-4 md:p-6 max-w-5xl">
-        {/* ── Header ── */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <div className="flex items-center gap-3 mb-1">
-              <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Gestión de Roles</h1>
-              <Badge variant="secondary" className="tabular-nums">
-                {users.length} usuarios
-              </Badge>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Administrá los roles del sistema y asignalos a los miembros.
-            </p>
-          </div>
-          <Button onClick={() => setAssignOpen(true)} className="w-full sm:w-auto">
-            <UserCog className="w-4 h-4 mr-2" />
-            Asignar Rol
-          </Button>
+      {/* ── Stats strip ── */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
+          <p className="text-2xl font-bold">{ROLE_DEFS.length}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">Roles del sistema</p>
         </div>
-
-        {/* ── Stats strip ── */}
-        <div className="grid grid-cols-3 gap-3">
-          <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
-            <p className="text-2xl font-bold">{ROLE_DEFS.length}</p>
-            <p className="text-xs text-muted-foreground mt-0.5">Roles del sistema</p>
-          </div>
-          <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
-            <p className="text-2xl font-bold">{users.length}</p>
-            <p className="text-xs text-muted-foreground mt-0.5">Usuarios activos</p>
-          </div>
-          <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
-            <p className="text-2xl font-bold text-primary">
-              {usersByRole['admin']?.length ?? 0 + (usersByRole['pastor']?.length ?? 0)}
-            </p>
-            <p className="text-xs text-muted-foreground mt-0.5">Con acceso admin</p>
-          </div>
+        <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
+          <p className="text-2xl font-bold">{users.length}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">Usuarios activos</p>
         </div>
-
-        {/* ── Role cards ── */}
-        <div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
-          {ROLE_DEFS.map(def => {
-            const Icon = def.icon;
-            const roleUsers = usersByRole[def.id] ?? [];
-            const isExpanded = expandedRole === def.id;
-            const level = ROLE_LEVELS[def.id];
-
-            return (
-              <div
-                key={def.id}
-                className="rounded-2xl border border-border/50 bg-card overflow-hidden shadow-sm"
-              >
-                {/* Color accent */}
-                <div className={`h-0.5 bg-gradient-to-r ${def.gradient}`} />
-
-                <div className="p-4 sm:p-5">
-                  {/* Role header */}
-                  <div className="flex items-start justify-between gap-3 mb-3">
-                    <div className="flex items-center gap-3">
-                      <div
-                        className={`w-10 h-10 rounded-xl ${def.bg} flex items-center justify-center flex-shrink-0`}
-                      >
-                        <Icon className={`w-5 h-5 ${def.text}`} />
-                      </div>
-                      <div>
-                        <div className="flex items-center gap-2 flex-wrap">
-                          <h3 className="font-semibold text-sm leading-tight">
-                            {ROLE_DISPLAY_NAMES[def.id]}
-                          </h3>
-                          <span
-                            className={`text-[10px] font-bold px-2 py-0.5 rounded-full border ${def.bg} ${def.text} ${def.border}`}
-                          >
-                            Nivel {level}
-                          </span>
-                        </div>
-                        <p className="text-xs text-muted-foreground mt-0.5 leading-snug">
-                          {def.description}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="text-right flex-shrink-0">
-                      <p className="text-xl font-bold leading-tight">{roleUsers.length}</p>
-                      <p className="text-xs text-muted-foreground">usuarios</p>
-                    </div>
-                  </div>
-
-                  {/* Permissions mini-matrix */}
-                  <div className="grid grid-cols-1 gap-1.5 mb-3">
-                    {def.permissions.map(cat => (
-                      <div key={cat.category} className="flex items-center gap-2">
-                        <span className="text-[10px] text-muted-foreground w-24 flex-shrink-0 uppercase tracking-wide font-medium">
-                          {cat.category}
-                        </span>
-                        <div className="flex items-center gap-1 flex-wrap">
-                          {cat.actions.map(action => (
-                            <span
-                              key={action.label}
-                              className={`inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded font-medium ${
-                                action.allowed
-                                  ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
-                                  : 'bg-muted text-muted-foreground/50 line-through'
-                              }`}
-                            >
-                              {action.allowed ? (
-                                <Check className="w-2.5 h-2.5" />
-                              ) : (
-                                <X className="w-2.5 h-2.5" />
-                              )}
-                              {action.label}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-
-                  {/* Toggle users button */}
-                  <button
-                    onClick={() => setExpandedRole(isExpanded ? null : def.id)}
-                    disabled={roleUsers.length === 0}
-                    className={`w-full flex items-center justify-between px-3 py-2 rounded-xl text-xs font-medium border transition-colors duration-200 ${
-                      roleUsers.length === 0
-                        ? 'border-border/30 text-muted-foreground/40 cursor-default'
-                        : 'border-border/50 hover:bg-muted/40 cursor-pointer'
-                    }`}
-                  >
-                    <span>
-                      {roleUsers.length === 0
-                        ? 'Sin usuarios asignados'
-                        : `Ver ${roleUsers.length} usuario${roleUsers.length !== 1 ? 's' : ''}`}
-                    </span>
-                    {roleUsers.length > 0 &&
-                      (isExpanded ? (
-                        <ChevronUp className="w-3.5 h-3.5" />
-                      ) : (
-                        <ChevronDown className="w-3.5 h-3.5" />
-                      ))}
-                  </button>
-                </div>
-
-                {/* Expanded users list */}
-                {isExpanded && roleUsers.length > 0 && (
-                  <div className="border-t border-border/30 bg-muted/20 px-4 sm:px-5 py-3 space-y-2 max-h-56 overflow-y-auto">
-                    {roleUsers.map(u => (
-                      <div key={u.id} className="flex items-center gap-3">
-                        <Avatar className="w-7 h-7 flex-shrink-0">
-                          <AvatarFallback className={`text-[10px] font-bold ${def.bg} ${def.text}`}>
-                            {initials(u)}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="flex-1 min-w-0">
-                          <p className="text-xs font-medium truncate">
-                            {u.first_name} {u.last_name}
-                          </p>
-                          <p className="text-[10px] text-muted-foreground truncate">{u.email}</p>
-                        </div>
-                        {/* Don't allow changing own role */}
-                        {u.id !== currentUser?.id && (
-                          <button
-                            onClick={() => {
-                              setAssignUserId(u.id);
-                              setAssignRole('');
-                              setAssignOpen(true);
-                            }}
-                            className="text-[10px] text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 cursor-pointer px-2 py-1 rounded-lg hover:bg-muted"
-                          >
-                            Cambiar
-                          </button>
-                        )}
-                        {u.id === currentUser?.id && (
-                          <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 px-2">
-                            Vos
-                          </span>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            );
-          })}
+        <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
+          <p className="text-2xl font-bold text-primary">
+            {usersByRole['admin']?.length ?? 0 + (usersByRole['pastor']?.length ?? 0)}
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">Con acceso admin</p>
         </div>
       </div>
 
-      {/* ── Assign Role Dialog ── */}
-      <Dialog
-        open={assignOpen}
-        onOpenChange={open => {
-          setAssignOpen(open);
-          if (!open) {
-            setAssignUserId('');
-            setAssignRole('');
-            setAssignSearch('');
-          }
-        }}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <UserCog className="w-5 h-5 text-primary" />
-              Asignar Rol
-            </DialogTitle>
-            <DialogDescription>
-              Cambiá el rol de un usuario. El cambio aplica de inmediato.
-            </DialogDescription>
-          </DialogHeader>
+      {/* ── Role cards ── */}
+      <div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
+        {ROLE_DEFS.map(def => {
+          const Icon = def.icon;
+          const roleUsers = usersByRole[def.id] ?? [];
+          const isExpanded = expandedRole === def.id;
+          const level = ROLE_LEVELS[def.id];
 
-          <div className="space-y-4 py-2">
-            {/* User selector */}
-            <div className="space-y-2">
-              <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Usuario
-              </Label>
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                <Input
-                  placeholder="Buscar por nombre o email..."
-                  value={assignSearch}
-                  onChange={e => setAssignSearch(e.target.value)}
-                  className="pl-9 text-sm"
-                />
-              </div>
+          return (
+            <div
+              key={def.id}
+              className="rounded-2xl border border-border/50 bg-card overflow-hidden shadow-sm"
+            >
+              {/* Color accent */}
+              <div className={`h-0.5 bg-gradient-to-r ${def.gradient}`} />
 
-              <div className="rounded-xl border border-border/50 max-h-48 overflow-y-auto">
-                {filteredForAssign.length === 0 ? (
-                  <p className="text-xs text-muted-foreground text-center py-6">Sin resultados</p>
-                ) : (
-                  filteredForAssign.map(u => {
-                    const def = ROLE_DEFS.find(d => d.id === u.role);
-                    const isSelected = assignUserId === u.id;
-                    const isSelf = u.id === currentUser?.id;
-                    return (
-                      <button
-                        key={u.id}
-                        disabled={isSelf}
-                        onClick={() => setAssignUserId(u.id)}
-                        className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors cursor-pointer ${
-                          isSelected
-                            ? 'bg-primary/10 border-l-2 border-primary'
-                            : 'hover:bg-muted/40'
-                        } ${isSelf ? 'opacity-40 cursor-not-allowed' : ''}`}
-                      >
-                        <Avatar className="w-7 h-7 flex-shrink-0">
-                          <AvatarFallback
-                            className={`text-[10px] font-bold ${def?.bg ?? ''} ${def?.text ?? ''}`}
-                          >
-                            {initials(u)}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="flex-1 min-w-0">
-                          <p className="text-xs font-medium truncate">
-                            {u.first_name} {u.last_name}
-                            {isSelf && <span className="text-muted-foreground ml-1">(vos)</span>}
-                          </p>
-                          <p className="text-[10px] text-muted-foreground truncate">{u.email}</p>
-                        </div>
+              <div className="p-4 sm:p-5">
+                {/* Role header */}
+                <div className="flex items-start justify-between gap-3 mb-3">
+                  <div className="flex items-center gap-3">
+                    <div
+                      className={`w-10 h-10 rounded-xl ${def.bg} flex items-center justify-center flex-shrink-0`}
+                    >
+                      <Icon className={`w-5 h-5 ${def.text}`} />
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="font-semibold text-sm leading-tight">
+                          {ROLE_DISPLAY_NAMES[def.id]}
+                        </h3>
                         <span
-                          className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${def?.bg ?? 'bg-muted'} ${def?.text ?? 'text-muted-foreground'} flex-shrink-0`}
+                          className={`text-[10px] font-bold px-2 py-0.5 rounded-full border ${def.bg} ${def.text} ${def.border}`}
                         >
-                          {ROLE_DISPLAY_NAMES[u.role]}
+                          Nivel {level}
                         </span>
-                      </button>
-                    );
-                  })
-                )}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-0.5 leading-snug">
+                        {def.description}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    <p className="text-xl font-bold leading-tight">{roleUsers.length}</p>
+                    <p className="text-xs text-muted-foreground">usuarios</p>
+                  </div>
+                </div>
+
+                {/* Permissions mini-matrix */}
+                <div className="grid grid-cols-1 gap-1.5 mb-3">
+                  {def.permissions.map(cat => (
+                    <div key={cat.category} className="flex items-center gap-2">
+                      <span className="text-[10px] text-muted-foreground w-24 flex-shrink-0 uppercase tracking-wide font-medium">
+                        {cat.category}
+                      </span>
+                      <div className="flex items-center gap-1 flex-wrap">
+                        {cat.actions.map(action => (
+                          <span
+                            key={action.label}
+                            className={`inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded font-medium ${
+                              action.allowed
+                                ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                                : 'bg-muted text-muted-foreground/50 line-through'
+                            }`}
+                          >
+                            {action.allowed ? (
+                              <Check className="w-2.5 h-2.5" />
+                            ) : (
+                              <X className="w-2.5 h-2.5" />
+                            )}
+                            {action.label}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Toggle users button */}
+                <button
+                  onClick={() => setExpandedRole(isExpanded ? null : def.id)}
+                  disabled={roleUsers.length === 0}
+                  className={`w-full flex items-center justify-between px-3 py-2 rounded-xl text-xs font-medium border transition-colors duration-200 ${
+                    roleUsers.length === 0
+                      ? 'border-border/30 text-muted-foreground/40 cursor-default'
+                      : 'border-border/50 hover:bg-muted/40 cursor-pointer'
+                  }`}
+                >
+                  <span>
+                    {roleUsers.length === 0
+                      ? 'Sin usuarios asignados'
+                      : `Ver ${roleUsers.length} usuario${roleUsers.length !== 1 ? 's' : ''}`}
+                  </span>
+                  {roleUsers.length > 0 &&
+                    (isExpanded ? (
+                      <ChevronUp className="w-3.5 h-3.5" />
+                    ) : (
+                      <ChevronDown className="w-3.5 h-3.5" />
+                    ))}
+                </button>
               </div>
-            </div>
 
-            {/* Role selector */}
-            <div className="space-y-2">
-              <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Nuevo Rol
-              </Label>
-              <Select
-                value={assignRole}
-                onValueChange={v => setAssignRole(v as UserRole)}
-                disabled={!assignUserId}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Seleccioná un rol..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {ROLE_DEFS.map(def => {
-                    const currentUserRole = users.find(u => u.id === assignUserId)?.role;
-                    return (
-                      <SelectItem key={def.id} value={def.id} disabled={def.id === currentUserRole}>
-                        <div className="flex items-center gap-2">
-                          <def.icon className={`w-3.5 h-3.5 ${def.text}`} />
-                          <span>{ROLE_DISPLAY_NAMES[def.id]}</span>
-                          {def.id === currentUserRole && (
-                            <span className="text-muted-foreground text-xs">(actual)</span>
-                          )}
-                        </div>
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
+              {/* Expanded users list */}
+              {isExpanded && roleUsers.length > 0 && (
+                <div className="border-t border-border/30 bg-muted/20 px-4 sm:px-5 py-3 space-y-2 max-h-56 overflow-y-auto">
+                  {roleUsers.map(u => (
+                    <div key={u.id} className="flex items-center gap-3">
+                      <Avatar className="w-7 h-7 flex-shrink-0">
+                        <AvatarFallback className={`text-[10px] font-bold ${def.bg} ${def.text}`}>
+                          {initials(u)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs font-medium truncate">
+                          {u.first_name} {u.last_name}
+                        </p>
+                        <p className="text-[10px] text-muted-foreground truncate">{u.email}</p>
+                      </div>
+                      {/* Don't allow changing own role */}
+                      {u.id !== currentUser?.id && (
+                        <button
+                          onClick={() => {
+                            setAssignUserId(u.id);
+                            setAssignRole('');
+                            setAssignOpen(true);
+                          }}
+                          className="text-[10px] text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 cursor-pointer px-2 py-1 rounded-lg hover:bg-muted"
+                        >
+                          Cambiar
+                        </button>
+                      )}
+                      {u.id === currentUser?.id && (
+                        <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 px-2">
+                          Vos
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
+          );
+        })}
+      </div>
+    </>
+  );
 
-            {/* Footer buttons */}
-            <div className="flex gap-2 pt-2">
-              <Button variant="outline" className="flex-1" onClick={() => setAssignOpen(false)}>
-                Cancelar
-              </Button>
-              <Button
-                className="flex-1"
-                disabled={!assignUserId || !assignRole || saving}
-                onClick={handleAssignSubmit}
-              >
-                {saving ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
-                Guardar cambio
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+  const assignDialogBody = (
+    <div className="space-y-4 py-2">
+      {/* User selector */}
+      <div className="space-y-2">
+        <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Usuario
+        </Label>
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Input
+            placeholder="Buscar por nombre o email..."
+            value={assignSearch}
+            onChange={e => setAssignSearch(e.target.value)}
+            className="pl-9 text-sm"
+          />
+        </div>
 
+        <div className="rounded-xl border border-border/50 max-h-48 overflow-y-auto">
+          {filteredForAssign.length === 0 ? (
+            <p className="text-xs text-muted-foreground text-center py-6">Sin resultados</p>
+          ) : (
+            filteredForAssign.map(u => {
+              const def = ROLE_DEFS.find(d => d.id === u.role);
+              const isSelected = assignUserId === u.id;
+              const isSelf = u.id === currentUser?.id;
+              return (
+                <button
+                  key={u.id}
+                  disabled={isSelf}
+                  onClick={() => setAssignUserId(u.id)}
+                  className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors cursor-pointer ${
+                    isSelected ? 'bg-primary/10 border-l-2 border-primary' : 'hover:bg-muted/40'
+                  } ${isSelf ? 'opacity-40 cursor-not-allowed' : ''}`}
+                >
+                  <Avatar className="w-7 h-7 flex-shrink-0">
+                    <AvatarFallback
+                      className={`text-[10px] font-bold ${def?.bg ?? ''} ${def?.text ?? ''}`}
+                    >
+                      {initials(u)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-medium truncate">
+                      {u.first_name} {u.last_name}
+                      {isSelf && <span className="text-muted-foreground ml-1">(vos)</span>}
+                    </p>
+                    <p className="text-[10px] text-muted-foreground truncate">{u.email}</p>
+                  </div>
+                  <span
+                    className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${def?.bg ?? 'bg-muted'} ${def?.text ?? 'text-muted-foreground'} flex-shrink-0`}
+                  >
+                    {ROLE_DISPLAY_NAMES[u.role]}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      {/* Role selector */}
+      <div className="space-y-2">
+        <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Nuevo Rol
+        </Label>
+        <Select
+          value={assignRole}
+          onValueChange={v => setAssignRole(v as UserRole)}
+          disabled={!assignUserId}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Seleccioná un rol..." />
+          </SelectTrigger>
+          <SelectContent>
+            {ROLE_DEFS.map(def => {
+              const currentUserRole = users.find(u => u.id === assignUserId)?.role;
+              return (
+                <SelectItem key={def.id} value={def.id} disabled={def.id === currentUserRole}>
+                  <div className="flex items-center gap-2">
+                    <def.icon className={`w-3.5 h-3.5 ${def.text}`} />
+                    <span>{ROLE_DISPLAY_NAMES[def.id]}</span>
+                    {def.id === currentUserRole && (
+                      <span className="text-muted-foreground text-xs">(actual)</span>
+                    )}
+                  </div>
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+
+  const assignDialogFooter = (
+    <>
+      <Button variant="outline" className="flex-1" onClick={() => setAssignOpen(false)}>
+        Cancelar
+      </Button>
+      <Button
+        className="flex-1"
+        disabled={!assignUserId || !assignRole || saving}
+        onClick={handleAssignSubmit}
+      >
+        {saving ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
+        Guardar cambio
+      </Button>
+    </>
+  );
+
+  const assignOpenChange = (open: boolean) => {
+    setAssignOpen(open);
+    if (!open) {
+      setAssignUserId('');
+      setAssignRole('');
+      setAssignSearch('');
+    }
+  };
+
+  const assignDialogs = isMobileApp ? (
+    <Drawer open={assignOpen} onOpenChange={assignOpenChange}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle className="flex items-center gap-2">
+            <UserCog className="w-5 h-5 text-primary" />
+            Asignar Rol
+          </DrawerTitle>
+          <DrawerDescription>
+            Cambiá el rol de un usuario. El cambio aplica de inmediato.
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="px-4 overflow-y-auto">{assignDialogBody}</div>
+        <DrawerFooter className="flex-row gap-2">{assignDialogFooter}</DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <Dialog open={assignOpen} onOpenChange={assignOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <UserCog className="w-5 h-5 text-primary" />
+            Asignar Rol
+          </DialogTitle>
+          <DialogDescription>
+            Cambiá el rol de un usuario. El cambio aplica de inmediato.
+          </DialogDescription>
+        </DialogHeader>
+        {assignDialogBody}
+        <div className="flex gap-2 pt-2">{assignDialogFooter}</div>
+      </DialogContent>
+    </Dialog>
+  );
+
+  const confirmDialog = (
+    <>
       {/* ── Confirm role change ── */}
       <AlertDialog open={!!confirmChange} onOpenChange={open => !open && setConfirmChange(null)}>
         <AlertDialogContent>
@@ -807,6 +820,60 @@ export default function RoleManagementPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+    </>
+  );
+
+  if (isMobileApp) {
+    return (
+      <>
+        <MobileScreen
+          title="Gestión de Roles"
+          subtitle={`${users.length} usuarios`}
+          action={
+            <button
+              type="button"
+              onClick={() => setAssignOpen(true)}
+              className="p-2 -mr-1 rounded-xl hover:bg-accent/60 active:bg-accent transition-colors cursor-pointer"
+              aria-label="Asignar Rol"
+            >
+              <UserCog className="w-4 h-4" />
+            </button>
+          }
+        >
+          <div className="px-4 pt-3 space-y-4">{bodyContent}</div>
+        </MobileScreen>
+        {assignDialogs}
+        {confirmDialog}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-6 p-3 sm:p-4 md:p-6 max-w-5xl">
+        {/* ── Header ── */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3 mb-1">
+              <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Gestión de Roles</h1>
+              <Badge variant="secondary" className="tabular-nums">
+                {users.length} usuarios
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Administrá los roles del sistema y asignalos a los miembros.
+            </p>
+          </div>
+          <Button onClick={() => setAssignOpen(true)} className="w-full sm:w-auto">
+            <UserCog className="w-4 h-4 mr-2" />
+            Asignar Rol
+          </Button>
+        </div>
+
+        {bodyContent}
+      </div>
+      {assignDialogs}
+      {confirmDialog}
     </>
   );
 }

--- a/src/pages/dashboard/RolesPage.tsx
+++ b/src/pages/dashboard/RolesPage.tsx
@@ -13,6 +13,8 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
 import { Can } from '@/components/Can';
+import { MobileScreen } from '@/components/mobile/MobileScreen';
+import { useMobileMode } from '@/hooks/useMobileMode';
 import { Shield, Users, Settings, Loader2, Lock } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
@@ -43,6 +45,7 @@ const MODULE_LABELS: Record<string, string> = {
 };
 
 const RolesPage = () => {
+  const isMobileApp = useMobileMode();
   const [roles, setRoles] = useState<RoleData[]>([]);
   const [loading, setLoading] = useState(true);
   const [totalUsers, setTotalUsers] = useState(0);
@@ -193,23 +196,8 @@ const RolesPage = () => {
     );
   }
 
-  return (
-    <div className="space-y-3 sm:space-y-6 p-3 sm:p-4 md:p-6">
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 sm:gap-3">
-        <div className="min-w-0">
-          <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
-            Gestión de Roles
-          </h1>
-          <p className="text-sm sm:text-base text-muted-foreground">
-            Administra los roles y permisos del sistema
-          </p>
-        </div>
-        <Button onClick={loadRoleStats} className="w-full sm:w-auto">
-          <Shield className="h-4 w-4 mr-2" />
-          Actualizar
-        </Button>
-      </div>
-
+  const bodyContent = (
+    <>
       {/* Stats */}
       <div className="grid gap-2 sm:gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
         <Card>
@@ -367,7 +355,11 @@ const RolesPage = () => {
           )}
         </CardContent>
       </Card>
+    </>
+  );
 
+  const sheets = (
+    <>
       {/* Sheet: gestionar módulos de un rol */}
       <Sheet open={permsOpen} onOpenChange={setPermsOpen}>
         <SheetContent className="w-full sm:max-w-md overflow-y-auto">
@@ -487,6 +479,50 @@ const RolesPage = () => {
           )}
         </SheetContent>
       </Sheet>
+    </>
+  );
+
+  if (isMobileApp) {
+    return (
+      <>
+        <MobileScreen
+          title="Gestión de Roles"
+          subtitle="Roles y permisos del sistema"
+          action={
+            <button
+              type="button"
+              onClick={loadRoleStats}
+              className="p-2 -mr-1 rounded-xl hover:bg-accent/60 active:bg-accent transition-colors cursor-pointer"
+              aria-label="Actualizar"
+            >
+              <Shield className="h-4 w-4" />
+            </button>
+          }
+        >
+          <div className="px-4 pt-3 space-y-4">{bodyContent}</div>
+        </MobileScreen>
+        {sheets}
+      </>
+    );
+  }
+
+  return (
+    <div className="space-y-3 sm:space-y-6 p-3 sm:p-4 md:p-6">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 sm:gap-3">
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-bold text-foreground">Gestión de Roles</h1>
+          <p className="text-sm sm:text-base text-muted-foreground">
+            Administra los roles y permisos del sistema
+          </p>
+        </div>
+        <Button onClick={loadRoleStats} className="w-full sm:w-auto">
+          <Shield className="h-4 w-4 mr-2" />
+          Actualizar
+        </Button>
+      </div>
+
+      {bodyContent}
+      {sheets}
     </div>
   );
 };

--- a/src/pages/dashboard/SettingsPage.tsx
+++ b/src/pages/dashboard/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import LogoUploader from '@/components/LogoUploader';
 import DiscipleshipMap from '@/components/discipleship/DiscipleshipMap';
 import ZoneManagement from '@/components/discipleship/ZoneManagement';
+import { MobileScreen } from '@/components/mobile/MobileScreen';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -19,11 +20,14 @@ import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/hooks/useAuth';
+import { useMobileMode } from '@/hooks/useMobileMode';
 import { applyBrandColors } from '@/hooks/useBrandColors';
 import { SettingsService } from '@/services/settings.service';
 import type { ChurchInfo, NotificationConfig, SystemSettings } from '@/types/settings.types';
 import {
   Bell,
+  ChevronLeft,
+  ChevronRight,
   Church,
   Database,
   Loader2,
@@ -36,9 +40,22 @@ import {
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
+const SECTIONS = [
+  { key: 'general', label: 'General', icon: Settings },
+  { key: 'church', label: 'Iglesia', icon: Church },
+  { key: 'zones', label: 'Zonas', icon: Map },
+  { key: 'notifications', label: 'Notificaciones', icon: Bell },
+  { key: 'security', label: 'Seguridad', icon: Shield },
+  { key: 'backup', label: 'Respaldos', icon: Database },
+] as const;
+
+type SectionKey = (typeof SECTIONS)[number]['key'];
+
 const SettingsPage = () => {
   const { user } = useAuth();
-  const [activeTab, setActiveTab] = useState('general');
+  const isMobileApp = useMobileMode();
+  const [activeTab, setActiveTab] = useState<SectionKey>('general');
+  const [mobileSection, setMobileSection] = useState<SectionKey | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -132,6 +149,903 @@ const SettingsPage = () => {
     );
   }
 
+  // ===== Contenido de cada sección (compartido entre desktop y mobile) =====
+
+  const generalContent = (
+    <Card className={isMobileApp ? 'border-none shadow-none' : undefined}>
+      {!isMobileApp && (
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Settings className="w-5 h-5" />
+            Configuración General
+          </CardTitle>
+          <CardDescription>Configuraciones básicas del sistema</CardDescription>
+        </CardHeader>
+      )}
+      <CardContent
+        className={isMobileApp ? 'space-y-4 p-0' : 'space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6'}
+      >
+        {systemSettings && (
+          <>
+            <div className="rounded-lg border bg-muted/40 p-3 sm:p-4 flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium">Plataforma: JETRO</p>
+                <p className="text-xs text-muted-foreground">
+                  El nombre y logo de tu iglesia se configuran en la pestaña{' '}
+                  <span className="font-medium">Iglesia</span> — JETRO se muestra siempre junto a
+                  esa marca, no se reemplaza.
+                </p>
+              </div>
+              <Badge variant="outline">v{systemSettings.site_version}</Badge>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+              <div className="space-y-2">
+                <Label htmlFor="timezone">Zona Horaria</Label>
+                <Select
+                  value={systemSettings.timezone}
+                  onValueChange={value =>
+                    setSystemSettings({
+                      ...systemSettings,
+                      timezone: value,
+                    })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="America/Argentina/Buenos_Aires">
+                      América/Buenos_Aires (UTC-3)
+                    </SelectItem>
+                    <SelectItem value="America/Santiago">América/Santiago (UTC-3)</SelectItem>
+                    <SelectItem value="America/Sao_Paulo">América/São Paulo (UTC-3)</SelectItem>
+                    <SelectItem value="America/Santo_Domingo">
+                      América/Santo_Domingo (UTC-4)
+                    </SelectItem>
+                    <SelectItem value="America/Caracas">América/Caracas (UTC-4)</SelectItem>
+                    <SelectItem value="America/Bogota">América/Bogotá (UTC-5)</SelectItem>
+                    <SelectItem value="America/Lima">América/Lima (UTC-5)</SelectItem>
+                    <SelectItem value="America/Mexico_City">América/Mexico_City (UTC-6)</SelectItem>
+                    <SelectItem value="Europe/Madrid">Europa/Madrid (UTC+1)</SelectItem>
+                    <SelectItem value="UTC">UTC</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="default_language">Idioma por Defecto</Label>
+                <Select
+                  value={systemSettings.default_language}
+                  onValueChange={value =>
+                    setSystemSettings({
+                      ...systemSettings,
+                      default_language: value,
+                    })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="es">Español</SelectItem>
+                    <SelectItem value="en">English</SelectItem>
+                    <SelectItem value="pt">Português</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-4">
+              <h3 className="text-lg font-semibold">Preferencias de Interfaz</h3>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label>Tema por Defecto</Label>
+                    <p className="text-sm text-muted-foreground">Tema para nuevos usuarios</p>
+                  </div>
+                  <Select
+                    value={systemSettings.default_theme}
+                    onValueChange={(value: 'light' | 'dark' | 'auto') =>
+                      setSystemSettings({
+                        ...systemSettings,
+                        default_theme: value,
+                      })
+                    }
+                  >
+                    <SelectTrigger className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="light">Claro</SelectItem>
+                      <SelectItem value="dark">Oscuro</SelectItem>
+                      <SelectItem value="auto">Auto</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label>Animaciones</Label>
+                    <p className="text-sm text-muted-foreground">
+                      Mostrar animaciones en la interfaz
+                    </p>
+                  </div>
+                  <Switch
+                    checked={systemSettings.animations_enabled}
+                    onCheckedChange={checked =>
+                      setSystemSettings({
+                        ...systemSettings,
+                        animations_enabled: checked,
+                      })
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label>Modo Mantenimiento</Label>
+                    <p className="text-sm text-muted-foreground">
+                      Desactivar acceso temporal al sistema
+                    </p>
+                  </div>
+                  <Switch
+                    checked={systemSettings.maintenance_mode}
+                    onCheckedChange={checked =>
+                      setSystemSettings({
+                        ...systemSettings,
+                        maintenance_mode: checked,
+                      })
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex justify-end pt-4">
+              <Button onClick={handleSaveSystemSettings} disabled={isSaving}>
+                {isSaving ? (
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <Save className="w-4 h-4 mr-2" />
+                )}
+                {isSaving ? 'Guardando...' : 'Guardar Cambios'}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+
+  const churchContent = (
+    <Card className={isMobileApp ? 'border-none shadow-none' : undefined}>
+      {!isMobileApp && (
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Church className="w-5 h-5" />
+            Información de la Iglesia
+          </CardTitle>
+          <CardDescription>Datos generales de tu congregación</CardDescription>
+        </CardHeader>
+      )}
+      <CardContent
+        className={isMobileApp ? 'space-y-4 p-0' : 'space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6'}
+      >
+        {churchInfo && (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+              <div className="space-y-2">
+                <Label htmlFor="church_name">Nombre de la Iglesia</Label>
+                <Input
+                  id="church_name"
+                  value={churchInfo.name}
+                  onChange={e =>
+                    setChurchInfo({
+                      ...churchInfo,
+                      name: e.target.value,
+                    })
+                  }
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="pastor_name">Pastor Principal</Label>
+                <Input
+                  id="pastor_name"
+                  value={churchInfo.pastor_name || ''}
+                  onChange={e =>
+                    setChurchInfo({
+                      ...churchInfo,
+                      pastor_name: e.target.value,
+                    })
+                  }
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="church_phone">Teléfono</Label>
+                <Input
+                  id="church_phone"
+                  value={churchInfo.phone || ''}
+                  onChange={e =>
+                    setChurchInfo({
+                      ...churchInfo,
+                      phone: e.target.value,
+                    })
+                  }
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="church_email">Email</Label>
+                <Input
+                  id="church_email"
+                  type="email"
+                  value={churchInfo.email || ''}
+                  onChange={e =>
+                    setChurchInfo({
+                      ...churchInfo,
+                      email: e.target.value,
+                    })
+                  }
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="church_website">Sitio Web</Label>
+                <Input
+                  id="church_website"
+                  value={churchInfo.website || ''}
+                  onChange={e =>
+                    setChurchInfo({
+                      ...churchInfo,
+                      website: e.target.value,
+                    })
+                  }
+                />
+              </div>
+
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="church_address">Dirección</Label>
+                <Textarea
+                  id="church_address"
+                  value={churchInfo.address || ''}
+                  onChange={e =>
+                    setChurchInfo({
+                      ...churchInfo,
+                      address: e.target.value,
+                    })
+                  }
+                  rows={2}
+                />
+              </div>
+
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="church_mission">Misión</Label>
+                <Textarea
+                  id="church_mission"
+                  value={churchInfo.mission || ''}
+                  onChange={e =>
+                    setChurchInfo({
+                      ...churchInfo,
+                      mission: e.target.value,
+                    })
+                  }
+                  rows={3}
+                />
+              </div>
+
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="church_vision">Visión</Label>
+                <Textarea
+                  id="church_vision"
+                  value={churchInfo.vision || ''}
+                  onChange={e =>
+                    setChurchInfo({
+                      ...churchInfo,
+                      vision: e.target.value,
+                    })
+                  }
+                  rows={3}
+                />
+              </div>
+            </div>
+
+            <Separator />
+
+            {/* Logo y Branding */}
+            <div className="space-y-4">
+              <h3 className="text-lg font-semibold">Logo y Branding</h3>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+                {/* Logo */}
+                <div className="space-y-2">
+                  <Label>Logo Principal</Label>
+                  <LogoUploader
+                    currentUrl={churchInfo.logo_url}
+                    type="logo"
+                    onUploadSuccess={url =>
+                      setChurchInfo({
+                        ...churchInfo,
+                        logo_url: url,
+                      })
+                    }
+                    onDeleteSuccess={() =>
+                      setChurchInfo({
+                        ...churchInfo,
+                        logo_url: null,
+                      })
+                    }
+                  />
+                </div>
+
+                {/* Colores */}
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="primary_color">Color Primario</Label>
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="color"
+                        value={churchInfo.primary_color}
+                        onChange={e => {
+                          const next = { ...churchInfo, primary_color: e.target.value };
+                          setChurchInfo(next);
+                          applyBrandColors(next.primary_color, next.secondary_color);
+                        }}
+                        className="w-10 h-10 rounded-lg border cursor-pointer"
+                      />
+                      <Input
+                        id="primary_color"
+                        value={churchInfo.primary_color}
+                        onChange={e => {
+                          const next = { ...churchInfo, primary_color: e.target.value };
+                          setChurchInfo(next);
+                          if (/^#[0-9a-fA-F]{6}$/.test(e.target.value))
+                            applyBrandColors(next.primary_color, next.secondary_color);
+                        }}
+                        placeholder="#1e40af"
+                        className="flex-1"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="secondary_color">Color Secundario</Label>
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="color"
+                        value={churchInfo.secondary_color}
+                        onChange={e => {
+                          const next = { ...churchInfo, secondary_color: e.target.value };
+                          setChurchInfo(next);
+                          applyBrandColors(next.primary_color, next.secondary_color);
+                        }}
+                        className="w-10 h-10 rounded-lg border cursor-pointer"
+                      />
+                      <Input
+                        id="secondary_color"
+                        value={churchInfo.secondary_color}
+                        onChange={e => {
+                          const next = { ...churchInfo, secondary_color: e.target.value };
+                          setChurchInfo(next);
+                          if (/^#[0-9a-fA-F]{6}$/.test(e.target.value))
+                            applyBrandColors(next.primary_color, next.secondary_color);
+                        }}
+                        placeholder="#fbbf24"
+                        className="flex-1"
+                      />
+                    </div>
+                  </div>
+
+                  {/* Live preview */}
+                  <div className="rounded-lg border p-4 space-y-3">
+                    <p className="text-xs text-muted-foreground font-medium">Vista previa</p>
+                    <div className="flex flex-wrap gap-2 items-center">
+                      <span
+                        className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-white"
+                        style={{ background: churchInfo.primary_color }}
+                      >
+                        Botón primario
+                      </span>
+                      <span
+                        className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium"
+                        style={{
+                          background: churchInfo.secondary_color,
+                          color: '#1a1a1a',
+                        }}
+                      >
+                        Botón secundario
+                      </span>
+                      <span
+                        className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold text-white"
+                        style={{ background: churchInfo.primary_color }}
+                      >
+                        Badge
+                      </span>
+                    </div>
+                    <div
+                      className="h-2 w-full rounded-full"
+                      style={{
+                        background: `linear-gradient(to right, ${churchInfo.primary_color}, ${churchInfo.secondary_color})`,
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <Separator />
+
+            {/* Redes Sociales */}
+            <div className="space-y-4">
+              <h3 className="text-lg font-semibold">Redes Sociales</h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 md:gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="social_facebook">Facebook</Label>
+                  <Input
+                    id="social_facebook"
+                    value={churchInfo.social_facebook || ''}
+                    onChange={e =>
+                      setChurchInfo({
+                        ...churchInfo,
+                        social_facebook: e.target.value,
+                      })
+                    }
+                    placeholder="https://facebook.com/..."
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="social_instagram">Instagram</Label>
+                  <Input
+                    id="social_instagram"
+                    value={churchInfo.social_instagram || ''}
+                    onChange={e =>
+                      setChurchInfo({
+                        ...churchInfo,
+                        social_instagram: e.target.value,
+                      })
+                    }
+                    placeholder="https://instagram.com/..."
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="social_youtube">YouTube</Label>
+                  <Input
+                    id="social_youtube"
+                    value={churchInfo.social_youtube || ''}
+                    onChange={e =>
+                      setChurchInfo({
+                        ...churchInfo,
+                        social_youtube: e.target.value,
+                      })
+                    }
+                    placeholder="https://youtube.com/..."
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="social_twitter">Twitter/X</Label>
+                  <Input
+                    id="social_twitter"
+                    value={churchInfo.social_twitter || ''}
+                    onChange={e =>
+                      setChurchInfo({
+                        ...churchInfo,
+                        social_twitter: e.target.value,
+                      })
+                    }
+                    placeholder="https://twitter.com/..."
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex justify-end pt-4">
+              <Button onClick={handleSaveChurchInfo} disabled={isSaving}>
+                {isSaving ? (
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <Save className="w-4 h-4 mr-2" />
+                )}
+                {isSaving ? 'Guardando...' : 'Guardar Cambios'}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+
+  const zonesContent = isMobileApp ? (
+    <div className="space-y-4">
+      <ZoneManagement />
+      <div>
+        <h3 className="text-sm font-semibold mb-2 flex items-center gap-2">
+          <Map className="w-4 h-4" />
+          Mapa de Células
+        </h3>
+        <DiscipleshipMap />
+      </div>
+    </div>
+  ) : (
+    <>
+      <ZoneManagement />
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Map className="w-5 h-5" />
+            Mapa de Células
+          </CardTitle>
+          <CardDescription>Visualiza la distribución geográfica de las células</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <DiscipleshipMap />
+        </CardContent>
+      </Card>
+    </>
+  );
+
+  const notificationsContent = (
+    <Card className={isMobileApp ? 'border-none shadow-none' : undefined}>
+      {!isMobileApp && (
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Bell className="w-5 h-5" />
+            Configuración de Notificaciones
+          </CardTitle>
+          <CardDescription>Gestiona cómo y cuándo enviar notificaciones</CardDescription>
+        </CardHeader>
+      )}
+      <CardContent
+        className={isMobileApp ? 'space-y-4 p-0' : 'space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6'}
+      >
+        {notificationConfig && (
+          <>
+            <div className="space-y-6">
+              <div>
+                <h3 className="text-lg font-semibold mb-4">Canales de Notificación</h3>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Email</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Habilitar notificaciones por correo
+                      </p>
+                    </div>
+                    <Switch
+                      checked={notificationConfig.email_enabled}
+                      onCheckedChange={checked =>
+                        setNotificationConfig({
+                          ...notificationConfig,
+                          email_enabled: checked,
+                        })
+                      }
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Push</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Notificaciones en navegador/app
+                      </p>
+                    </div>
+                    <Switch
+                      checked={notificationConfig.push_enabled}
+                      onCheckedChange={checked =>
+                        setNotificationConfig({
+                          ...notificationConfig,
+                          push_enabled: checked,
+                        })
+                      }
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>SMS</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Mensajes de texto (costo adicional)
+                      </p>
+                    </div>
+                    <Switch
+                      checked={notificationConfig.sms_enabled}
+                      onCheckedChange={checked =>
+                        setNotificationConfig({
+                          ...notificationConfig,
+                          sms_enabled: checked,
+                        })
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <Separator />
+
+              <div>
+                <h3 className="text-lg font-semibold mb-4">Tipos de Notificación</h3>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Nuevos Registros</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Notificar cuando se registre un nuevo usuario
+                      </p>
+                    </div>
+                    <Switch
+                      checked={notificationConfig.new_user_notifications}
+                      onCheckedChange={checked =>
+                        setNotificationConfig({
+                          ...notificationConfig,
+                          new_user_notifications: checked,
+                        })
+                      }
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Cambios de Roles</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Notificar cuando se modifiquen roles
+                      </p>
+                    </div>
+                    <Switch
+                      checked={notificationConfig.role_change_notifications}
+                      onCheckedChange={checked =>
+                        setNotificationConfig({
+                          ...notificationConfig,
+                          role_change_notifications: checked,
+                        })
+                      }
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label>Recordatorios de Eventos</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Recordatorios automáticos de eventos
+                      </p>
+                    </div>
+                    <Switch
+                      checked={notificationConfig.event_reminders}
+                      onCheckedChange={checked =>
+                        setNotificationConfig({
+                          ...notificationConfig,
+                          event_reminders: checked,
+                        })
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <Separator />
+
+              <p className="text-sm text-muted-foreground">
+                Los correos del sistema se envían a través de un proveedor gestionado (Resend) — no
+                requiere configuración SMTP.
+              </p>
+            </div>
+
+            <div className="flex justify-end pt-4">
+              <Button onClick={handleSaveNotificationConfig} disabled={isSaving}>
+                {isSaving ? (
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <Save className="w-4 h-4 mr-2" />
+                )}
+                {isSaving ? 'Guardando...' : 'Guardar Cambios'}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+
+  const securityContent = (
+    <Card className={isMobileApp ? 'border-none shadow-none' : undefined}>
+      {!isMobileApp && (
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Shield className="w-5 h-5" />
+            Seguridad del Sistema
+          </CardTitle>
+          <CardDescription>Configuraciones de seguridad y acceso</CardDescription>
+        </CardHeader>
+      )}
+      <CardContent
+        className={isMobileApp ? 'space-y-4 p-0' : 'space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6'}
+      >
+        <div className="space-y-4">
+          <div className="flex items-center justify-between p-4 border rounded-lg">
+            <div>
+              <h4 className="font-medium">Registro de Usuarios</h4>
+              <p className="text-sm text-muted-foreground">
+                Permitir que nuevos usuarios se registren
+              </p>
+            </div>
+            <Switch
+              checked={systemSettings?.allow_registrations || false}
+              onCheckedChange={checked =>
+                systemSettings &&
+                setSystemSettings({
+                  ...systemSettings,
+                  allow_registrations: checked,
+                })
+              }
+            />
+          </div>
+
+          <div className="flex items-center justify-between p-4 border rounded-lg">
+            <div>
+              <h4 className="font-medium">Tiempo de Sesión</h4>
+              <p className="text-sm text-muted-foreground">
+                Minutos de inactividad antes de cerrar sesión
+              </p>
+            </div>
+            <Input
+              type="number"
+              className="w-24"
+              value={systemSettings?.session_timeout_minutes || 60}
+              onChange={e =>
+                systemSettings &&
+                setSystemSettings({
+                  ...systemSettings,
+                  session_timeout_minutes: parseInt(e.target.value) || 60,
+                })
+              }
+            />
+          </div>
+
+          <div className="flex items-center justify-between p-4 border rounded-lg">
+            <div>
+              <h4 className="font-medium">Máximo Usuarios por Grupo</h4>
+              <p className="text-sm text-muted-foreground">
+                Límite de miembros en grupos de discipulado
+              </p>
+            </div>
+            <Input
+              type="number"
+              className="w-24"
+              value={systemSettings?.max_users_per_group || 12}
+              onChange={e =>
+                systemSettings &&
+                setSystemSettings({
+                  ...systemSettings,
+                  max_users_per_group: parseInt(e.target.value) || 12,
+                })
+              }
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end pt-4">
+          <Button onClick={handleSaveSystemSettings} disabled={isSaving}>
+            {isSaving ? (
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            ) : (
+              <Save className="w-4 h-4 mr-2" />
+            )}
+            {isSaving ? 'Guardando...' : 'Guardar Cambios'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  const backupContent = (
+    <Card className={isMobileApp ? 'border-none shadow-none' : undefined}>
+      {!isMobileApp && (
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Database className="w-5 h-5" />
+            Respaldos y Datos
+          </CardTitle>
+          <CardDescription>Gestión de respaldos del sistema</CardDescription>
+        </CardHeader>
+      )}
+      <CardContent
+        className={isMobileApp ? 'space-y-4 p-0' : 'space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6'}
+      >
+        <div className="rounded-lg border border-dashed p-6 text-center space-y-3">
+          <Database className="w-10 h-10 mx-auto text-muted-foreground/50" />
+          <div>
+            <h4 className="font-medium">Respaldos en desarrollo</h4>
+            <p className="text-sm text-muted-foreground mt-1">
+              La exportación e importación de datos estará disponible en una próxima versión. Por
+              ahora, Supabase realiza respaldos automáticos diariamente.
+            </p>
+          </div>
+          <Badge variant="outline">Supabase Backup: Activo</Badge>
+        </div>
+
+        <div className="p-4 bg-muted rounded-lg space-y-2">
+          <h4 className="font-medium text-sm">Información de respaldo</h4>
+          <ul className="text-sm text-muted-foreground space-y-1 list-disc list-inside">
+            <li>Respaldo automático cada 24 horas vía Supabase</li>
+            <li>Retención de 7 días en plan gratuito</li>
+            <li>Restauración disponible desde el panel de Supabase</li>
+          </ul>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  const sectionContent: Record<SectionKey, React.ReactNode> = {
+    general: generalContent,
+    church: churchContent,
+    zones: zonesContent,
+    notifications: notificationsContent,
+    security: securityContent,
+    backup: backupContent,
+  };
+
+  // ===== Layout mobile: lista de secciones con drill-down =====
+  if (isMobileApp) {
+    if (mobileSection) {
+      const meta = SECTIONS.find(s => s.key === mobileSection)!;
+      return (
+        <MobileScreen title="Configuración">
+          <div className="-mx-3 -mt-3">
+            <div className="sticky top-14 z-30 bg-background/95 backdrop-blur-lg border-b border-border/40 px-3 h-12 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setMobileSection(null)}
+                className="p-1.5 -ml-1 rounded-xl hover:bg-accent/60 active:bg-accent transition-colors cursor-pointer"
+              >
+                <ChevronLeft className="w-5 h-5" />
+              </button>
+              <span className="font-semibold truncate flex-1 text-sm">{meta.label}</span>
+            </div>
+            <div className="px-4 pt-4">{sectionContent[mobileSection]}</div>
+          </div>
+        </MobileScreen>
+      );
+    }
+
+    return (
+      <MobileScreen title="Configuración" subtitle="Administra tu iglesia">
+        <div className="px-4 pt-3 space-y-3">
+          <Button
+            variant="outline"
+            onClick={loadAllSettings}
+            disabled={isLoading}
+            className="w-full"
+          >
+            <RotateCcw className="w-4 h-4 mr-2" />
+            Recargar
+          </Button>
+          <div className="rounded-2xl border border-border divide-y divide-border bg-card overflow-hidden">
+            {SECTIONS.map(section => {
+              const Icon = section.icon;
+              return (
+                <button
+                  type="button"
+                  key={section.key}
+                  onClick={() => setMobileSection(section.key)}
+                  className="w-full flex items-center gap-3 px-4 py-3.5 text-left active:bg-accent/50 transition-colors"
+                >
+                  <div className="p-2 rounded-xl bg-muted">
+                    <Icon className="w-4 h-4 text-muted-foreground" />
+                  </div>
+                  <span className="flex-1 text-sm font-medium">{section.label}</span>
+                  <ChevronRight className="w-4 h-4 text-muted-foreground" />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </MobileScreen>
+    );
+  }
+
+  // ===== Layout de escritorio =====
   return (
     <div className="space-y-3 sm:space-y-6 p-3 sm:p-4 md:p-6">
       {/* Header */}
@@ -155,833 +1069,31 @@ const SettingsPage = () => {
         </Button>
       </div>
 
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-3 sm:space-y-6">
+      <Tabs
+        value={activeTab}
+        onValueChange={value => setActiveTab(value as SectionKey)}
+        className="space-y-3 sm:space-y-6"
+      >
         {/* Los tabs envuelven en vez de scrollear o comprimirse: con grid de N
             columnas fijas el label más largo quedaba cortado entre 768 y 1280px.
             `grow` los reparte en la fila y `flex-wrap` baja el sobrante. */}
         <TabsList className="flex h-auto w-full flex-wrap gap-2 p-1.5">
-          <TabsTrigger value="general" className="min-h-11 grow px-3 text-xs sm:text-sm">
-            General
-          </TabsTrigger>
-          <TabsTrigger value="church" className="min-h-11 grow px-3 text-xs sm:text-sm">
-            Iglesia
-          </TabsTrigger>
-          <TabsTrigger value="zones" className="min-h-11 grow px-3 text-xs sm:text-sm">
-            Zonas
-          </TabsTrigger>
-          <TabsTrigger value="notifications" className="min-h-11 grow px-3 text-xs sm:text-sm">
-            Notificaciones
-          </TabsTrigger>
-          <TabsTrigger value="security" className="min-h-11 grow px-3 text-xs sm:text-sm">
-            Seguridad
-          </TabsTrigger>
-          <TabsTrigger value="backup" className="min-h-11 grow px-3 text-xs sm:text-sm">
-            Respaldos
-          </TabsTrigger>
+          {SECTIONS.map(section => (
+            <TabsTrigger
+              key={section.key}
+              value={section.key}
+              className="min-h-11 grow px-3 text-xs sm:text-sm"
+            >
+              {section.label}
+            </TabsTrigger>
+          ))}
         </TabsList>
 
-        {/* ===== TAB: GENERAL ===== */}
-        <TabsContent value="general" className="space-y-3 sm:space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Settings className="w-5 h-5" />
-                Configuración General
-              </CardTitle>
-              <CardDescription>Configuraciones básicas del sistema</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6">
-              {systemSettings && (
-                <>
-                  <div className="rounded-lg border bg-muted/40 p-3 sm:p-4 flex items-center justify-between gap-3">
-                    <div>
-                      <p className="text-sm font-medium">Plataforma: JETRO</p>
-                      <p className="text-xs text-muted-foreground">
-                        El nombre y logo de tu iglesia se configuran en la pestaña{' '}
-                        <span className="font-medium">Iglesia</span> — JETRO se muestra siempre
-                        junto a esa marca, no se reemplaza.
-                      </p>
-                    </div>
-                    <Badge variant="outline">v{systemSettings.site_version}</Badge>
-                  </div>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                    <div className="space-y-2">
-                      <Label htmlFor="timezone">Zona Horaria</Label>
-                      <Select
-                        value={systemSettings.timezone}
-                        onValueChange={value =>
-                          setSystemSettings({
-                            ...systemSettings,
-                            timezone: value,
-                          })
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="America/Argentina/Buenos_Aires">
-                            América/Buenos_Aires (UTC-3)
-                          </SelectItem>
-                          <SelectItem value="America/Santiago">América/Santiago (UTC-3)</SelectItem>
-                          <SelectItem value="America/Sao_Paulo">
-                            América/São Paulo (UTC-3)
-                          </SelectItem>
-                          <SelectItem value="America/Santo_Domingo">
-                            América/Santo_Domingo (UTC-4)
-                          </SelectItem>
-                          <SelectItem value="America/Caracas">América/Caracas (UTC-4)</SelectItem>
-                          <SelectItem value="America/Bogota">América/Bogotá (UTC-5)</SelectItem>
-                          <SelectItem value="America/Lima">América/Lima (UTC-5)</SelectItem>
-                          <SelectItem value="America/Mexico_City">
-                            América/Mexico_City (UTC-6)
-                          </SelectItem>
-                          <SelectItem value="Europe/Madrid">Europa/Madrid (UTC+1)</SelectItem>
-                          <SelectItem value="UTC">UTC</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="default_language">Idioma por Defecto</Label>
-                      <Select
-                        value={systemSettings.default_language}
-                        onValueChange={value =>
-                          setSystemSettings({
-                            ...systemSettings,
-                            default_language: value,
-                          })
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="es">Español</SelectItem>
-                          <SelectItem value="en">English</SelectItem>
-                          <SelectItem value="pt">Português</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-
-                  <Separator />
-
-                  <div className="space-y-4">
-                    <h3 className="text-lg font-semibold">Preferencias de Interfaz</h3>
-                    <div className="space-y-4">
-                      <div className="flex items-center justify-between">
-                        <div className="space-y-0.5">
-                          <Label>Tema por Defecto</Label>
-                          <p className="text-sm text-muted-foreground">Tema para nuevos usuarios</p>
-                        </div>
-                        <Select
-                          value={systemSettings.default_theme}
-                          onValueChange={(value: 'light' | 'dark' | 'auto') =>
-                            setSystemSettings({
-                              ...systemSettings,
-                              default_theme: value,
-                            })
-                          }
-                        >
-                          <SelectTrigger className="w-32">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="light">Claro</SelectItem>
-                            <SelectItem value="dark">Oscuro</SelectItem>
-                            <SelectItem value="auto">Auto</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-
-                      <div className="flex items-center justify-between">
-                        <div className="space-y-0.5">
-                          <Label>Animaciones</Label>
-                          <p className="text-sm text-muted-foreground">
-                            Mostrar animaciones en la interfaz
-                          </p>
-                        </div>
-                        <Switch
-                          checked={systemSettings.animations_enabled}
-                          onCheckedChange={checked =>
-                            setSystemSettings({
-                              ...systemSettings,
-                              animations_enabled: checked,
-                            })
-                          }
-                        />
-                      </div>
-
-                      <div className="flex items-center justify-between">
-                        <div className="space-y-0.5">
-                          <Label>Modo Mantenimiento</Label>
-                          <p className="text-sm text-muted-foreground">
-                            Desactivar acceso temporal al sistema
-                          </p>
-                        </div>
-                        <Switch
-                          checked={systemSettings.maintenance_mode}
-                          onCheckedChange={checked =>
-                            setSystemSettings({
-                              ...systemSettings,
-                              maintenance_mode: checked,
-                            })
-                          }
-                        />
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="flex justify-end pt-4">
-                    <Button onClick={handleSaveSystemSettings} disabled={isSaving}>
-                      {isSaving ? (
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      ) : (
-                        <Save className="w-4 h-4 mr-2" />
-                      )}
-                      {isSaving ? 'Guardando...' : 'Guardar Cambios'}
-                    </Button>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* ===== TAB: IGLESIA ===== */}
-        <TabsContent value="church" className="space-y-3 sm:space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Church className="w-5 h-5" />
-                Información de la Iglesia
-              </CardTitle>
-              <CardDescription>Datos generales de tu congregación</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6">
-              {churchInfo && (
-                <>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                    <div className="space-y-2">
-                      <Label htmlFor="church_name">Nombre de la Iglesia</Label>
-                      <Input
-                        id="church_name"
-                        value={churchInfo.name}
-                        onChange={e =>
-                          setChurchInfo({
-                            ...churchInfo,
-                            name: e.target.value,
-                          })
-                        }
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="pastor_name">Pastor Principal</Label>
-                      <Input
-                        id="pastor_name"
-                        value={churchInfo.pastor_name || ''}
-                        onChange={e =>
-                          setChurchInfo({
-                            ...churchInfo,
-                            pastor_name: e.target.value,
-                          })
-                        }
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="church_phone">Teléfono</Label>
-                      <Input
-                        id="church_phone"
-                        value={churchInfo.phone || ''}
-                        onChange={e =>
-                          setChurchInfo({
-                            ...churchInfo,
-                            phone: e.target.value,
-                          })
-                        }
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="church_email">Email</Label>
-                      <Input
-                        id="church_email"
-                        type="email"
-                        value={churchInfo.email || ''}
-                        onChange={e =>
-                          setChurchInfo({
-                            ...churchInfo,
-                            email: e.target.value,
-                          })
-                        }
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="church_website">Sitio Web</Label>
-                      <Input
-                        id="church_website"
-                        value={churchInfo.website || ''}
-                        onChange={e =>
-                          setChurchInfo({
-                            ...churchInfo,
-                            website: e.target.value,
-                          })
-                        }
-                      />
-                    </div>
-
-                    <div className="space-y-2 md:col-span-2">
-                      <Label htmlFor="church_address">Dirección</Label>
-                      <Textarea
-                        id="church_address"
-                        value={churchInfo.address || ''}
-                        onChange={e =>
-                          setChurchInfo({
-                            ...churchInfo,
-                            address: e.target.value,
-                          })
-                        }
-                        rows={2}
-                      />
-                    </div>
-
-                    <div className="space-y-2 md:col-span-2">
-                      <Label htmlFor="church_mission">Misión</Label>
-                      <Textarea
-                        id="church_mission"
-                        value={churchInfo.mission || ''}
-                        onChange={e =>
-                          setChurchInfo({
-                            ...churchInfo,
-                            mission: e.target.value,
-                          })
-                        }
-                        rows={3}
-                      />
-                    </div>
-
-                    <div className="space-y-2 md:col-span-2">
-                      <Label htmlFor="church_vision">Visión</Label>
-                      <Textarea
-                        id="church_vision"
-                        value={churchInfo.vision || ''}
-                        onChange={e =>
-                          setChurchInfo({
-                            ...churchInfo,
-                            vision: e.target.value,
-                          })
-                        }
-                        rows={3}
-                      />
-                    </div>
-                  </div>
-
-                  <Separator />
-
-                  {/* Logo y Branding */}
-                  <div className="space-y-4">
-                    <h3 className="text-lg font-semibold">Logo y Branding</h3>
-
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-                      {/* Logo */}
-                      <div className="space-y-2">
-                        <Label>Logo Principal</Label>
-                        <LogoUploader
-                          currentUrl={churchInfo.logo_url}
-                          type="logo"
-                          onUploadSuccess={url =>
-                            setChurchInfo({
-                              ...churchInfo,
-                              logo_url: url,
-                            })
-                          }
-                          onDeleteSuccess={() =>
-                            setChurchInfo({
-                              ...churchInfo,
-                              logo_url: null,
-                            })
-                          }
-                        />
-                      </div>
-
-                      {/* Colores */}
-                      <div className="space-y-4">
-                        <div className="space-y-2">
-                          <Label htmlFor="primary_color">Color Primario</Label>
-                          <div className="flex items-center gap-2">
-                            <input
-                              type="color"
-                              value={churchInfo.primary_color}
-                              onChange={e => {
-                                const next = { ...churchInfo, primary_color: e.target.value };
-                                setChurchInfo(next);
-                                applyBrandColors(next.primary_color, next.secondary_color);
-                              }}
-                              className="w-10 h-10 rounded-lg border cursor-pointer"
-                            />
-                            <Input
-                              id="primary_color"
-                              value={churchInfo.primary_color}
-                              onChange={e => {
-                                const next = { ...churchInfo, primary_color: e.target.value };
-                                setChurchInfo(next);
-                                if (/^#[0-9a-fA-F]{6}$/.test(e.target.value))
-                                  applyBrandColors(next.primary_color, next.secondary_color);
-                              }}
-                              placeholder="#1e40af"
-                              className="flex-1"
-                            />
-                          </div>
-                        </div>
-
-                        <div className="space-y-2">
-                          <Label htmlFor="secondary_color">Color Secundario</Label>
-                          <div className="flex items-center gap-2">
-                            <input
-                              type="color"
-                              value={churchInfo.secondary_color}
-                              onChange={e => {
-                                const next = { ...churchInfo, secondary_color: e.target.value };
-                                setChurchInfo(next);
-                                applyBrandColors(next.primary_color, next.secondary_color);
-                              }}
-                              className="w-10 h-10 rounded-lg border cursor-pointer"
-                            />
-                            <Input
-                              id="secondary_color"
-                              value={churchInfo.secondary_color}
-                              onChange={e => {
-                                const next = { ...churchInfo, secondary_color: e.target.value };
-                                setChurchInfo(next);
-                                if (/^#[0-9a-fA-F]{6}$/.test(e.target.value))
-                                  applyBrandColors(next.primary_color, next.secondary_color);
-                              }}
-                              placeholder="#fbbf24"
-                              className="flex-1"
-                            />
-                          </div>
-                        </div>
-
-                        {/* Live preview */}
-                        <div className="rounded-lg border p-4 space-y-3">
-                          <p className="text-xs text-muted-foreground font-medium">Vista previa</p>
-                          <div className="flex flex-wrap gap-2 items-center">
-                            <span
-                              className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-white"
-                              style={{ background: churchInfo.primary_color }}
-                            >
-                              Botón primario
-                            </span>
-                            <span
-                              className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium"
-                              style={{
-                                background: churchInfo.secondary_color,
-                                color: '#1a1a1a',
-                              }}
-                            >
-                              Botón secundario
-                            </span>
-                            <span
-                              className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold text-white"
-                              style={{ background: churchInfo.primary_color }}
-                            >
-                              Badge
-                            </span>
-                          </div>
-                          <div
-                            className="h-2 w-full rounded-full"
-                            style={{
-                              background: `linear-gradient(to right, ${churchInfo.primary_color}, ${churchInfo.secondary_color})`,
-                            }}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <Separator />
-
-                  {/* Redes Sociales */}
-                  <div className="space-y-4">
-                    <h3 className="text-lg font-semibold">Redes Sociales</h3>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2 md:gap-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="social_facebook">Facebook</Label>
-                        <Input
-                          id="social_facebook"
-                          value={churchInfo.social_facebook || ''}
-                          onChange={e =>
-                            setChurchInfo({
-                              ...churchInfo,
-                              social_facebook: e.target.value,
-                            })
-                          }
-                          placeholder="https://facebook.com/..."
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="social_instagram">Instagram</Label>
-                        <Input
-                          id="social_instagram"
-                          value={churchInfo.social_instagram || ''}
-                          onChange={e =>
-                            setChurchInfo({
-                              ...churchInfo,
-                              social_instagram: e.target.value,
-                            })
-                          }
-                          placeholder="https://instagram.com/..."
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="social_youtube">YouTube</Label>
-                        <Input
-                          id="social_youtube"
-                          value={churchInfo.social_youtube || ''}
-                          onChange={e =>
-                            setChurchInfo({
-                              ...churchInfo,
-                              social_youtube: e.target.value,
-                            })
-                          }
-                          placeholder="https://youtube.com/..."
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="social_twitter">Twitter/X</Label>
-                        <Input
-                          id="social_twitter"
-                          value={churchInfo.social_twitter || ''}
-                          onChange={e =>
-                            setChurchInfo({
-                              ...churchInfo,
-                              social_twitter: e.target.value,
-                            })
-                          }
-                          placeholder="https://twitter.com/..."
-                        />
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="flex justify-end pt-4">
-                    <Button onClick={handleSaveChurchInfo} disabled={isSaving}>
-                      {isSaving ? (
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      ) : (
-                        <Save className="w-4 h-4 mr-2" />
-                      )}
-                      {isSaving ? 'Guardando...' : 'Guardar Cambios'}
-                    </Button>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* ===== TAB: ZONAS ===== */}
-        <TabsContent value="zones" className="space-y-3 sm:space-y-6">
-          <ZoneManagement />
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Map className="w-5 h-5" />
-                Mapa de Células
-              </CardTitle>
-              <CardDescription>Visualiza la distribución geográfica de las células</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <DiscipleshipMap />
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* ===== TAB: NOTIFICACIONES ===== */}
-        <TabsContent value="notifications" className="space-y-3 sm:space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Bell className="w-5 h-5" />
-                Configuración de Notificaciones
-              </CardTitle>
-              <CardDescription>Gestiona cómo y cuándo enviar notificaciones</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6">
-              {notificationConfig && (
-                <>
-                  <div className="space-y-6">
-                    <div>
-                      <h3 className="text-lg font-semibold mb-4">Canales de Notificación</h3>
-                      <div className="space-y-4">
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-0.5">
-                            <Label>Email</Label>
-                            <p className="text-sm text-muted-foreground">
-                              Habilitar notificaciones por correo
-                            </p>
-                          </div>
-                          <Switch
-                            checked={notificationConfig.email_enabled}
-                            onCheckedChange={checked =>
-                              setNotificationConfig({
-                                ...notificationConfig,
-                                email_enabled: checked,
-                              })
-                            }
-                          />
-                        </div>
-
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-0.5">
-                            <Label>Push</Label>
-                            <p className="text-sm text-muted-foreground">
-                              Notificaciones en navegador/app
-                            </p>
-                          </div>
-                          <Switch
-                            checked={notificationConfig.push_enabled}
-                            onCheckedChange={checked =>
-                              setNotificationConfig({
-                                ...notificationConfig,
-                                push_enabled: checked,
-                              })
-                            }
-                          />
-                        </div>
-
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-0.5">
-                            <Label>SMS</Label>
-                            <p className="text-sm text-muted-foreground">
-                              Mensajes de texto (costo adicional)
-                            </p>
-                          </div>
-                          <Switch
-                            checked={notificationConfig.sms_enabled}
-                            onCheckedChange={checked =>
-                              setNotificationConfig({
-                                ...notificationConfig,
-                                sms_enabled: checked,
-                              })
-                            }
-                          />
-                        </div>
-                      </div>
-                    </div>
-
-                    <Separator />
-
-                    <div>
-                      <h3 className="text-lg font-semibold mb-4">Tipos de Notificación</h3>
-                      <div className="space-y-4">
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-0.5">
-                            <Label>Nuevos Registros</Label>
-                            <p className="text-sm text-muted-foreground">
-                              Notificar cuando se registre un nuevo usuario
-                            </p>
-                          </div>
-                          <Switch
-                            checked={notificationConfig.new_user_notifications}
-                            onCheckedChange={checked =>
-                              setNotificationConfig({
-                                ...notificationConfig,
-                                new_user_notifications: checked,
-                              })
-                            }
-                          />
-                        </div>
-
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-0.5">
-                            <Label>Cambios de Roles</Label>
-                            <p className="text-sm text-muted-foreground">
-                              Notificar cuando se modifiquen roles
-                            </p>
-                          </div>
-                          <Switch
-                            checked={notificationConfig.role_change_notifications}
-                            onCheckedChange={checked =>
-                              setNotificationConfig({
-                                ...notificationConfig,
-                                role_change_notifications: checked,
-                              })
-                            }
-                          />
-                        </div>
-
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-0.5">
-                            <Label>Recordatorios de Eventos</Label>
-                            <p className="text-sm text-muted-foreground">
-                              Recordatorios automáticos de eventos
-                            </p>
-                          </div>
-                          <Switch
-                            checked={notificationConfig.event_reminders}
-                            onCheckedChange={checked =>
-                              setNotificationConfig({
-                                ...notificationConfig,
-                                event_reminders: checked,
-                              })
-                            }
-                          />
-                        </div>
-                      </div>
-                    </div>
-
-                    <Separator />
-
-                    <p className="text-sm text-muted-foreground">
-                      Los correos del sistema se envían a través de un proveedor gestionado (Resend)
-                      — no requiere configuración SMTP.
-                    </p>
-                  </div>
-
-                  <div className="flex justify-end pt-4">
-                    <Button onClick={handleSaveNotificationConfig} disabled={isSaving}>
-                      {isSaving ? (
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      ) : (
-                        <Save className="w-4 h-4 mr-2" />
-                      )}
-                      {isSaving ? 'Guardando...' : 'Guardar Cambios'}
-                    </Button>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* ===== TAB: SEGURIDAD ===== */}
-        <TabsContent value="security" className="space-y-3 sm:space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Shield className="w-5 h-5" />
-                Seguridad del Sistema
-              </CardTitle>
-              <CardDescription>Configuraciones de seguridad y acceso</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6">
-              <div className="space-y-4">
-                <div className="flex items-center justify-between p-4 border rounded-lg">
-                  <div>
-                    <h4 className="font-medium">Registro de Usuarios</h4>
-                    <p className="text-sm text-muted-foreground">
-                      Permitir que nuevos usuarios se registren
-                    </p>
-                  </div>
-                  <Switch
-                    checked={systemSettings?.allow_registrations || false}
-                    onCheckedChange={checked =>
-                      systemSettings &&
-                      setSystemSettings({
-                        ...systemSettings,
-                        allow_registrations: checked,
-                      })
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between p-4 border rounded-lg">
-                  <div>
-                    <h4 className="font-medium">Tiempo de Sesión</h4>
-                    <p className="text-sm text-muted-foreground">
-                      Minutos de inactividad antes de cerrar sesión
-                    </p>
-                  </div>
-                  <Input
-                    type="number"
-                    className="w-24"
-                    value={systemSettings?.session_timeout_minutes || 60}
-                    onChange={e =>
-                      systemSettings &&
-                      setSystemSettings({
-                        ...systemSettings,
-                        session_timeout_minutes: parseInt(e.target.value) || 60,
-                      })
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between p-4 border rounded-lg">
-                  <div>
-                    <h4 className="font-medium">Máximo Usuarios por Grupo</h4>
-                    <p className="text-sm text-muted-foreground">
-                      Límite de miembros en grupos de discipulado
-                    </p>
-                  </div>
-                  <Input
-                    type="number"
-                    className="w-24"
-                    value={systemSettings?.max_users_per_group || 12}
-                    onChange={e =>
-                      systemSettings &&
-                      setSystemSettings({
-                        ...systemSettings,
-                        max_users_per_group: parseInt(e.target.value) || 12,
-                      })
-                    }
-                  />
-                </div>
-              </div>
-
-              <div className="flex justify-end pt-4">
-                <Button onClick={handleSaveSystemSettings} disabled={isSaving}>
-                  {isSaving ? (
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  ) : (
-                    <Save className="w-4 h-4 mr-2" />
-                  )}
-                  {isSaving ? 'Guardando...' : 'Guardar Cambios'}
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* ===== TAB: RESPALDOS ===== */}
-        <TabsContent value="backup" className="space-y-3 sm:space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Database className="w-5 h-5" />
-                Respaldos y Datos
-              </CardTitle>
-              <CardDescription>Gestión de respaldos del sistema</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 sm:space-y-6 p-2 sm:p-3 md:p-6">
-              <div className="rounded-lg border border-dashed p-6 text-center space-y-3">
-                <Database className="w-10 h-10 mx-auto text-muted-foreground/50" />
-                <div>
-                  <h4 className="font-medium">Respaldos en desarrollo</h4>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    La exportación e importación de datos estará disponible en una próxima versión.
-                    Por ahora, Supabase realiza respaldos automáticos diariamente.
-                  </p>
-                </div>
-                <Badge variant="outline">Supabase Backup: Activo</Badge>
-              </div>
-
-              <div className="p-4 bg-muted rounded-lg space-y-2">
-                <h4 className="font-medium text-sm">Información de respaldo</h4>
-                <ul className="text-sm text-muted-foreground space-y-1 list-disc list-inside">
-                  <li>Respaldo automático cada 24 horas vía Supabase</li>
-                  <li>Retención de 7 días en plan gratuito</li>
-                  <li>Restauración disponible desde el panel de Supabase</li>
-                </ul>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
+        {SECTIONS.map(section => (
+          <TabsContent key={section.key} value={section.key} className="space-y-3 sm:space-y-6">
+            {sectionContent[section.key]}
+          </TabsContent>
+        ))}
       </Tabs>
     </div>
   );


### PR DESCRIPTION
## Resumen

- **Bug real**: `MobileSegment`/`MobileSectionHeader`/`MobileScreen` renderizaban `<button>` sin `type="button"` — dentro de un `<form>` (edición de usuario en mobile) cualquier tab de sección disparaba el submit automático sin dejar editar.
- **Configuración, Roles, Gestión de Roles, Gestión de Módulos**: no tenían ningún manejo mobile (sin header, sin back). Ahora usan `MobileScreen`; Configuración pasa de 6 tabs comprimidos a lista drill-down.
- **Mapa** (Discipulado→Mapa, Zonas→Mapa): tiles CARTO minimalistas → OpenStreetMap estándar (calles/manzanas reales). El mapa de Discipulado no tenía mobile: ahora es pantalla completa con toggles flotantes y un Drawer para filtrar por zona.
- **Música**: la pantalla "Equipo" apilaba Integrantes + Instrumentos en el mismo scroll, y el FAB "Nuevo culto" tapaba contenido en pantallas donde no correspondía. Ahora son 2 pantallas propias y el FAB está condicionado.
- **GroupMembers**: selección múltiple en "Agregar Miembro", diálogos Dialog→Drawer en mobile.
- **Avatares**: `getAvatarColor()` (hash → paleta) reemplaza dicebear en 4 pantallas — consistente y sin depender de una API externa para listas de 500+ usuarios.
- Corrige tipados `any` preexistentes en `PersonalDashboard`/`ModulesManagementPage` que bloqueaban el pre-commit hook.
- `scripts/seed-reports-attendance.mjs`: seed local (solo apunta a `127.0.0.1:54322`) para poblar reportes/asistencia y que las gráficas del dashboard tengan data en un ambiente recién levantado.

## Test plan
- [x] `tsc --noEmit` limpio en cada paso
- [x] Suite completa (138 tests frontend + Go build/test) verde en el pre-push hook
- [x] Verificado en vivo en viewport mobile: edición de usuario (bug de auto-submit), Configuración (drill-down), Roles/Gestión de Roles (Drawer de Asignar Rol), Gestión de Módulos, Mapa (tiles + Drawer de zonas), Música (Integrantes/Instrumentos separados, FAB condicionado)