### PR TITLE
feat(provider): borrado automático de datos de tenants cancelados

### DIFF
--- a/apps/backend-go/handlers/provider.go
+++ b/apps/backend-go/handlers/provider.go
@@ -399,6 +399,9 @@ func (h *ProviderHandler) SetModule(c echo.Context) error {
 }
 
 // setTenantStatus is the shared implementation for Suspend/Reactivate.
+// Reactivate también limpia cancelled_at: si el tenant vuelve a 'active'
+// dentro del período de gracia, StartTenantPurgeScheduler ya lo excluye por
+// status, pero limpiar el timestamp evita un rastro confuso en la tabla.
 func (h *ProviderHandler) setTenantStatus(c echo.Context, status string) error {
 	tenantID := c.Param("id")
 	db := config.GetDB()
@@ -406,7 +409,11 @@ func (h *ProviderHandler) setTenantStatus(c echo.Context, status string) error {
 		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "database connection not available"})
 	}
 
-	res, err := db.DB.Exec(`UPDATE public.churches SET status = $1, updated_at = NOW() WHERE id = $2`, status, tenantID)
+	query := `UPDATE public.churches SET status = $1, updated_at = NOW() WHERE id = $2`
+	if status == "active" {
+		query = `UPDATE public.churches SET status = $1, cancelled_at = NULL, updated_at = NOW() WHERE id = $2`
+	}
+	res, err := db.DB.Exec(query, status, tenantID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update tenant status"})
 	}
@@ -429,4 +436,34 @@ func (h *ProviderHandler) Suspend(c echo.Context) error {
 // Reactivate handles POST /provider/tenants/:id/reactivate.
 func (h *ProviderHandler) Reactivate(c echo.Context) error {
 	return h.setTenantStatus(c, "active")
+}
+
+// Cancel handles POST /provider/tenants/:id/cancel. Marca el tenant como
+// cancelado y arranca el período de gracia (TenantPurgeGraceDays, ver
+// scheduler.go) antes del borrado automático de sus datos. Reactivate
+// dentro del período de gracia cancela el borrado.
+func (h *ProviderHandler) Cancel(c echo.Context) error {
+	tenantID := c.Param("id")
+	db := config.GetDB()
+	if db == nil || db.DB == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "database connection not available"})
+	}
+
+	res, err := db.DB.Exec(`
+		UPDATE public.churches
+		SET status = 'cancelled', cancelled_at = NOW(), updated_at = NOW()
+		WHERE id = $1
+	`, tenantID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to cancel tenant"})
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to confirm update"})
+	}
+	if rows == 0 {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "tenant not found"})
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }

--- a/apps/backend-go/handlers/scheduler.go
+++ b/apps/backend-go/handlers/scheduler.go
@@ -36,6 +36,85 @@ func StartWeeklyReportScheduler() {
 	}()
 }
 
