### PR TITLE
fix(dashboard,music): aisla actividad reciente por tenant y oculta Música sin membresía

### DIFF
--- a/apps/backend-go/handlers/dashboard.go
+++ b/apps/backend-go/handlers/dashboard.go
@@ -193,7 +193,11 @@ func (h *DashboardHandler) GetRoleDistribution(c echo.Context) ([]models.RoleDis
 }
 
 func (h *DashboardHandler) GetRecentActivity(c echo.Context) ([]models.RecentActivity, error) {
+	churchID, _ := c.Get("church_id").(string)
+
 	// Usar LEFT JOIN para capturar registros donde changed_by es NULL (ej: seed data)
+	// church_id scoping: audit_logs es multi-tenant (ver phase2b_tenant_schema_group_b) —
+	// sin este WHERE, cada dashboard mostraba actividad de TODAS las iglesias.
 	query := `
 		SELECT
 			a.id,
@@ -204,11 +208,12 @@ func (h *DashboardHandler) GetRecentActivity(c echo.Context) ([]models.RecentAct
 			a.changed_at
 		FROM audit_logs a
 		LEFT JOIN users u ON a.changed_by = u.id
+		WHERE a.church_id = $1
 		ORDER BY a.changed_at DESC
 		LIMIT 10
 	`
 
-	rows, err := config.GetDB().DB.Query(query)
+	rows, err := config.GetDB().DB.Query(query, churchID)
 	if err != nil {
 		return nil, err
 	}

--- a/src/__tests__/pages/MusicPage.test.tsx
+++ b/src/__tests__/pages/MusicPage.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/services/music.service', () => ({
     getSongStats: vi.fn().mockResolvedValue([]),
     getMyAssignments: vi.fn().mockResolvedValue([]),
     getMyUnavailability: vi.fn().mockResolvedValue([]),
+    getMyModuleRole: vi.fn().mockResolvedValue({ roleLevel: 1, isDirector: false, hasRole: true }),
   },
 }));
 