+// TenantPurgeGraceDays: días desde que un tenant queda status='cancelled'
+// hasta que StartTenantPurgeScheduler borra sus datos automáticamente.
+// Decisión de negocio, no técnica — 30 días es el default de la industria.
+const TenantPurgeGraceDays = 30
+
+// tenantPurgeCheckInterval: cada cuánto corre el chequeo. Diario alcanza —
+// no hace falta más granularidad para un borrado con 30 días de margen.
+const tenantPurgeCheckInterval = 24 * time.Hour
+
+// StartTenantPurgeScheduler lanza la goroutine que, una vez por día, busca
+// tenants cancelados hace más de TenantPurgeGraceDays y todavía no
+// purgados, y les borra los datos (purgeChurchData) dentro de una
+// transacción. Si algo falla en un tenant, loguea y sigue con el resto —
+// un tenant con error no bloquea el borrado de los demás.
+func StartTenantPurgeScheduler() {
+	go func() {
+		for {
+			db := config.GetDB()
+			if db == nil || db.DB == nil {
+				log.Println("[scheduler] purga de tenants: DB no disponible, omitiendo")
+			} else if err := runTenantPurgeSweep(db.DB); err != nil {
+				log.Printf("[scheduler] error en sweep de purga de tenants: %v", err)
+			}
+			time.Sleep(tenantPurgeCheckInterval)
+		}
+	}()
+}
+
+// runTenantPurgeSweep busca churches elegibles y las purga una por una.
+func runTenantPurgeSweep(db *sql.DB) error {
+	rows, err := db.Query(`
+		SELECT id, name FROM public.churches
+		WHERE status = 'cancelled'
+		  AND cancelled_at IS NOT NULL
+		  AND cancelled_at <= NOW() - ($1 || ' days')::interval
+		  AND deleted_at IS NULL
+	`, TenantPurgeGraceDays)
+	if err != nil {
+		return fmt.Errorf("runTenantPurgeSweep: query candidates: %w", err)
+	}
+
+	type candidate struct{ id, name string }
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if scanErr := rows.Scan(&c.id, &c.name); scanErr == nil {
+			candidates = append(candidates, c)
+		}
+	}
+	if closeErr := rows.Close(); closeErr != nil {
+		return fmt.Errorf("runTenantPurgeSweep: closing rows: %w", closeErr)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("runTenantPurgeSweep: iterating candidates: %w", err)
+	}
+
+	for _, c := range candidates {
+		counts, purgeErr := purgeChurchData(db, c.id)
+		if purgeErr != nil {
+			log.Printf("[scheduler] purga de tenant %s (%s) falló, NO se borró nada: %v", c.id, c.name, purgeErr)
+			continue
+		}
+
+		var totalRows int64
+		for _, n := range counts {
+			totalRows += n
+		}
+
+		if _, err := db.Exec(`UPDATE public.churches SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1`, c.id); err != nil {
+			log.Printf("[scheduler] tenant %s (%s): datos purgados (%d filas) pero no se pudo marcar deleted_at: %v", c.id, c.name, totalRows, err)
+			continue
+		}
+
+		log.Printf("[scheduler] tenant %s (%s) purgado: %d filas borradas en %d tablas", c.id, c.name, totalRows, len(counts))
+	}
+
+	return nil
+}
+
 // nextSaturdayAt23 returns the next Saturday at 23:00 local time after `from`.
 // If `from` is already Saturday but before 23:00, it returns today's 23:00.
 // If `from` is Saturday at or after 23:01, it returns next Saturday's 23:00.

--- a/apps/backend-go/handlers/tenant_purge.go
+++ b/apps/backend-go/handlers/tenant_purge.go
@@ -1,0 +1,103 @@
+// Package handlers — borrado automático de datos de un tenant cancelado.
+//
+// Disparado por StartTenantPurgeScheduler (scheduler.go) cuando un tenant
+// lleva TenantPurgeGraceDays en status='cancelled'. Borra TODA la data
+// personal de la iglesia (usuarios, discipulado, música, zonas, reportes,
+// etc.) y deja el registro en churches como tombstone (id/name/status,
+// deleted_at seteado) para trazabilidad — sin datos personales de sus
+// miembros.
+//
+// El orden de los DELETE respeta las foreign keys reales de la base (ver
+// información obtenida de information_schema, no supuesta) — pero la
+// seguridad real viene de que todo corre en UNA transacción: si algo falla
+// en cualquier paso, no se borra nada. Nunca hay un borrado parcial.
+package handlers
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// tenantPurgeTables lista, EN ORDEN, las tablas con church_id a vaciar antes
+// de tocar users/zones. El orden dentro de cada grupo no importa entre sí;
+// lo que importa es que un grupo completo termine antes de que empiece el
+// siguiente (evita violar foreign keys entre estas tablas).
+var tenantPurgeTables = [][]string{
+	// Grupo 1: hojas del árbol de dependencias — nada más las referencia.
+	{
+		"audit_logs", "goal_manual_progress", "discipleship_group_members",
+		"discipleship_attendance", "event_registrations", "music_assignments",
+		"music_event_songs", "music_unavailability", "module_user_roles",
+		"notifications", "report_generations", "reports", "user_permissions",
+		"discipleship_alerts", "discipleship_hierarchy",
+		// Sin foreign key detectada hacia otra tabla de este tenant — se
+		// pueden borrar en cualquier momento, van acá por prolijidad.
+		"church_info", "modules", "system_settings", "notification_config",
+		"settings_audit_log", "role_module_access", "federated_sessions_log",
+		"user_invitations", "user_preferences", "user_profiles",
+		"cell_multiplication_tracking", "discipleship_levels",
+		"access_denied_logs", "music_telegram_files", "live_streams",
+		"report_compliance",
+	},
+	// Grupo 2: dependen de algo del grupo 1.
+	{
+		"goal_assignments", "events", "music_members", "music_events",
+		"music_songs", "discipleship_groups",
+	},
+	// Grupo 3: dependen de algo del grupo 2 (y de zones, que se borra después).
+	{"discipleship_goals", "discipleship_reports"},
+}
+
+// purgeChurchData borra todos los datos de una iglesia dentro de una sola
+// transacción. Devuelve cuántas filas se borraron por tabla — para el log
+// de auditoría ("borramos X filas de Y tablas el día Z"). No borra la fila
+// de churches: eso lo hace el caller, convirtiéndola en tombstone.
+func purgeChurchData(db *sql.DB, churchID string) (map[string]int64, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("purgeChurchData: begin tx: %w", err)
+	}
+	defer tx.Rollback() // no-op si ya se hizo Commit
+
+	counts := make(map[string]int64)
+
+	for _, group := range tenantPurgeTables {
+		for _, table := range group {
+			res, err := tx.Exec(fmt.Sprintf(`DELETE FROM public.%s WHERE church_id = $1`, table), churchID)
+			if err != nil {
+				return nil, fmt.Errorf("purgeChurchData: delete from %s: %w", table, err)
+			}
+			n, _ := res.RowsAffected()
+			counts[table] = n
+		}
+	}
+
+	// zones <-> users es circular (zones.supervisor_id -> users,
+	// users.zone_id -> zones): hay que romper la referencia antes de poder
+	// borrar cualquiera de las dos.
+	if _, err := tx.Exec(`UPDATE public.users SET zone_id = NULL WHERE church_id = $1`, churchID); err != nil {
+		return nil, fmt.Errorf("purgeChurchData: unlink users.zone_id: %w", err)
+	}
+	if _, err := tx.Exec(`UPDATE public.zones SET supervisor_id = NULL WHERE church_id = $1`, churchID); err != nil {
+		return nil, fmt.Errorf("purgeChurchData: unlink zones.supervisor_id: %w", err)
+	}
+
+	res, err := tx.Exec(`DELETE FROM public.users WHERE church_id = $1`, churchID)
+	if err != nil {
+		return nil, fmt.Errorf("purgeChurchData: delete from users: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	counts["users"] = n
+
+	res, err = tx.Exec(`DELETE FROM public.zones WHERE church_id = $1`, churchID)
+	if err != nil {
+		return nil, fmt.Errorf("purgeChurchData: delete from zones: %w", err)
+	}
+	n, _ = res.RowsAffected()
+	counts["zones"] = n
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("purgeChurchData: commit: %w", err)
+	}
+	return counts, nil
+}