@@ -85,6 +86,11 @@ beforeEach(() => {
   vi.mocked(MusicService.getSongStats).mockResolvedValue([]);
   vi.mocked(MusicService.getMyAssignments).mockResolvedValue([]);
   vi.mocked(MusicService.getMyUnavailability).mockResolvedValue([]);
+  vi.mocked(MusicService.getMyModuleRole).mockResolvedValue({
+    roleLevel: 1,
+    isDirector: false,
+    hasRole: true,
+  });
 });
 
 describe('MusicPage — director role', () => {
@@ -106,10 +112,10 @@ describe('MusicPage — director role', () => {
 });
 
 describe('MusicPage — servidor role', () => {
-  test('shows Mis cultos and Mis indisponibilidades for servidor', () => {
+  test('shows Mis cultos and Mis indisponibilidades for servidor', async () => {
     renderWithServidor();
 
-    expect(screen.getByText('Mis cultos')).toBeInTheDocument();
+    expect(await screen.findByText('Mis cultos')).toBeInTheDocument();
     expect(screen.getByText('Mis indisponibilidades')).toBeInTheDocument();
   });
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -16,6 +16,7 @@ import { useSystem } from '@/contexts/SystemContext';
 import { usePermissions } from '@/hooks/usePermissions';
 import { PLATFORM_NAME } from '@/lib/branding';
 import { menuItems, superAdminItems, filterNavItems } from '@/lib/nav-items';
+import { useMusicAccess } from '@/pages/dashboard/music/use-music-access';
 
 interface AppSidebarProps {
   churchName?: string;
@@ -27,11 +28,18 @@ export function AppSidebar({ churchName = 'Tu Iglesia', logoUrl }: AppSidebarPro
   const location = useLocation();
   const { isModuleInstalled } = useSystem();
   const { permissions, hasAccess } = usePermissions();
+  const { hasAccess: hasMusicAccess } = useMusicAccess();
   const currentPath = location.pathname;
 
   const isActive = (path: string) => currentPath === path;
 
-  const filteredItems = filterNavItems(menuItems, { permissions, hasAccess, isModuleInstalled });
+  const hasModuleAccess = (key: string) => (key === 'music' ? hasMusicAccess : true);
+  const filteredItems = filterNavItems(menuItems, {
+    permissions,
+    hasAccess,
+    isModuleInstalled,
+    hasModuleAccess,
+  });
 
   // Show "Gestión de Módulos" ONLY for the admin role (500).
   // Pastors and staff have admin-level access but shouldn't manage modules

--- a/src/components/mobile/MobileMoreSheet.tsx
+++ b/src/components/mobile/MobileMoreSheet.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useSystem } from '@/contexts/SystemContext';
 import { usePermissions } from '@/hooks/usePermissions';
 import { menuItems, superAdminItems, filterNavItems } from '@/lib/nav-items';
+import { useMusicAccess } from '@/pages/dashboard/music/use-music-access';
 
 /**
  * Mobile "Más" sheet: every section/module the user can reach (driven by the
@@ -21,8 +22,14 @@ export function MobileMoreSheet({
   const { logout } = useAuth();
   const { isModuleInstalled } = useSystem();
   const { permissions, hasAccess } = usePermissions();
+  const { hasAccess: hasMusicAccess } = useMusicAccess();
 
-  const gate = { permissions, hasAccess, isModuleInstalled };
+  const gate = {
+    permissions,
+    hasAccess,
+    isModuleInstalled,
+    hasModuleAccess: (key: string) => (key === 'music' ? hasMusicAccess : true),
+  };
   // Exclude "Inicio" — it's always the first primary tab in the bottom bar.
   const items = filterNavItems(
     menuItems.filter(i => i.url !== '/dashboard'),

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -22,6 +22,8 @@ export interface MenuItemConfig {
   minRole: number;
   /** pastor + staff con has_admin_access */
   requireAdminAccess?: boolean;
+  /** Además de rol+módulo instalado, requiere pertenecer al equipo del módulo (ver NavGate.hasModuleAccess) */
+  requiresMembership?: boolean;
 }
 
 // Single source of truth for navigation. Consumed by the sidebar (desktop),
@@ -58,6 +60,7 @@ export const menuItems: MenuItemConfig[] = [
     icon: Music2,
     requiredModule: 'music',
     minRole: ROLE_LEVELS.member,
+    requiresMembership: true,
   },
   {
     title: 'Reportes',
@@ -84,9 +87,11 @@ interface NavGate {
   permissions: { has_admin_access?: boolean } | null | undefined;
   hasAccess: (minRole: number) => boolean;
   isModuleInstalled: (key: string) => boolean;
+  /** For items with requiresMembership: true — is the user actually part of that module's team? */
+  hasModuleAccess?: (key: string) => boolean;
 }
 
-/** Shared gating: role/admin access + module installed. */
+/** Shared gating: role/admin access + module installed (+ team membership when requiresMembership). */
 export function filterNavItems(items: MenuItemConfig[], gate: NavGate): MenuItemConfig[] {
   return items.filter(item => {
     if (item.requireAdminAccess) {
@@ -95,6 +100,10 @@ export function filterNavItems(items: MenuItemConfig[], gate: NavGate): MenuItem
       return false;
     }
     if (!item.requiredModule || item.requiredModule === 'base') return true;
-    return gate.isModuleInstalled(item.requiredModule);
+    if (!gate.isModuleInstalled(item.requiredModule)) return false;
+    if (item.requiresMembership && gate.permissions && !gate.permissions.has_admin_access) {
+      return gate.hasModuleAccess?.(item.requiredModule) ?? true;
+    }
+    return true;
   });
 }

--- a/src/pages/dashboard/MusicPage.tsx
+++ b/src/pages/dashboard/MusicPage.tsx
@@ -1127,19 +1127,43 @@ function DirectorMobile({ onOpenEvent }: { onOpenEvent: (e: MusicEvent) => void 
 // ─────────────────────────────────────────────
 // MusicPage root
 // ─────────────────────────────────────────────
+function NoMusicAccess() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-border p-10 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+        <Music2 className="h-7 w-7 text-muted-foreground" />
+      </div>
+      <div>
+        <p className="font-semibold">No sos parte del equipo de música</p>
+        <p className="mx-auto max-w-xs text-sm text-muted-foreground">
+          Pedile al director que te agregue como integrante para ver tus cultos y asignaciones.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export default function MusicPage() {
   const isMobileApp = useMobileMode();
   const navigate = useNavigate();
-  const { isDirector } = useMusicAccess();
+  const { isDirector, hasAccess, loadingAccess } = useMusicAccess();
   const [createEventOpen, setCreateEventOpen] = useState(false);
 
   const openEvent = (e: MusicEvent) => navigate(`/dashboard/music/eventos/${e.id}`);
 
-  const body = !isDirector ? (
+  const servidorBody = loadingAccess ? (
+    <Skeleton className="h-44 w-full rounded-2xl" />
+  ) : !hasAccess ? (
+    <NoMusicAccess />
+  ) : (
     <>
       <ServidorMusicHero />
       <ServidorView />
     </>
+  );
+
+  const body = !isDirector ? (
+    servidorBody
   ) : (
     <>
       <DirectorMusicHero onOpenEvent={openEvent} />
@@ -1181,7 +1205,15 @@ export default function MusicPage() {
       <>
         <MobileScreen title="Música" subtitle={isDirector ? 'Equipo de alabanza' : 'Mis cultos'}>
           <div className="music-shell music-aurora min-h-screen px-4 py-4 space-y-5">
-            {isDirector ? <DirectorMobile onOpenEvent={openEvent} /> : <ServidorMobile />}
+            {isDirector ? (
+              <DirectorMobile onOpenEvent={openEvent} />
+            ) : loadingAccess ? (
+              <Skeleton className="h-44 w-full rounded-2xl" />
+            ) : !hasAccess ? (
+              <NoMusicAccess />
+            ) : (
+              <ServidorMobile />
+            )}
           </div>
         </MobileScreen>
       </>

--- a/src/pages/dashboard/discipleship/LeaderDashboard.tsx
+++ b/src/pages/dashboard/discipleship/LeaderDashboard.tsx
@@ -10,7 +10,7 @@ import { MobileStatTile } from '@/components/mobile/MobileStatTile';
 import { useMobileMode } from '@/hooks/useMobileMode';
 import { useLeaderDiscipleshipData } from '@/hooks/useLeaderDiscipleshipData';
 import { DiscipleshipService } from '@/services/discipleship.service';
-import type { GroupMemberWithDetails } from '@/types/discipleship.types';
+import type { AttendanceWithDetails, GroupMemberWithDetails } from '@/types/discipleship.types';
 import { addDays, format, startOfISOWeek } from 'date-fns';
 import { getIsoWeek, justEndedWeek } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
@@ -62,7 +62,9 @@ export default function LeaderDashboard() {
         setMembers(list);
         // Inicializar todos como presentes por defecto
         const init: Record<string, boolean> = {};
-        list.forEach(m => { init[m.user_id] = true; });
+        list.forEach(m => {
+          init[m.user_id] = true;
+        });
         setAttendanceMap(init);
       })
       .catch(() => setMembers([]))
@@ -78,13 +80,19 @@ export default function LeaderDashboard() {
         if (existing && existing.length > 0) {
           // Hay registros para esta fecha — usar esos valores
           const map: Record<string, boolean> = {};
-          members.forEach(m => { map[m.user_id] = false; }); // default ausente
-          existing.forEach((a: any) => { map[a.user_id] = a.present; });
+          members.forEach(m => {
+            map[m.user_id] = false;
+          }); // default ausente
+          existing.forEach((a: AttendanceWithDetails) => {
+            map[a.user_id] = a.present;
+          });
           setAttendanceMap(map);
         } else {
           // Sin registros — resetear todos a presentes
           const init: Record<string, boolean> = {};
-          members.forEach(m => { init[m.user_id] = true; });
+          members.forEach(m => {
+            init[m.user_id] = true;
+          });
           setAttendanceMap(init);
         }
       })
@@ -236,7 +244,9 @@ export default function LeaderDashboard() {
 
   const membersList = loadingMembers ? (
     <div className="space-y-2">
-      {[...Array(4)].map((_, i) => <Skeleton key={i} className="h-12 w-full" />)}
+      {[...Array(4)].map((_, i) => (
+        <Skeleton key={i} className="h-12 w-full" />
+      ))}
     </div>
   ) : members.length === 0 ? (
     <div className="text-center py-8 text-muted-foreground">
@@ -286,7 +296,10 @@ export default function LeaderDashboard() {
     <div className="space-y-4">
       {/* Date picker */}
       <div className="flex items-center gap-3">
-        <label htmlFor="attendance-date" className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+        <label
+          htmlFor="attendance-date"
+          className="text-sm font-medium text-muted-foreground whitespace-nowrap"
+        >
           Fecha de reunión
         </label>
         <input
@@ -301,7 +314,9 @@ export default function LeaderDashboard() {
       {/* Member rows */}
       {!attendanceLoaded ? (
         <div className="space-y-2">
-          {[...Array(3)].map((_, i) => <Skeleton key={i} className="h-12 w-full" />)}
+          {[...Array(3)].map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
         </div>
       ) : (
         <div className="divide-y">
@@ -369,7 +384,10 @@ export default function LeaderDashboard() {
         {myReports.slice(0, 5).map(report => {
           const reportData = report.report_data as { attendance?: number; conversions?: number };
           return (
-            <div key={report.id} className="flex items-center justify-between p-3 border rounded-lg">
+            <div
+              key={report.id}
+              className="flex items-center justify-between p-3 border rounded-lg"
+            >
               <div>
                 <p className="font-medium">
                   Semana {format(new Date(report.period_start), 'dd MMM', { locale: es })} -{' '}
@@ -419,7 +437,10 @@ export default function LeaderDashboard() {
             value={myGroup?.member_count || stats?.total_members || 0}
             sub={`${myGroup?.active_members || 0} activos`}
           />
-          <MobileStatTile label="Asistencia" value={`${stats?.average_attendance || 0}%`} />
+          <MobileStatTile
+            label="Asistencia"
+            value={`${Math.round(stats?.average_attendance || 0)}%`}
+          />
           <MobileStatTile label="Reunión" value={myGroup?.meeting_day || 'N/D'} />
           <MobileStatTile
             label="Reporte"
@@ -497,7 +518,7 @@ export default function LeaderDashboard() {
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{stats?.average_attendance || 0}%</div>
+            <div className="text-2xl font-bold">{Math.round(stats?.average_attendance || 0)}%</div>
             <p className="text-xs text-muted-foreground">Últimas 4 semanas</p>
           </CardContent>
         </Card>
@@ -560,7 +581,9 @@ export default function LeaderDashboard() {
             <Users className="h-5 w-5" />
             Mi Gente
             {members.length > 0 && (
-              <Badge variant="secondary" className="ml-1">{members.length}</Badge>
+              <Badge variant="secondary" className="ml-1">
+                {members.length}
+              </Badge>
             )}
           </CardTitle>
         </CardHeader>

--- a/src/pages/dashboard/music/use-music-access.ts
+++ b/src/pages/dashboard/music/use-music-access.ts
@@ -14,7 +14,7 @@ export function useMusicAccess() {
   const systemDirector =
     !!permissions && (permissions.has_admin_access || permissions.role === 'pastor');
 
-  const { data: moduleRole } = useQuery({
+  const { data: moduleRole, isLoading: loadingModuleRole } = useQuery({
     queryKey: ['music-my-module-role'],
     queryFn: () => MusicService.getMyModuleRole(),
     enabled: !!permissions && !systemDirector,
@@ -22,5 +22,9 @@ export function useMusicAccess() {
   });
 
   const isDirector = systemDirector || (moduleRole?.isDirector ?? false);
-  return { isDirector };
+  // hasAccess: manages the module (admin/pastor/director) or was actually added
+  // to the music team (music_members + module_user_roles row). A plain member
+  // with neither should not see the module at all.
+  const hasAccess = systemDirector || (moduleRole?.hasRole ?? false);
+  return { isDirector, hasAccess, loadingAccess: !systemDirector && loadingModuleRole };
 }

--- a/src/services/music.service.ts
+++ b/src/services/music.service.ts
@@ -273,15 +273,20 @@ export class MusicService {
     return mapMember(raw);
   }
 
-  static async getMyModuleRole(): Promise<{ roleLevel: number; isDirector: boolean }> {
+  /** hasRole=false means the backend returned no_module_role (404): the user was never added to the music team. */
+  static async getMyModuleRole(): Promise<{
+    roleLevel: number;
+    isDirector: boolean;
+    hasRole: boolean;
+  }> {
     try {
       const raw = await ApiService.get<{ role_level?: number }>(
         '/permissions/module-role?module=music'
       );
       const level = raw.role_level ?? 0;
-      return { roleLevel: level, isDirector: level >= 5 };
+      return { roleLevel: level, isDirector: level >= 5, hasRole: true };
     } catch {
-      return { roleLevel: 0, isDirector: false };
+      return { roleLevel: 0, isDirector: false, hasRole: false };
     }
   }
 


### PR DESCRIPTION
## Summary
- `GetRecentActivity` consultaba `audit_logs` sin `WHERE church_id` — el feed de "Actividad reciente" del dashboard mostraba auditoría de TODAS las iglesias, no solo la propia. Confirmado que `audit_logs.church_id` existe y está poblado (migración `phase2b_tenant_schema_group_b`); solo faltaba el filtro.
- `LeaderDashboard` mostraba el promedio de asistencia sin redondear (`76.35524798154556%`). Los demás dashboards de discipulado (Pastoral, Coordinador, Supervisores) ya usaban `Math.round`; este había quedado afuera del patrón.
- El ítem "Música" aparecía en el sidebar/menú mobile para cualquier usuario con el módulo instalado, sin importar si tenía rol asignado en el equipo — verificado contra producción que un usuario sin fila en `music_members`/`module_user_roles`/`user_invitations` igual lo veía. Se agrega `hasRole` al endpoint de module-role, un gate `requiresMembership` en `filterNavItems`, y un estado explícito ("No sos parte del equipo de música") si se entra por URL directa sin membresía.

## Test plan
- [x] `go build ./...` y `go vet` limpios
- [x] `tsc --noEmit` limpio
- [x] `pnpm test:run` — 138/138 tests pasan (incluye fix de mock en `MusicPage.test.tsx` para reflejar que el servidor de prueba es miembro real del equipo)
- [x] Verificado contra la DB de producción (Supabase) que el usuario de prueba (`server@sionerp.local`) no tenía fila en `music_members`/`module_user_roles`/`user_invitations`