--- a/apps/backend-go/handlers/tenant_purge_test.go
+++ b/apps/backend-go/handlers/tenant_purge_test.go
@@ -1,0 +1,96 @@
+package handlers
+
+// tenant_purge_test.go — Integration test for purgeChurchData.
+//
+// Corre solo con TEST_DATABASE_URL seteada (mismo patrón que compliance_test.go).
+// Verifica lo que realmente importa acá porque el borrado es irreversible:
+//   1. La referencia circular zones<->users no rompe la transacción.
+//   2. Se borra TODO lo del tenant purgado (incluyendo una tabla de cada
+//      "capa" de dependencias: hoja, media, alta).
+//   3. Un tenant de control, sin relación, queda completamente intacto.
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestPurgeChurchData(t *testing.T) {
+	db := openTestDB(t)
+
+	// Tenant a purgar: zona + usuario con referencia circular
+	// (zone.supervisor_id -> user, user.zone_id -> zone), un grupo (capa
+	// media) y un reporte (capa alta) — ejercitan las tres capas del
+	// orden de borrado, no solo el caso fácil.
+	churchA := seedChurch(t, db, "Purge Target Co")
+	userA := seedUser(t, db, churchA, "purge-target@test.local")
+	zoneA := seedZone(t, db, churchA, "Zona a Purgar")
+	if _, err := db.Exec(`UPDATE users SET zone_id = $1 WHERE id = $2`, zoneA, userA); err != nil {
+		t.Fatalf("link user to zone: %v", err)
+	}
+	if _, err := db.Exec(`UPDATE zones SET supervisor_id = $1 WHERE id = $2`, userA, zoneA); err != nil {
+		t.Fatalf("link zone to supervisor (referencia circular): %v", err)
+	}
+	groupA := seedGroup(t, db, churchA, zoneA, userA, "Grupo a Purgar")
+	reportA := seedDiscipleshipReport(t, db, churchA, userA, 5, 2)
+	_ = groupA
+	_ = reportA
+
+	// Tenant de control: no debe verse afectado por la purga de churchA.
+	churchB := seedChurch(t, db, "Control Co (no tocar)")
+	userB := seedUser(t, db, churchB, "control@test.local")
+	zoneB := seedZone(t, db, churchB, "Zona de Control")
+	t.Cleanup(func() {
+		db.Exec(`DELETE FROM churches WHERE id IN ($1, $2)`, churchA, churchB)
+	})
+
+	counts, err := purgeChurchData(db, churchA)
+	if err != nil {
+		t.Fatalf("purgeChurchData falló — con la transacción, esto significa que NO se borró nada: %v", err)
+	}
+
+	if counts["users"] != 1 {
+		t.Errorf("esperaba 1 usuario borrado de churchA, borró %d", counts["users"])
+	}
+	if counts["zones"] != 1 {
+		t.Errorf("esperaba 1 zona borrada de churchA, borró %d", counts["zones"])
+	}
+	if counts["discipleship_groups"] != 1 {
+		t.Errorf("esperaba 1 grupo borrado de churchA, borró %d", counts["discipleship_groups"])
+	}
+	if counts["discipleship_reports"] != 1 {
+		t.Errorf("esperaba 1 reporte borrado de churchA, borró %d", counts["discipleship_reports"])
+	}
+
+	assertZeroRows(t, db, "users", churchA)
+	assertZeroRows(t, db, "zones", churchA)
+	assertZeroRows(t, db, "discipleship_groups", churchA)
+	assertZeroRows(t, db, "discipleship_reports", churchA)
+
+	// El tenant de control tiene que seguir intacto — el bug más caro acá
+	// sería un WHERE mal armado que se lleve puesto a alguien más.
+	assertOneRow(t, db, "users", churchB, userB)
+	assertOneRow(t, db, "zones", churchB, zoneB)
+}
+
+func assertZeroRows(t *testing.T, db *sql.DB, table, churchID string) {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE church_id = $1`, churchID).Scan(&n); err != nil {
+		t.Fatalf("assertZeroRows(%s): %v", table, err)
+	}
+	if n != 0 {
+		t.Errorf("%s: esperaba 0 filas para el tenant purgado, quedaron %d", table, n)
+	}
+}
+
+func assertOneRow(t *testing.T, db *sql.DB, table, churchID, expectID string) {
+	t.Helper()
+	var id string
+	err := db.QueryRow(`SELECT id FROM `+table+` WHERE church_id = $1`, churchID).Scan(&id)
+	if err != nil {
+		t.Fatalf("assertOneRow(%s): tenant de control perdió su fila — la purga se llevó puesto algo que no debía: %v", table, err)
+	}
+	if id != expectID {
+		t.Errorf("%s: id inesperado %q (esperaba %q)", table, id, expectID)
+	}
+}

--- a/apps/backend-go/main.go
+++ b/apps/backend-go/main.go
@@ -179,6 +179,9 @@ func main() {
 	// Start background scheduler (weekly report check every Tuesday 8am)
 	handlers.StartWeeklyReportScheduler()
 
+	// Borrado automático de datos de tenants cancelados (30 días de gracia)
+	handlers.StartTenantPurgeScheduler()
+
 	// Start Telegram channel ingestion for the Music module (no-op if unconfigured)
 	handlers.StartTelegramIngestion()
 

--- a/apps/backend-go/routes/routes.go
+++ b/apps/backend-go/routes/routes.go
@@ -63,6 +63,7 @@ func SetupRoutes(e *echo.Echo) {
 	provider.POST("/tenants/:id/modules", providerHandler.SetModule)
 	provider.POST("/tenants/:id/suspend", providerHandler.Suspend)
 	provider.POST("/tenants/:id/reactivate", providerHandler.Reactivate)
+	provider.POST("/tenants/:id/cancel", providerHandler.Cancel)
 
 	// El mismo secreto de servicio también gatea el onboarding self-service
 	// (decisión del usuario, ver sdd/provider-api/design Decisión 5): deja

--- a/docs/INSUMO_LEGAL_SAAS.md
+++ b/docs/INSUMO_LEGAL_SAAS.md
@@ -1,0 +1,117 @@
+# Insumo técnico para ToS, EULA, Política de Privacidad y SLA — SionERP
+
+> Este documento NO es un contrato ni tiene validez legal. Es el insumo técnico/factual — verificado contra el código real, no inventado — para que tu abogado redacte los cuatro documentos (Términos de Servicio, EULA, Política de Privacidad y Protección de Datos, SLA) sobre una base precisa de lo que SionERP hace hoy.
+
+**Empresa que comercializa**: constituida en Venezuela.
+**Mercado inicial**: iglesias en Venezuela, con expansión a otros países de LATAM sin definir todavía.
+
+---
+
+## 1. Qué es el producto (para el ToS/EULA)
+
+SionERP es un sistema de gestión eclesiástica (SaaS, facturación mensual) para iglesias: administración de miembros, discipulado/células, zonas geográficas, eventos, reportes y (opcional) gestión de equipo de alabanza. Se vende por **módulos activables** — el cliente paga por lo que usa (Discipulado, Eventos, Reportes Avanzados, Música, etc.), el módulo Base (usuarios, roles, configuración) siempre está incluido.
+
+Cada iglesia cliente es un **tenant** (inquilino) — importante para el ToS: quién es "el cliente" (la iglesia, representada por su administrador) y quién es "el usuario final" (cada miembro/líder con una cuenta dentro de esa iglesia) son roles legalmente distintos, relevante para el EULA.
+
+---
+
+## 2. Arquitectura de datos real (importante — corrige un documento interno desactualizado)
+
+El `CLAUDE.md` del proyecto todavía describe la decisión de arquitectura original ("una base de datos PostgreSQL por iglesia, aislamiento físico total"). **Esa ya no es la arquitectura real.** Verificado contra el código de esta sesión (decenas de handlers backend, todos con el mismo patrón `WHERE church_id = $N`) y contra el proyecto Supabase de producción:
+
+- **Es una base de datos compartida, con aislamiento lógico por fila** (`church_id` en cada tabla + Row Level Security de Postgres), no una base física separada por iglesia.
+- El acceso a cada request pasa por un middleware que fuerza el scope al `church_id` del usuario autenticado.
+
+Esto **no es necesariamente peor** para el cliente (RLS bien implementado es un estándar de la industria, lo usan la mayoría de los SaaS multi-tenant), pero la Política de Privacidad y el SLA tienen que describir el aislamiento **como es** ("aislamiento lógico mediante políticas de seguridad a nivel de fila, reforzado por middleware de autorización") y no como "base de datos físicamente separada por cliente", porque esa segunda frase sería una afirmación falsa con consecuencias si alguna vez hay un incidente de seguridad.
+
+---
+
+## 3. Inventario de datos personales recolectados
+
+Campos que el sistema efectivamente guarda sobre las personas (miembros de la iglesia), verificado contra el modelo real (`users` + tablas de discipulado/música):
+
+**Identificación y contacto**: nombre, apellido, cédula/documento de identidad, email, teléfono, WhatsApp (sí/no), dirección física.
+
+**Datos demográficos**: fecha de nacimiento, estado civil, ocupación, nivel educativo.
+
+**Datos religiosos/eclesiásticos** — ⚠️ en la mayoría de los marcos de protección de datos (GDPR, y por extensión buena parte de la doctrina LATAM) esto se trata como **categoría especial/sensible**, con requisitos de consentimiento reforzado: estado de bautismo y fecha, "cómo conoció la iglesia", interés en ministerio, grupo celular, notas pastorales (texto libre — potencialmente el campo más sensible de todo el sistema, lo carga el pastor/staff sobre un miembro), nivel jerárquico de discipulado.
+
+**Geolocalización**: coordenadas de check-in (usuarios y grupos/células), usadas para el mapa. Esto es dato de ubicación, sensible en la mayoría de los marcos.
+
+**Datos de uso/operación**: asistencia a reuniones/cultos, reportes semanales de líderes, auditoría de cambios (triggers de auditoría activos sobre las tablas más críticas: alertas, metas, reportes, perfiles de usuario).
+
+**Contacto de emergencia**: nombre y teléfono de un tercero (la persona de emergencia no es usuaria del sistema — dato de un tercero recolectado indirectamente, punto que tu abogado va a querer mirar).
+
+**Módulo Música (si el cliente lo activa)**: instrumento que toca cada integrante, disponibilidad/indisponibilidad declarada por fecha.
+
+---
+
+## 4. Terceros que procesan datos (subencargados del tratamiento)
+
+Confirmado en el código y en la config de despliegue:
+
+- **Supabase** — base de datos (Postgres), autenticación (JWT) y backups. ⚠️ Falta confirmar con precisión la región del proyecto de Supabase en uso (US/EU/otra) — esto determina si hay transferencia internacional de datos, dato que tu abogado necesita para la Política de Privacidad.
+- **Vercel** — hosting del frontend (despliegue confirmado activo en este repo).
+- **Resend** — envío de emails transaccionales (invitaciones, notificaciones). Confirmado en `apps/backend-go/emails/service.go` y `config/email.go`.
+- **SMS**: hay un toggle de "notificaciones por SMS" en Configuración, pero **no hay ningún proveedor de SMS integrado en el código** (no hay Twilio ni equivalente) — es una opción de UI sin funcionalidad real todavía. No debería aparecer como subencargado activo hasta que se implemente.
+
+---
+
+## 5. Medidas de seguridad técnicas ya implementadas
+
+Para el SLA y la sección de seguridad de la Política de Privacidad, esto SÍ está confirmado en producción:
+
+- HTTPS forzado + HSTS (1 año, vía middleware `Secure` de Echo) — todo el tráfico rechaza HTTP plano.
+- Autenticación JWT vía Supabase Auth.
+- Row Level Security a nivel de base de datos + middleware de autorización por rol/jerarquía en cada endpoint.
+- Comparación de claves de API en tiempo constante (`crypto/subtle.ConstantTimeCompare`) para la integración con terceros (Provider API).
+- Triggers de auditoría en las tablas de negocio más críticas (alertas, metas, reportes, perfiles).
+- Backups automáticos diarios vía Supabase (**retención de 7 días si el plan es el gratuito** — esto es un dato de negocio, no técnico: si van a vender con una promesa de retención de backup mayor a 7 días, hay que confirmar en qué plan de Supabase está corriendo producción).
+
+---
+
+## 6. Borrado automático de datos (implementado 2026-08-11)
+
+**Ya no es una promesa a futuro — está construido y probado.** Cuando una iglesia se da de baja:
+
+1. Provider API marca el tenant como `status = 'cancelled'`, `cancelled_at = NOW()` (`POST /provider/tenants/:id/cancel`).
+2. Un scheduler corre una vez por día (`StartTenantPurgeScheduler`, `apps/backend-go/handlers/scheduler.go`) y busca tenants cancelados hace más de **30 días** (`TenantPurgeGraceDays` — período de gracia elegido por el negocio, no una restricción técnica, se puede ajustar) que todavía no fueron purgados.
+3. Para cada uno, `purgeChurchData` borra en una sola transacción TODOS los datos de esa iglesia — las 42 tablas con `church_id` de la base (usuarios, discipulado, música, zonas, reportes, auditoría, todo). Si algo falla en el medio, la transacción entera se revierte: nunca queda un borrado parcial.
+4. La fila de `churches` NO se borra — queda como tombstone (id/name/status/`deleted_at`) para poder demostrar auditoría: "esta iglesia canceló el [fecha], sus datos se borraron el [fecha]". El tombstone no contiene datos personales de ningún miembro.
+5. Si la iglesia se reactiva dentro de los 30 días (`POST /provider/tenants/:id/reactivate`), el borrado se cancela — vuelve a `status='active'` y el scheduler la excluye.
+
+Verificado con un test de integración real (`tenant_purge_test.go`) contra la base: borra todo lo del tenant cancelado, no toca ni una fila de otro tenant.
+
+**Para el ToS/Política de Privacidad**: ahora sí podés prometer un plazo concreto de borrado post-cancelación (30 días desde la cancelación formal). Lo que tu abogado todavía tiene que definir es si ese número (30 días) es el que quieren comprometer contractualmente, o si prefieren dejarlo en un rango ("hasta 30 días") por margen operativo.
+
+**Lo que sigue sin existir**: un endpoint de **exportación** de datos (portabilidad) — si el contrato promete "exportá tu información cuando quieras", hoy eso todavía se resuelve manualmente vía soporte, no self-service. Tampoco hay un "reporte de todos mis datos" para que un usuario final lo pida directamente desde la app (aunque las tablas críticas sí tienen auditoría de cambios).
+
+---
+
+## 7. Ciclo de vida de cuenta (para el ToS)
+
+- Alta de una iglesia: vía Provider API (`CreateTenant`), con link de activación por email (dinámico, dominio configurable vía `FRONTEND_URL`).
+- Cada iglesia tiene `status` (activo/suspendido) y `plan` — existe endpoint de **suspensión y reactivación** de tenant (relevante para la cláusula de "qué pasa si no pagás").
+- Un tenant suspendido bloquea el login de sus usuarios (verificado en `middleware/auth.go`).
+- Activación/registro de usuarios finales dentro de una iglesia: por invitación (con el mismo modal, ya sea invitación directa o automática al asignarlos a un módulo).
+
+---
+
+## 8. Contexto legal de Venezuela — para que tu abogado lo tenga presente
+
+Esto no es asesoría legal, es contexto que como no-abogado me parece relevante no omitir: Venezuela **no tiene todavía una ley integral de protección de datos personales** equivalente al GDPR europeo o a la LGPD brasileña. La protección hoy se apoya principalmente en el derecho constitucional de **habeas data** (Art. 28 CRBV) y en normativa sectorial dispersa, no en un estatuto único y detallado. Esto le da a tu abogado más libertad para definir contractualmente los términos (porque hay menos un piso legal obligatorio que replicar), pero también significa que si en algún momento venden a iglesias en países con marcos más estrictos (México con su LFPDPPP, Colombia con su Ley 1581, o cualquier país con ley tipo GDPR), la Política de Privacidad va a necesitar una capa adicional específica para esos mercados — no alcanza con una sola política genérica LATAM.
+
+---
+
+## 9. Lo que queda 100% en manos de tu abogado (no technical input posible)
+
+- Jurisdicción y mecanismo de resolución de disputas (tribunales vs. arbitraje).
+- Moneda de facturación y tratamiento de mora/cancelación.
+- Límites de responsabilidad e indemnización.
+- Redacción exacta del consentimiento reforzado para los datos religiosos/sensibles (punto 3).
+- El plazo de retención post-cancelación ya está definido e implementado (30 días, punto 6) — lo que falta es la redacción contractual exacta y si van a comprometerlo como número fijo o como máximo. Sigue abierto qué pasa con los **backups** de Supabase de una iglesia dada de baja (el borrado alcanza las tablas en vivo, no necesariamente copias de backup ya tomadas antes del borrado — confirmar con Supabase cuál es su propia política de retención/purga de backups).
+- Si van a requerir un DPA (Data Processing Agreement) formal con Supabase/Vercel/Resend, más allá de sus ToS estándar como proveedores.
+
+---
+
+*Generado a partir de una revisión directa del código de SionERP (branch `develop`, commit `2c63073`) — no de la documentación interna del proyecto, que en el punto 2 estaba desactualizada.*

--- a/supabase/migrations/20260811000001_tenant_cancellation_lifecycle.sql
+++ b/supabase/migrations/20260811000001_tenant_cancellation_lifecycle.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Migration: 20260811000001_tenant_cancellation_lifecycle.sql
+-- Ciclo de cancelación de tenant: distingue "suspendido" (temporal, ej. mora)
+-- de "cancelado" (el cliente se va) y deja rastro de cuándo se borraron los
+-- datos, para el borrado automático con período de gracia.
+-- =============================================================================
+
+ALTER TABLE public.churches
+    ADD COLUMN IF NOT EXISTS cancelled_at timestamptz,
+    ADD COLUMN IF NOT EXISTS deleted_at   timestamptz;
+
+COMMENT ON COLUMN public.churches.cancelled_at IS
+    'Cuándo se marcó el tenant como cancelado (status=cancelled). El borrado automático de datos se dispara N días después de esta fecha — ver StartTenantPurgeScheduler.';
+COMMENT ON COLUMN public.churches.deleted_at IS
+    'Cuándo se ejecutó el borrado automático de los datos del tenant. NULL = todavía no se borró. Una vez seteado, el tenant queda como tombstone (solo id/name/status para trazabilidad, sin datos personales de sus usuarios).';


### PR DESCRIPTION
## Resumen

Parte del trabajo de preparar SionERP para venderse como SaaS mensual: `docs/INSUMO_LEGAL_SAAS.md` (insumo técnico para que el abogado del cliente redacte ToS/EULA/Política de Privacidad/SLA) había marcado como hueco real que no existía forma de cumplir una promesa de "borramos tus datos si cancelás". Este PR lo cierra.

- **Migración**: `churches` +`cancelled_at`, +`deleted_at`.
- **`POST /provider/tenants/:id/cancel`**: marca `status=cancelled`, arranca el período de gracia de 30 días. `Reactivate` (ya existía) lo cancela y limpia `cancelled_at`.
- **`purgeChurchData`**: borra TODA la data de una iglesia — verifiqué contra la base real que son 42 tablas con `church_id` — en una sola transacción. Si algo falla, no se borra nada (nunca hay borrado parcial). Rompe explícitamente la referencia circular `zones.supervisor_id <-> users.zone_id` antes de borrar (si no, ninguna de las dos se puede borrar). La fila de `churches` queda como tombstone sin datos personales, para trazabilidad.
- **`StartTenantPurgeScheduler`**: corre 1 vez por día, purga tenants cancelados hace más de 30 días (`TenantPurgeGraceDays`, ajustable) sin `deleted_at` todavía.
- Actualicé `docs/INSUMO_LEGAL_SAAS.md` con el borrado ya implementado (antes decía "no existe todavía") y con la corrección de que la arquitectura actual es una sola DB compartida con RLS, no una DB por iglesia (para que el ToS describa el aislamiento como es).

## Test plan
- [x] `go build ./...` y `go vet ./...` limpios
- [x] Test de integración real contra Postgres (`tenant_purge_test.go`, `TEST_DATABASE_URL` local): verifica las 3 capas de dependencias + la referencia circular zones/users + que un tenant de control no se ve afectado — pasa.
- [x] `go test ./...` completo verde (incluye el nuevo test)
- [x] Suite de frontend (138 tests) + build de Go en verde en el pre-push hook