### PR TITLE
feat(dashboard,music): analítica avanzada de discipulado + tema claro/oscuro en Música

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,65 @@
+name: DB Backup (Supabase -> B2)
+
+# Backup diario de la base de Supabase (plan Free no trae backups automaticos)
+# hacia un bucket de Backblaze B2. Corre en GitHub Actions: sin server propio.
+#
+# GOTCHA: los triggers `schedule` solo disparan desde la rama default (main).
+# Este archivo tiene que estar en main para que el cron ande. `workflow_dispatch`
+# (el boton "Run workflow") anda desde cualquier rama donde exista.
+#
+# Retencion: NO se borra nada por script (un bug ahi borra el backup que
+# justo necesitabas). Se resuelve con una lifecycle rule en el bucket de B2
+# -> "keep only the last N days". Ver instrucciones al pie.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'   # 06:17 UTC diario (~02:17 Venezuela), hora muerta
+  workflow_dispatch: {}     # correr a mano desde la pestana Actions
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Instalar pg_dump 17
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17 || {
+            sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+            curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client-17
+          }
+          command -v rclone >/dev/null || sudo apt-get install -y rclone
+
+      - name: Dump + subir a B2
+        env:
+          # Connection string de Supabase. Usar la del "Session pooler"
+          # (Dashboard -> Project Settings -> Database -> Connection string ->
+          # Session mode). El pooler transaccional (puerto 6543) NO sirve para
+          # pg_dump; el Session pooler (5432) si.
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          B2_BUCKET: ${{ secrets.B2_BUCKET }}
+          RCLONE_CONFIG_B2_TYPE: b2
+          RCLONE_CONFIG_B2_ACCOUNT: ${{ secrets.B2_KEY_ID }}
+          RCLONE_CONFIG_B2_KEY: ${{ secrets.B2_APP_KEY }}
+        run: |
+          set -euo pipefail
+          FILE="sionerp-$(date -u +%Y%m%d-%H%M%S).dump"
+
+          # -Fc: formato custom comprimido (restaura con pg_restore).
+          # --no-owner/--no-privileges: restaura limpio en un proyecto Supabase
+          # nuevo sin pelear con roles.
+          pg_dump "$SUPABASE_DB_URL" -Fc --no-owner --no-privileges -f "$FILE"
+
+          # Sanity check: un dump que "anduvo" pero salio vacio es PEOR que no
+          # tener backup, porque te da falsa tranquilidad. Si sale sospechoso, aborto.
+          SIZE=$(stat -c%s "$FILE")
+          echo "Dump: $FILE ($SIZE bytes)"
+          if [ "$SIZE" -lt 51200 ]; then
+            echo "::error::Dump sospechosamente chico (<50KB) - aborto sin subir." >&2
+            exit 1
+          fi
+
+          rclone copy "$FILE" "b2:${B2_BUCKET}/daily/" --progress
+          echo "Backup subido OK: daily/$FILE"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,14 +4,20 @@ name: Deploy to production
 # hacíamos a mano:
 #   1. verify  — typecheck + build del frontend y build + vet del backend Go
 #                (si algo no compila, NO se despliega nada)
-#   2. migrate — aplica las migraciones de Supabase pendientes a la DB de prod
-#   3. deploy  — dispara los deploys de backend (Render) y frontend (Vercel)
+#   2. backup  — pg_dump de la DB de prod → Backblaze B2 (pre-migrate/). Si el
+#                backup falla, las migraciones NO corren (no hay migración sin
+#                un respaldo fresco).
+#   3. migrate — aplica las migraciones de Supabase pendientes a la DB de prod
+#   4. deploy  — dispara los deploys de backend (Render) y frontend (Vercel)
 #
 # ── Secrets requeridos (Settings → Secrets and variables → Actions) ──
 #   SUPABASE_DB_URL     (ya existe) — connection string de la DB de producción,
 #                        percent-encoded (si la contraseña tiene @ : / # etc.,
-#                        deben ir escapados, ej. @ → %40). `supabase db push`
-#                        aplica SOLO las migraciones no aplicadas (idempotente).
+#                        deben ir escapados, ej. @ → %40). Usar la del "Session
+#                        pooler" (5432). `supabase db push` aplica SOLO las
+#                        migraciones no aplicadas (idempotente).
+#   B2_BUCKET, B2_KEY_ID, B2_APP_KEY  (ya existen, los usa db-backup.yml) —
+#                        destino del backup previo a migrar.
 #   RENDER_DEPLOY_HOOK  (opcional)  — deploy hook de Render. Dejalo SIN setear si
 #                        Render ya auto-deploya desde GitHub → el paso se salta.
 #   VERCEL_DEPLOY_HOOK  (opcional)  — deploy hook de Vercel. Mismo criterio.
@@ -61,9 +67,57 @@ jobs:
           go build ./...
           go vet ./...
 
+  backup:
+    name: Backup DB (pre-migración)
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Instalar pg_dump 17 + rclone
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17 || {
+            sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+            curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client-17
+          }
+          command -v rclone >/dev/null || sudo apt-get install -y rclone
+
+      - name: Dump + subir a B2 (pre-migrate/)
+        env:
+          # Usar la connection string del "Session pooler" (5432); el pooler
+          # transaccional (6543) NO sirve para pg_dump.
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          B2_BUCKET: ${{ secrets.B2_BUCKET }}
+          RCLONE_CONFIG_B2_TYPE: b2
+          RCLONE_CONFIG_B2_ACCOUNT: ${{ secrets.B2_KEY_ID }}
+          RCLONE_CONFIG_B2_KEY: ${{ secrets.B2_APP_KEY }}
+        run: |
+          set -euo pipefail
+          for v in SUPABASE_DB_URL B2_BUCKET RCLONE_CONFIG_B2_ACCOUNT RCLONE_CONFIG_B2_KEY; do
+            if [ -z "${!v:-}" ]; then
+              echo "::error::Falta el secret $v (requerido para el backup previo a migrar)"; exit 1
+            fi
+          done
+          FILE="sionerp-premigrate-$(date -u +%Y%m%d-%H%M%S)-${GITHUB_SHA::7}.dump"
+          # -Fc comprimido (restaura con pg_restore); sin owner/privilegios para
+          # restaurar limpio en un proyecto nuevo.
+          pg_dump "$SUPABASE_DB_URL" -Fc --no-owner --no-privileges -f "$FILE"
+          SIZE=$(stat -c%s "$FILE")
+          echo "Dump: $FILE ($SIZE bytes)"
+          # Un dump vacío que "anduvo" es peor que no tener backup: aborta antes
+          # de migrar, así no se aplica nada sobre un respaldo inservible.
+          if [ "$SIZE" -lt 51200 ]; then
+            echo "::error::Dump sospechosamente chico (<50KB) - aborto sin subir ni migrar." >&2
+            exit 1
+          fi
+          rclone copy "$FILE" "b2:${B2_BUCKET}/pre-migrate/" --progress
+          echo "Backup pre-migración subido: pre-migrate/$FILE"
+
   migrate:
     name: Migraciones Supabase (prod)
-    needs: verify
+    needs: backup
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,111 @@
+name: Deploy to production
+
+# Corre automáticamente, al llegar código a la rama de producción, lo que antes
+# hacíamos a mano:
+#   1. verify  — typecheck + build del frontend y build + vet del backend Go
+#                (si algo no compila, NO se despliega nada)
+#   2. migrate — aplica las migraciones de Supabase pendientes a la DB de prod
+#   3. deploy  — dispara los deploys de backend (Render) y frontend (Vercel)
+#
+# ── Secrets requeridos (Settings → Secrets and variables → Actions) ──
+#   SUPABASE_DB_URL     (ya existe) — connection string de la DB de producción,
+#                        percent-encoded (si la contraseña tiene @ : / # etc.,
+#                        deben ir escapados, ej. @ → %40). `supabase db push`
+#                        aplica SOLO las migraciones no aplicadas (idempotente).
+#   RENDER_DEPLOY_HOOK  (opcional)  — deploy hook de Render. Dejalo SIN setear si
+#                        Render ya auto-deploya desde GitHub → el paso se salta.
+#   VERCEL_DEPLOY_HOOK  (opcional)  — deploy hook de Vercel. Mismo criterio.
+#
+# ── Trigger ──
+# Configurado en `main` (rama de producción por convención / default del repo).
+# Si tu producción sale de otra rama, cambiá `branches:` de abajo.
+# `workflow_dispatch` permite además correrlo a mano desde la pestaña Actions.
+#
+# ── Gate manual (recomendado) ──
+# El job `migrate` usa el environment `production`. En Settings → Environments →
+# production podés exigir "Required reviewers" para que las migraciones a prod
+# esperen una aprobación humana antes de correr.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false # nunca cortar una migración a mitad de camino
+
+jobs:
+  verify:
+    name: Verify (build + typecheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Typecheck + build frontend
+        run: |
+          pnpm typecheck
+          pnpm build
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: apps/backend-go/go.sum
+      - name: Build + vet backend
+        working-directory: apps/backend-go
+        run: |
+          go build ./...
+          go vet ./...
+
+  migrate:
+    name: Migraciones Supabase (prod)
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: supabase db push
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          if [ -z "$SUPABASE_DB_URL" ]; then
+            echo "::error::Falta el secret SUPABASE_DB_URL"; exit 1
+          fi
+          supabase db push --db-url "$SUPABASE_DB_URL"
+
+  deploy-backend:
+    name: Deploy backend (Render)
+    needs: migrate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render deploy hook
+        env:
+          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "RENDER_DEPLOY_HOOK sin setear — se asume auto-deploy de Render desde GitHub. Saltando."
+            exit 0
+          fi
+          curl -fsSL -X POST "$HOOK"
+
+  deploy-frontend:
+    name: Deploy frontend (Vercel)
+    needs: migrate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel deploy hook
+        env:
+          HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "VERCEL_DEPLOY_HOOK sin setear — se asume auto-deploy de Vercel desde GitHub. Saltando."
+            exit 0
+          fi
+          curl -fsSL -X POST "$HOOK"

--- a/apps/backend-go/handlers/dashboard.go
+++ b/apps/backend-go/handlers/dashboard.go
@@ -67,13 +67,6 @@ func (h *DashboardHandler) GetStats(c echo.Context) error {
 		})
 	}
 
-	recentActivity, err := h.GetRecentActivity(c)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{
-			"error": "Failed to fetch recent activity",
-		})
-	}
-
 	currentUserRole := ""
 	if email := c.Get("email"); email != nil {
 		userEmail := email.(string)
@@ -86,6 +79,23 @@ func (h *DashboardHandler) GetStats(c echo.Context) error {
 		} else {
 			fmt.Printf("User role found: %s\n", currentUserRole)
 		}
+	}
+
+	// "Actividad reciente" son altas/bajas/ediciones de USUARIOS de toda la
+	// iglesia — un supervisor o servidor no tiene por qué ver quién dio de baja
+	// a quién. Se filtra acá, no solo en la UI: la respuesta cruda del endpoint
+	// no debe traer el feed si el rol no es admin/pastor/staff, o alcanza con
+	// abrir Network tab para verlo igual.
+	var recentActivity []models.RecentActivity
+	if utils.IsAdminRole(currentUserRole) {
+		recentActivity, err = h.GetRecentActivity(c)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{
+				"error": "Failed to fetch recent activity",
+			})
+		}
+	} else {
+		recentActivity = []models.RecentActivity{}
 	}
 
 	systemActivity := 0.0

--- a/apps/backend-go/handlers/dashboard.go
+++ b/apps/backend-go/handlers/dashboard.go
@@ -20,13 +20,14 @@ func NewDashboardHandler() *DashboardHandler {
 // GetStats returns dashboard statistics
 func (h *DashboardHandler) GetStats(c echo.Context) error {
 	db := config.GetDB()
+	churchID, _ := c.Get("church_id").(string)
 	var totalUser int
 
 	err := db.DB.QueryRow(`
     	SELECT COUNT(*)
 			FROM users
-			WHERE is_active = true AND is_active_member = true
-		`).Scan(&totalUser)
+			WHERE is_active = true AND is_active_member = true AND church_id = $1
+		`, churchID).Scan(&totalUser)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to fetch total users countt",
@@ -38,8 +39,8 @@ func (h *DashboardHandler) GetStats(c echo.Context) error {
 	err = db.DB.QueryRow(
 		`SELECT COUNT(*)
 			FROM users
-			WHERE is_active = true AND created_at >= $1`,
-		oneMonthAgo).Scan(&newRegistrations)
+			WHERE is_active = true AND created_at >= $1 AND church_id = $2`,
+		oneMonthAgo, churchID).Scan(&newRegistrations)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to fetch new registrations count",
@@ -51,15 +52,15 @@ func (h *DashboardHandler) GetStats(c echo.Context) error {
 	err = db.DB.QueryRow(
 		`SELECT COUNT(DISTINCT role)
 			FROM users
-		  WHERE is_active = true
-		`).Scan(&activeRoles)
+		  WHERE is_active = true AND church_id = $1
+		`, churchID).Scan(&activeRoles)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to fetch active roles count",
 		})
 	}
 
-	rolesDistribution, err := h.GetRoleDistribution(c)
+	rolesDistribution, err := h.GetRoleDistribution(churchID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to fetch roles distribution",
@@ -77,8 +78,8 @@ func (h *DashboardHandler) GetStats(c echo.Context) error {
 	if email := c.Get("email"); email != nil {
 		userEmail := email.(string)
 		err = db.DB.QueryRow(
-			`SELECT role FROM users WHERE email = $1`,
-			userEmail,
+			`SELECT role FROM users WHERE email = $1 AND church_id = $2`,
+			userEmail, churchID,
 		).Scan(&currentUserRole)
 		if err != nil {
 			fmt.Printf("Error fetching user role for %s: %v\n", userEmail, err)
@@ -101,9 +102,13 @@ func (h *DashboardHandler) GetStats(c echo.Context) error {
 		LastLogin:        time.Now(),
 	}
 
-	discipleshipStats := h.getDiscipleshipStats(db)
+	discipleshipStats := h.getDiscipleshipStats(db.DB, churchID)
 
-	// Fetch installed modules
+	// Fetch installed modules — NOT scoped by church_id: la tabla `modules` es global
+	// hoy (sin columna church_id), así que instalar/desinstalar un módulo afecta a
+	// TODAS las iglesias por igual. Es un gap real de multi-tenancy, pero requiere una
+	// migración de schema — queda para el trabajo de "puerta de comercialización
+	// multi-tenant" (ver roadmap), no es parte de este fix de analítica.
 	installedModules := []string{}
 	rows, err := db.DB.Query("SELECT key FROM modules WHERE is_installed = true")
 	if err == nil {
@@ -130,7 +135,7 @@ func (h *DashboardHandler) GetStats(c echo.Context) error {
 	return c.JSON(http.StatusOK, response)
 }
 
-func (h *DashboardHandler) GetRoleDistribution(c echo.Context) ([]models.RoleDistribution, error) {
+func (h *DashboardHandler) GetRoleDistribution(churchID string) ([]models.RoleDistribution, error) {
 	roleColors := map[string]string{
 		utils.RolePastor:     "#ff7c7c",
 		utils.RoleStaff:      "#ffc658",
@@ -149,11 +154,11 @@ func (h *DashboardHandler) GetRoleDistribution(c echo.Context) ([]models.RoleDis
 			role,
 			COUNT(*) as count
 		FROM users
-		WHERE is_active = true
+		WHERE is_active = true AND church_id = $1
 		GROUP BY role
 	`
 
-	rows, err := config.GetDB().DB.Query(query)
+	rows, err := config.GetDB().DB.Query(query, churchID)
 	if err != nil {
 		return nil, err
 	}
@@ -278,43 +283,86 @@ func formatTimeAgo(t time.Time) string {
 	}
 }
 
-func (h *DashboardHandler) getDiscipleshipStats(db *config.Database) models.DiscipleshipStats {
+func (h *DashboardHandler) getDiscipleshipStats(q config.Querier, churchID string) models.DiscipleshipStats {
 	stats := models.DiscipleshipStats{}
 
-	db.DB.QueryRow(`SELECT COUNT(*) FROM discipleship_groups WHERE status = 'active'`).Scan(&stats.TotalGroups)
+	q.QueryRow(`SELECT COUNT(*) FROM discipleship_groups WHERE status = 'active' AND church_id = $1`, churchID).Scan(&stats.TotalGroups)
 
-	db.DB.QueryRow(`SELECT COALESCE(SUM(active_members), 0) FROM discipleship_groups WHERE status = 'active'`).Scan(&stats.TotalMembers)
+	q.QueryRow(`SELECT COALESCE(SUM(active_members), 0) FROM discipleship_groups WHERE status = 'active' AND church_id = $1`, churchID).Scan(&stats.TotalMembers)
 
-	db.DB.QueryRow(`SELECT COUNT(DISTINCT leader_id) FROM discipleship_groups WHERE status = 'active'`).Scan(&stats.ActiveLeaders)
+	q.QueryRow(`SELECT COUNT(DISTINCT leader_id) FROM discipleship_groups WHERE status = 'active' AND church_id = $1`, churchID).Scan(&stats.ActiveLeaders)
 
-	db.DB.QueryRow(`
+	q.QueryRow(`
 		SELECT COALESCE(
 			AVG(CASE WHEN member_count > 0 THEN active_members::float / member_count * 100 ELSE 0 END), 0
 		)
-		FROM discipleship_groups WHERE status = 'active'
-	`).Scan(&stats.AvgAttendance)
+		FROM discipleship_groups WHERE status = 'active' AND church_id = $1
+	`, churchID).Scan(&stats.AvgAttendance)
 
-	db.DB.QueryRow(`SELECT COUNT(*) FROM discipleship_multiplications WHERE multiplication_date >= NOW() - INTERVAL '30 days'`).Scan(&stats.Multiplications)
+	stats.Multiplications = countSuccessfulMultiplications(q, churchID)
 
-	db.DB.QueryRow(`SELECT COUNT(*) FROM discipleship_alerts WHERE resolved = false`).Scan(&stats.AlertsCount)
+	q.QueryRow(`SELECT COUNT(*) FROM discipleship_alerts WHERE resolved = false AND church_id = $1`, churchID).Scan(&stats.AlertsCount)
 
-	db.DB.QueryRow(`
-		SELECT COALESCE(AVG(spiritual_temperature), 0)
-		FROM discipleship_attendance
-		WHERE meeting_date >= NOW() - INTERVAL '30 days'
-	`).Scan(&stats.SpiritualHealth)
+	stats.SpiritualHealth = calculateSpiritualHealth(q, churchID)
 
 	var prevMembers int
-	db.DB.QueryRow(`
+	q.QueryRow(`
 		SELECT COALESCE(SUM(active_members), 0)
 		FROM discipleship_groups
-		WHERE status = 'active' AND created_at <= NOW() - INTERVAL '30 days'
-	`).Scan(&prevMembers)
+		WHERE status = 'active' AND church_id = $1 AND created_at <= NOW() - INTERVAL '30 days'
+	`, churchID).Scan(&prevMembers)
 	if prevMembers > 0 {
 		stats.MonthlyGrowth = float64(stats.TotalMembers-prevMembers) / float64(prevMembers) * 100
 	}
 
 	return stats
+}
+
+// countSuccessfulMultiplications es la única fuente de verdad para "Multiplicaciones"
+// en todo el sistema. Antes existían 3 definiciones distintas (una sobre una tabla
+// inexistente `discipleship_multiplications`, otra contando grupos con
+// status='multiplying', otra sobre cell_multiplication_tracking) — se unifican acá
+// sobre la tabla real y dedicada a este propósito. Ventana: año calendario en curso,
+// el criterio que ya usaba GetDashboardStatsByLevel para niveles 3 y 5.
+func countSuccessfulMultiplications(q config.Querier, churchID string) int {
+	var count int
+	q.QueryRow(`
+		SELECT COUNT(*) FROM cell_multiplication_tracking
+		WHERE church_id = $1
+		AND multiplication_date >= DATE_TRUNC('year', CURRENT_DATE)
+		AND success_status = 'successful'
+	`, churchID).Scan(&count)
+	return count
+}
+
+// calculateSpiritualHealth es la única fuente de verdad para "Salud Espiritual" a nivel
+// de iglesia. Promedia 13 indicadores binarios del reporte semanal de cada líder y
+// reescala a /10 (sin el ×10/13 el índice llega a 13 y la UI, que lo rotula "/10",
+// mostraba cosas como "11.5/10"). Antes dashboard.go usaba una fórmula completamente
+// distinta (promedio de una columna spiritual_temperature en discipleship_attendance).
+func calculateSpiritualHealth(q config.Querier, churchID string) float64 {
+	var health float64
+	q.QueryRow(`
+		SELECT COALESCE(AVG(
+			CASE WHEN COALESCE((report_data->>'attendance_nd')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'attendance_dm')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'attendance_friends')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'attendance_kids')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'group_discipleships')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'group_evangelism')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'leader_new_disciples_care')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'leader_mature_disciples_care')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'spiritual_journal_days')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN COALESCE((report_data->>'leader_evangelism')::int, 0) > 0 THEN 1 ELSE 0 END +
+			CASE WHEN (report_data->>'service_attendance_sunday')::boolean THEN 1 ELSE 0 END +
+			CASE WHEN (report_data->>'service_attendance_prayer')::boolean THEN 1 ELSE 0 END +
+			CASE WHEN (report_data->>'doctrine_attendance')::boolean THEN 1 ELSE 0 END
+		) * 10.0 / 13.0, 0)
+		FROM discipleship_reports
+		WHERE church_id = $1
+		AND period_end >= CURRENT_DATE - INTERVAL '28 days'
+	`, churchID).Scan(&health)
+	return health
 }
 
 func formatAction(action, tableName string) string {

--- a/apps/backend-go/handlers/discipleship-goals.go
+++ b/apps/backend-go/handlers/discipleship-goals.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"backend-sion/config"
+	"backend-sion/models"
 	"backend-sion/utils"
 	"database/sql"
 	"fmt"
@@ -866,10 +867,11 @@ func (h *DiscipleshipGoalsHandler) CreateAssignments(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Se requiere al menos una asignación"})
 	}
 
-	// Verify the goal exists and belongs to this church
-	var goalExists bool
-	err = q.QueryRow("SELECT EXISTS(SELECT 1 FROM discipleship_goals WHERE id = $1 AND church_id = $2)", goalID, churchID).Scan(&goalExists)
-	if err != nil || !goalExists {
+	// Verify the goal exists and belongs to this church (also need its title
+	// for the assignment notifications below)
+	var goalTitle string
+	err = q.QueryRow("SELECT title FROM discipleship_goals WHERE id = $1 AND church_id = $2", goalID, churchID).Scan(&goalTitle)
+	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "Objetivo no encontrado"})
 	}
 
@@ -936,12 +938,28 @@ func (h *DiscipleshipGoalsHandler) CreateAssignments(c echo.Context) error {
 		})
 	}
 
-	// Audit log para cada asignación creada
+	// Audit log + notificación para cada asignación creada. El asignado necesita
+	// enterarse de que le tocó una porción del objetivo — sin esto, el primer
+	// aviso que tiene es descubrirlo por su cuenta en el dashboard.
 	for _, ca := range created {
 		caCopy := ca
 		go logGoalAudit(config.GetDB(), goalID, userID, "INSERT", "goal_assignments",
 			fmt.Sprintf(`{"assigned_to":%q,"target_value":%g,"goal_id":%q}`,
 				caCopy.AssignedTo, caCopy.TargetValue, goalID))
+
+		gID := goalID
+		cID := churchID
+		go utils.CreateNotification(db, models.NotificationInput{
+			ChurchID:          cID,
+			UserID:            caCopy.AssignedTo,
+			Type:              "info",
+			Title:             "Se te asignó un objetivo",
+			Message:           fmt.Sprintf("%q — meta: %g", goalTitle, caCopy.TargetValue),
+			ActionURL:         utils.Ptr("/dashboard/discipleship?tab=goals"),
+			ActionText:        utils.Ptr("Ver objetivo"),
+			RelatedEntityType: utils.Ptr("goal"),
+			RelatedEntityID:   &gID,
+		})
 	}
 
 	return c.JSON(http.StatusCreated, map[string]interface{}{
@@ -983,6 +1001,9 @@ func (h *DiscipleshipGoalsHandler) BatchAssignToZones(c echo.Context) error {
 	if req.DefaultTargetValue != nil {
 		defaultTarget = *req.DefaultTargetValue
 	}
+
+	var goalTitle string
+	q.QueryRow("SELECT title FROM discipleship_goals WHERE id = $1 AND church_id = $2", goalID, churchID).Scan(&goalTitle)
 
 	// Fetch all level-3 users (Supervisor General) scoped to this church
 	rows, err := q.Query(`
@@ -1031,6 +1052,21 @@ func (h *DiscipleshipGoalsHandler) BatchAssignToZones(c echo.Context) error {
 		created = append(created, CreatedAssignment{
 			ID: newID, GoalID: goalID, AssignedTo: supervisorID,
 			AssignedBy: userID, AssignedLevel: 3, TargetValue: defaultTarget, CreatedAt: createdAt,
+		})
+
+		supID := supervisorID
+		gID := goalID
+		cID := churchID
+		go utils.CreateNotification(db, models.NotificationInput{
+			ChurchID:          cID,
+			UserID:            supID,
+			Type:              "info",
+			Title:             "Se te asignó un objetivo",
+			Message:           fmt.Sprintf("%q — meta: %g", goalTitle, defaultTarget),
+			ActionURL:         utils.Ptr("/dashboard/discipleship?tab=goals"),
+			ActionText:        utils.Ptr("Ver objetivo"),
+			RelatedEntityType: utils.Ptr("goal"),
+			RelatedEntityID:   &gID,
 		})
 	}
 

--- a/apps/backend-go/handlers/discipleship-goals.go
+++ b/apps/backend-go/handlers/discipleship-goals.go
@@ -1141,19 +1141,78 @@ func (h *DiscipleshipGoalsHandler) GetAssignmentTree(c echo.Context) error {
 	}
 
 	// Visibility filter for non-pastor: show subtrees assigned TO me, or that I
-	// assigned/cascaded to someone else (the creator must see their own cascade
-	// even when they didn't self-assign a leaf).
+	// assigned/cascaded to someone else — but "root" here means the TRUE root
+	// of the cascade (parent_assignment_id IS NULL), not "the node closest to
+	// me". A batch cascade is typically created in one call by whoever owns the
+	// top level (e.g. a Coordinador assigning down to General→Auxiliar→Líder in
+	// one request), so assigned_by is the SAME person on every row — checking
+	// only the true root's assigned_to/assigned_by would mean nobody but that
+	// one creator ever sees the tree, even the líder holding the leaf. Instead:
+	// include each of MY OWN nodes, their full ancestor chain (so I see the
+	// goal's overall context up to the top) and their full descendant subtree
+	// (what I supervise) — but never an unrelated sibling branch.
+	included := map[string]bool{}
+	myNodes := map[string]bool{}
+	if canSeeAll {
+		for _, id := range orderedIDs {
+			included[id] = true
+		}
+	} else {
+		for _, id := range orderedIDs {
+			n := allNodes[id]
+			if n.AssignedTo == userID || n.AssignedBy == userID {
+				myNodes[id] = true
+			}
+		}
+		for id := range myNodes {
+			cur := allNodes[id]
+			for {
+				included[cur.ID] = true
+				if cur.ParentAssignmentID == nil {
+					break
+				}
+				parent, ok := allNodes[*cur.ParentAssignmentID]
+				if !ok {
+					break
+				}
+				cur = parent
+			}
+		}
+		frontier := map[string]bool{}
+		for id := range myNodes {
+			frontier[id] = true
+		}
+		for len(frontier) > 0 {
+			next := map[string]bool{}
+			for _, id := range orderedIDs {
+				if included[id] {
+					continue
+				}
+				n := allNodes[id]
+				if n.ParentAssignmentID != nil && frontier[*n.ParentAssignmentID] {
+					included[id] = true
+					next[id] = true
+				}
+			}
+			frontier = next
+		}
+	}
+
 	var roots []*FlatNode
 	for _, id := range orderedIDs {
+		if !included[id] {
+			continue
+		}
 		n := allNodes[id]
 		if n.ParentAssignmentID == nil {
-			if canSeeAll || n.AssignedTo == userID || n.AssignedBy == userID {
-				roots = append(roots, n)
-			}
+			roots = append(roots, n)
+		} else if parent, ok := allNodes[*n.ParentAssignmentID]; ok && included[parent.ID] {
+			parent.Children = append(parent.Children, n)
 		} else {
-			if parent, ok := allNodes[*n.ParentAssignmentID]; ok {
-				parent.Children = append(parent.Children, n)
-			}
+			// Parent exists but is out of scope (shouldn't happen — the
+			// ancestor walk above always includes the full chain to root —
+			// kept as a safety net so a node is never silently dropped).
+			roots = append(roots, n)
 		}
 	}
 

--- a/apps/backend-go/handlers/discipleship.go
+++ b/apps/backend-go/handlers/discipleship.go
@@ -2035,6 +2035,19 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 			SELECT COUNT(DISTINCT leader_id) FROM discipleship_groups WHERE %s
 		`, leaderScope), userID, churchID, churchID).Scan(&stats.ActiveLeaders)
 
+		// Zone name for display — igual que el General (case 3): se lee de la
+		// propia fila de jerarquía del auxiliar, no de discipleship_groups
+		// (el scope de grupos es por líderes directos, no por zona).
+		var auxZoneID sql.NullString
+		q.QueryRow(`
+			SELECT zone_id FROM discipleship_hierarchy WHERE user_id = $1 AND church_id = $2
+		`, userID, churchID).Scan(&auxZoneID)
+		if auxZoneID.Valid && auxZoneID.String != "" {
+			q.QueryRow(`
+				SELECT COALESCE(name, '') FROM zones WHERE id = $1 AND church_id = $2
+			`, auxZoneID.String, churchID).Scan(&stats.ZoneName)
+		}
+
 	case "3": // General Supervisor (L3) — su subtree de líderes (2-hop)
 		// Group/member counts scoped to the General's 2-hop leader subtree (not zone_id).
 		// ZoneName is kept for display; SubordinatesCount counts direct auxiliaries (1-hop).

--- a/apps/backend-go/handlers/discipleship.go
+++ b/apps/backend-go/handlers/discipleship.go
@@ -2014,22 +2014,26 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 		`, userID, churchID).Scan(&stats.TotalMembers)
 		stats.GrowthRate = memberGrowthRate(q, stats.TotalMembers, "leader_id = $1 AND church_id = $2 AND status = 'active'", userID, churchID)
 
-	case "2": // Supervisor Auxiliar - grupos que supervisa
-		q.QueryRow(`
-			SELECT COUNT(*) FROM discipleship_groups
-			WHERE supervisor_id = $1 AND church_id = $2 AND status = 'active'
-		`, userID, churchID).Scan(&stats.GroupsUnderSupervision)
+	case "2": // Supervisor Auxiliar - grupos de sus líderes directos
+		// `discipleship_groups.supervisor_id` es un campo manual y opcional del
+		// formulario de grupo (casi nunca se completa en la práctica) — NO es la
+		// fuente de verdad de a quién supervisa este auxiliar. Esa relación vive
+		// en discipleship_hierarchy, igual que para el General (case 3). Se
+		// resuelve vía directLeaderIDsSubquery (1 hop), como ya hace reports.go.
+		leaderScope := fmt.Sprintf("leader_id IN (%s) AND church_id = $2 AND status = 'active'", directLeaderIDsSubquery(3, 1))
 
-		q.QueryRow(`
-			SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups
-			WHERE supervisor_id = $1 AND church_id = $2 AND status = 'active'
-		`, userID, churchID).Scan(&stats.TotalMembers)
-		stats.GrowthRate = memberGrowthRate(q, stats.TotalMembers, "supervisor_id = $1 AND church_id = $2 AND status = 'active'", userID, churchID)
+		q.QueryRow(fmt.Sprintf(`
+			SELECT COUNT(*) FROM discipleship_groups WHERE %s
+		`, leaderScope), userID, churchID, churchID).Scan(&stats.GroupsUnderSupervision)
 
-		q.QueryRow(`
-			SELECT COUNT(DISTINCT leader_id) FROM discipleship_groups
-			WHERE supervisor_id = $1 AND church_id = $2 AND status = 'active'
-		`, userID, churchID).Scan(&stats.ActiveLeaders)
+		q.QueryRow(fmt.Sprintf(`
+			SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE %s
+		`, leaderScope), userID, churchID, churchID).Scan(&stats.TotalMembers)
+		stats.GrowthRate = memberGrowthRate(q, stats.TotalMembers, leaderScope, userID, churchID, churchID)
+
+		q.QueryRow(fmt.Sprintf(`
+			SELECT COUNT(DISTINCT leader_id) FROM discipleship_groups WHERE %s
+		`, leaderScope), userID, churchID, churchID).Scan(&stats.ActiveLeaders)
 
 	case "3": // General Supervisor (L3) — su subtree de líderes (2-hop)
 		// Group/member counts scoped to the General's 2-hop leader subtree (not zone_id).

--- a/apps/backend-go/handlers/discipleship.go
+++ b/apps/backend-go/handlers/discipleship.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -1538,7 +1539,7 @@ func (h *DiscipleshipHandler) GetAnalytics(c echo.Context) error {
 					CASE WHEN (r.report_data->>'service_attendance_sunday')::boolean THEN 1 ELSE 0 END +
 					CASE WHEN (r.report_data->>'service_attendance_prayer')::boolean THEN 1 ELSE 0 END +
 					CASE WHEN (r.report_data->>'doctrine_attendance')::boolean THEN 1 ELSE 0 END
-				)
+				) * 10.0 / 13.0
 				FROM discipleship_reports r
 				WHERE (r.report_data->>'group_id')::uuid = g.id
 				AND r.church_id = $2
@@ -1584,8 +1585,25 @@ func (h *DiscipleshipHandler) GetAnalytics(c echo.Context) error {
 		c.Logger().Error("Error counting active leaders:", err)
 	}
 
-	// Multiplications (groups with status 'multiplying', scoped by church_id via filterClause)
-	multiplicationsQuery := "SELECT COUNT(*) FROM discipleship_groups WHERE status = 'multiplying'" + filterClause
+	// Multiplications: misma definición unificada que dashboard.go y GetDashboardStatsByLevel
+	// (cell_multiplication_tracking, success_status='successful', año calendario) — antes
+	// esto contaba grupos con status='multiplying', una cosa distinta (estado actual del
+	// grupo, no eventos históricos de multiplicación). Se hace JOIN con discipleship_groups
+	// para poder reusar el mismo filtro jerárquico (leader/supervisor/subtree) que ya
+	// aplica al resto del endpoint, con columnas calificadas por alias para no chocar con
+	// cell_multiplication_tracking.church_id.
+	groupFilterClause := strings.NewReplacer(
+		"church_id", "g.church_id",
+		"leader_id", "g.leader_id",
+		"supervisor_id", "g.supervisor_id",
+		"zone_id", "g.zone_id",
+	).Replace(filterClause)
+	multiplicationsQuery := `
+		SELECT COUNT(*) FROM cell_multiplication_tracking cmt
+		JOIN discipleship_groups g ON g.id = cmt.parent_group_id
+		WHERE cmt.success_status = 'successful'
+		AND cmt.multiplication_date >= DATE_TRUNC('year', CURRENT_DATE)
+	` + groupFilterClause
 	err = q.QueryRow(multiplicationsQuery, filterArgs...).Scan(&analytics.Multiplications)
 	if err != nil {
 		c.Logger().Error("Error counting multiplications:", err)
@@ -1595,6 +1613,31 @@ func (h *DiscipleshipHandler) GetAnalytics(c echo.Context) error {
 	err = q.QueryRow("SELECT COUNT(*) FROM discipleship_alerts WHERE church_id = $1 AND resolved = false AND (expires_at IS NULL OR expires_at > NOW())", churchID).Scan(&analytics.PendingAlerts)
 	if err != nil {
 		c.Logger().Error("Error counting pending alerts:", err)
+	}
+
+	// Growth rate: mismo criterio que dashboard.go (MonthlyGrowth) y zones.go
+	// (growth_rate de zona) — compara miembros activos hoy contra miembros de
+	// grupos que ya existían hace 30 días, dentro del mismo scope jerárquico
+	// que el resto del endpoint (filterClause). Antes este campo nunca se
+	// asignaba, siempre quedaba en 0.
+	var prevMembers int
+	prevQuery := "SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE status = 'active' AND created_at <= NOW() - INTERVAL '30 days'" + filterClause
+	q.QueryRow(prevQuery, filterArgs...).Scan(&prevMembers)
+	if prevMembers > 0 {
+		analytics.GrowthRate = float64(analytics.TotalMembers-prevMembers) / float64(prevMembers) * 100
+	}
+
+	// Auxiliary supervisors (nivel 2) bajo el scope de quien consulta. Solo tiene
+	// sentido para General/Coordinador/Pastoral (nivel 3+) — un líder o supervisor
+	// auxiliar no tiene auxiliares propios, queda en 0. Antes esto se estimaba en
+	// el frontend como activeLeaders/4, un número inventado sin relación con datos
+	// reales de jerarquía.
+	if canSeeAll || (hierarchyLevel != nil && *hierarchyLevel >= 4) {
+		q.QueryRow(`SELECT COUNT(*) FROM discipleship_hierarchy WHERE church_id = $1 AND hierarchy_level = 2`, churchID).
+			Scan(&analytics.AuxiliarySupervisors)
+	} else if hierarchyLevel != nil && *hierarchyLevel == 3 {
+		auxQuery := fmt.Sprintf(`SELECT COUNT(*) FROM (%s) sub`, subtreeAuxIDsSubquery(1, 2))
+		q.QueryRow(auxQuery, churchID, userID).Scan(&analytics.AuxiliarySupervisors)
 	}
 
 	return c.JSON(http.StatusOK, analytics)
@@ -1845,6 +1888,10 @@ func (h *DiscipleshipHandler) GetWeeklyTrends(c echo.Context) error {
 				COALESCE((report_data->>'attendance_kids')::int, 0)
 			) as total_attendance,
 			SUM(COALESCE((report_data->>'attendance_friends')::int, 0)) as total_visitors,
+			SUM(
+				COALESCE((report_data->>'group_evangelism')::int, 0) +
+				COALESCE((report_data->>'leader_evangelism')::int, 0)
+			) as total_conversions,
 			COUNT(DISTINCT reporter_id) as groups_reporting
 		FROM discipleship_reports r
 		WHERE r.church_id = $1 AND report_level >= 1
@@ -1889,10 +1936,11 @@ func (h *DiscipleshipHandler) GetWeeklyTrends(c echo.Context) error {
 	defer rows.Close()
 
 	type WeeklyTrend struct {
-		WeekStart       string `json:"week_start"`
-		TotalAttendance int    `json:"total_attendance"`
-		TotalVisitors   int    `json:"total_visitors"`
-		GroupsReporting int    `json:"groups_reporting"`
+		WeekStart        string `json:"week_start"`
+		TotalAttendance  int    `json:"total_attendance"`
+		TotalVisitors    int    `json:"total_visitors"`
+		TotalConversions int    `json:"total_conversions"`
+		GroupsReporting  int    `json:"groups_reporting"`
 	}
 
 	var trends []WeeklyTrend
@@ -1900,7 +1948,7 @@ func (h *DiscipleshipHandler) GetWeeklyTrends(c echo.Context) error {
 		var t WeeklyTrend
 		err := rows.Scan(
 			&t.WeekStart, &t.TotalAttendance, &t.TotalVisitors,
-			&t.GroupsReporting,
+			&t.TotalConversions, &t.GroupsReporting,
 		)
 		if err != nil {
 			continue
@@ -1912,6 +1960,22 @@ func (h *DiscipleshipHandler) GetWeeklyTrends(c echo.Context) error {
 }
 
 // GetDashboardStatsByLevel obtiene estadísticas según el nivel del usuario
+// memberGrowthRate calcula el % de crecimiento de miembros comparando el total
+// actual contra el total de hace 30 días (mismo criterio que dashboard.go
+// MonthlyGrowth y zones.go growth_rate), reusando el mismo WHERE que cada caso de
+// GetDashboardStatsByLevel ya usa para TotalMembers — así el crecimiento respeta
+// el mismo scope jerárquico (líder/supervisor/general/coordinador/pastor) que el
+// resto de las stats de ese nivel.
+func memberGrowthRate(q config.Querier, currentMembers int, whereClause string, args ...interface{}) float64 {
+	var prevMembers int
+	query := "SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE " + whereClause + " AND created_at <= NOW() - INTERVAL '30 days'"
+	q.QueryRow(query, args...).Scan(&prevMembers)
+	if prevMembers <= 0 {
+		return 0
+	}
+	return float64(currentMembers-prevMembers) / float64(prevMembers) * 100
+}
+
 func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 	q, err := validateTx(c)
 	if err != nil {
@@ -1932,6 +1996,7 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 		PendingAlerts          int     `json:"pending_alerts"`
 		GroupsUnderSupervision int     `json:"groups_under_supervision"`
 		SubordinatesCount      int     `json:"subordinates_count"`
+		AuxiliarySupervisors   int     `json:"auxiliary_supervisors"`
 		PendingReports         int     `json:"pending_reports"`
 		ZoneName               string  `json:"zone_name"`
 	}
@@ -1947,6 +2012,7 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 			SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups
 			WHERE leader_id = $1 AND church_id = $2 AND status = 'active'
 		`, userID, churchID).Scan(&stats.TotalMembers)
+		stats.GrowthRate = memberGrowthRate(q, stats.TotalMembers, "leader_id = $1 AND church_id = $2 AND status = 'active'", userID, churchID)
 
 	case "2": // Supervisor Auxiliar - grupos que supervisa
 		q.QueryRow(`
@@ -1958,6 +2024,7 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 			SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups
 			WHERE supervisor_id = $1 AND church_id = $2 AND status = 'active'
 		`, userID, churchID).Scan(&stats.TotalMembers)
+		stats.GrowthRate = memberGrowthRate(q, stats.TotalMembers, "supervisor_id = $1 AND church_id = $2 AND status = 'active'", userID, churchID)
 
 		q.QueryRow(`
 			SELECT COUNT(DISTINCT leader_id) FROM discipleship_groups
@@ -1976,6 +2043,9 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 			SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups
 			WHERE leader_id IN (%s) AND church_id = $1 AND status = 'active'
 		`, subtreeLeaderIDsSubquery(1, 2)), churchID, userID).Scan(&stats.TotalMembers)
+		stats.GrowthRate = memberGrowthRate(q, stats.TotalMembers,
+			fmt.Sprintf("leader_id IN (%s) AND church_id = $1 AND status = 'active'", subtreeLeaderIDsSubquery(1, 2)),
+			churchID, userID)
 
 		// Zone name for display — still useful; read from the General's own hierarchy row.
 		var zoneID sql.NullString
@@ -1992,6 +2062,9 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 			SELECT COUNT(*) FROM discipleship_hierarchy
 			WHERE supervisor_id = $1 AND church_id = $2
 		`, userID, churchID).Scan(&stats.SubordinatesCount)
+		// Los reportes directos de un General son, precisamente, sus supervisores
+		// auxiliares (nivel 2) — mismo número, sin necesidad de otra query.
+		stats.AuxiliarySupervisors = stats.SubordinatesCount
 
 	case "4": // Coordinador - su zona
 		var coordZoneID sql.NullString
@@ -2009,6 +2082,7 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 				SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups
 				WHERE zone_id = $1 AND church_id = $2 AND status = 'active'
 			`, coordZoneID.String, churchID).Scan(&stats.TotalMembers)
+			stats.GrowthRate = memberGrowthRate(q, stats.TotalMembers, "zone_id = $1 AND church_id = $2 AND status = 'active'", coordZoneID.String, churchID)
 
 			q.QueryRow(`
 				SELECT COALESCE(name, '') FROM zones WHERE id = $1 AND church_id = $2
@@ -2025,11 +2099,10 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 		`, userID, churchID).Scan(&stats.SubordinatesCount)
 
 		q.QueryRow(`
-			SELECT COUNT(*) FROM cell_multiplication_tracking
-			WHERE church_id = $1
-			AND multiplication_date >= DATE_TRUNC('year', CURRENT_DATE)
-			AND success_status = 'successful'
-		`, churchID).Scan(&stats.Multiplications)
+			SELECT COUNT(*) FROM discipleship_hierarchy WHERE church_id = $1 AND hierarchy_level = 2
+		`, churchID).Scan(&stats.AuxiliarySupervisors)
+
+		stats.Multiplications = countSuccessfulMultiplications(q, churchID)
 
 	case "5": // Pastor - todo el sistema (scoped by church_id)
 		q.QueryRow(`
@@ -2039,17 +2112,17 @@ func (h *DiscipleshipHandler) GetDashboardStatsByLevel(c echo.Context) error {
 		q.QueryRow(`
 			SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE church_id = $1 AND status = 'active'
 		`, churchID).Scan(&stats.TotalMembers)
+		stats.GrowthRate = memberGrowthRate(q, stats.TotalMembers, "church_id = $1 AND status = 'active'", churchID)
 
 		q.QueryRow(`
 			SELECT COUNT(DISTINCT leader_id) FROM discipleship_groups WHERE church_id = $1 AND status = 'active'
 		`, churchID).Scan(&stats.ActiveLeaders)
 
 		q.QueryRow(`
-			SELECT COUNT(*) FROM cell_multiplication_tracking
-			WHERE church_id = $1
-			AND multiplication_date >= DATE_TRUNC('year', CURRENT_DATE)
-			AND success_status = 'successful'
-		`, churchID).Scan(&stats.Multiplications)
+			SELECT COUNT(*) FROM discipleship_hierarchy WHERE church_id = $1 AND hierarchy_level = 2
+		`, churchID).Scan(&stats.AuxiliarySupervisors)
+
+		stats.Multiplications = countSuccessfulMultiplications(q, churchID)
 	}
 
 	// Estadísticas comunes — leer de discipleship_reports
@@ -2204,7 +2277,7 @@ func (h *DiscipleshipHandler) GetLeaderGroupStats(c echo.Context) error {
 					CASE WHEN (r.report_data->>'service_attendance_sunday')::boolean THEN 1 ELSE 0 END +
 					CASE WHEN (r.report_data->>'service_attendance_prayer')::boolean THEN 1 ELSE 0 END +
 					CASE WHEN (r.report_data->>'doctrine_attendance')::boolean THEN 1 ELSE 0 END
-				)
+				) * 10.0 / 13.0
 				FROM discipleship_reports r
 				WHERE (r.report_data->>'group_id')::uuid = g.id
 				AND r.church_id = $2

--- a/apps/backend-go/handlers/discipleship.go
+++ b/apps/backend-go/handlers/discipleship.go
@@ -1719,6 +1719,64 @@ func nullIfEmpty(s string) interface{} {
 	return s
 }
 
+// GetActivityTimeline devuelve 24 buckets horarios (más viejo → más reciente)
+// con la cantidad de reportes REALES enviados en cada hora de las últimas 24h.
+// Respalda la línea de tiempo del mapa en vivo — nada de datos inventados, es
+// un COUNT sobre discipleship_reports.submitted_at.
+//
+// ponytail: buckets en horas de reloj del servidor (UTC), no alineados al
+// huso horario de la iglesia. Suficiente para el "vistazo en vivo" que pide
+// el diseño; si hace falta alinear a horas locales, sumar el offset acá.
+func (h *DiscipleshipHandler) GetActivityTimeline(c echo.Context) error {
+	q, err := validateTx(c)
+	if err != nil {
+		return err
+	}
+	dbGlobal := config.GetDB()
+	churchID, _ := c.Get("church_id").(string)
+	_, hierarchyLevel, _, canSeeAll := getDiscipleshipAccessInfo(c, dbGlobal)
+
+	userLevel := 5
+	if !canSeeAll && hierarchyLevel != nil {
+		userLevel = *hierarchyLevel
+	}
+
+	rows, err := q.Query(`
+		SELECT date_trunc('hour', submitted_at) as hour, COUNT(*)
+		FROM discipleship_reports
+		WHERE church_id = $1
+		AND report_level <= $2
+		AND submitted_at >= NOW() - INTERVAL '24 hours'
+		GROUP BY 1
+	`, churchID, userLevel)
+	if err != nil {
+		c.Logger().Error("Error fetching activity timeline:", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Error al obtener la línea de tiempo de actividad",
+		})
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var hour time.Time
+		var count int
+		if err := rows.Scan(&hour, &count); err != nil {
+			continue
+		}
+		counts[hour.UTC().Format("2006-01-02T15")] = count
+	}
+
+	now := time.Now().UTC()
+	buckets := make([]int, 24)
+	for i := 0; i < 24; i++ {
+		hourKey := now.Add(time.Duration(i-23) * time.Hour).Format("2006-01-02T15")
+		buckets[i] = counts[hourKey]
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{"buckets": buckets})
+}
+
 // GetMultiplications obtiene el historial de multiplicaciones
 func (h *DiscipleshipHandler) GetMultiplications(c echo.Context) error {
 	q, err := validateTx(c)

--- a/apps/backend-go/handlers/discipleship_alerts.go
+++ b/apps/backend-go/handlers/discipleship_alerts.go
@@ -146,7 +146,9 @@ func (h *DiscipleshipAlertsHandler) GetAlerts(c echo.Context) error {
 		UserName  string `json:"user_name,omitempty"`
 	}
 
-	var alerts []AlertWithDetails
+	// []AlertWithDetails{}, no nil: mismo motivo que GetReports — un slice nil
+	// serializa como JSON null y el frontend hace data.slice(...) sobre esto.
+	alerts := []AlertWithDetails{}
 	for rows.Next() {
 		var a AlertWithDetails
 		err = rows.Scan(

--- a/apps/backend-go/handlers/discipleship_reports.go
+++ b/apps/backend-go/handlers/discipleship_reports.go
@@ -126,12 +126,14 @@ func (h *DiscipleshipReportsHandler) CreateReport(c echo.Context) error {
 	db := config.GetDB()
 	go autoUpdateGoalProgressFromReport(db, userID, reportID, req.ReportData, churchID)
 
-	// Notify supervisor of new report (fire-and-forget)
+	// Notify supervisor of new report (fire-and-forget). Un Coordinador (tope
+	// de discipleship_hierarchy) no tiene supervisor_id — su reporte igual
+	// necesita avisarle a alguien: a todo admin/pastor de la iglesia.
+	db2 := db
+	repID := reportID
+	cID := churchID
 	if supervisorID.Valid && supervisorID.String != "" {
-		db2 := db
-		repID := reportID
 		supID := supervisorID.String
-		cID := churchID
 		go func() {
 			utils.CreateNotification(db2, models.NotificationInput{
 				ChurchID:          cID,
@@ -144,6 +146,37 @@ func (h *DiscipleshipReportsHandler) CreateReport(c echo.Context) error {
 				RelatedEntityType: utils.Ptr("report"),
 				RelatedEntityID:   &repID,
 			})
+		}()
+	} else {
+		go func() {
+			rows, err := db2.DB.Query(`
+				SELECT id FROM users WHERE church_id = $1 AND role IN ('admin', 'pastor') AND is_active = true
+			`, cID)
+			if err != nil {
+				log.Printf("[CreateReport] notify admins query failed: %v", err)
+				return
+			}
+			defer rows.Close()
+			var adminIDs []string
+			for rows.Next() {
+				var id string
+				if rows.Scan(&id) == nil {
+					adminIDs = append(adminIDs, id)
+				}
+			}
+			for _, adminID := range adminIDs {
+				utils.CreateNotification(db2, models.NotificationInput{
+					ChurchID:          cID,
+					UserID:            adminID,
+					Type:              "info",
+					Title:             "Nuevo reporte para revisar",
+					Message:           "El coordinador envió su reporte semanal.",
+					ActionURL:         utils.Ptr("/dashboard/discipleship?tab=reports"),
+					ActionText:        utils.Ptr("Ver reportes"),
+					RelatedEntityType: utils.Ptr("report"),
+					RelatedEntityID:   &repID,
+				})
+			}
 		}()
 	}
 

--- a/apps/backend-go/handlers/discipleship_reports.go
+++ b/apps/backend-go/handlers/discipleship_reports.go
@@ -589,6 +589,30 @@ func (h *DiscipleshipReportsHandler) ApproveReport(c echo.Context) error {
 		})
 	}()
 
+	// Notify the approver's OWN supervisor too — one level up from whoever
+	// approved (e.g. the líder's report gets approved by the aux, the aux's
+	// supervisor — the general — gets an FYI that a report moved through
+	// their downline, even though they didn't touch it themselves).
+	go func() {
+		var grandSupervisorID sql.NullString
+		db.DB.QueryRow(`
+			SELECT supervisor_id FROM discipleship_hierarchy WHERE user_id = $1 AND church_id = $2
+		`, userID, cID).Scan(&grandSupervisorID)
+		if grandSupervisorID.Valid && grandSupervisorID.String != "" {
+			utils.CreateNotification(db, models.NotificationInput{
+				ChurchID:          cID,
+				UserID:            grandSupervisorID.String,
+				Type:              "info",
+				Title:             "Se recibió un reporte en tu equipo",
+				Message:           "Un reporte fue revisado y aprobado en tu línea de supervisión.",
+				ActionURL:         utils.Ptr("/dashboard/discipleship?tab=reports"),
+				ActionText:        utils.Ptr("Ver reportes"),
+				RelatedEntityType: utils.Ptr("report"),
+				RelatedEntityID:   &repID,
+			})
+		}
+	}()
+
 	return c.JSON(http.StatusOK, map[string]string{
 		"message": "Reporte aprobado exitosamente",
 	})

--- a/apps/backend-go/handlers/discipleship_reports.go
+++ b/apps/backend-go/handlers/discipleship_reports.go
@@ -237,7 +237,10 @@ func (h *DiscipleshipReportsHandler) GetReports(c echo.Context) error {
 		ReporterName string `json:"reporter_name"`
 	}
 
-	var reports []ReportWithDetails
+	// []ReportWithDetails{}, no var-declared nil: un slice nil serializa como
+	// JSON null, y el frontend hace data.slice(...) sobre la respuesta — "cola
+	// vacía" real (0 filas) tiraba null.slice() del lado del cliente.
+	reports := []ReportWithDetails{}
 	for rows.Next() {
 		var r ReportWithDetails
 		var reportDataJSON []byte
@@ -546,8 +549,13 @@ func (h *DiscipleshipReportsHandler) ApproveReport(c echo.Context) error {
 		return err
 	}
 
-	// Verificar que el usuario es supervisor del reporte (scoped to church)
-	var supervisorID, reporterID string
+	// Verificar que el usuario es supervisor del reporte (scoped to church).
+	// supervisor_id es NULL para el reporte de un Coordinador (tope de la
+	// jerarquía, sin fila de supervisor) — escanear a sql.NullString, no a
+	// string: un Scan NULL→string falla y ese error caía en el mismo 404
+	// "Reporte no encontrado" que "la fila no existe", escondiendo el bug real.
+	var supervisorID sql.NullString
+	var reporterID string
 	err = q.QueryRow(`
 		SELECT supervisor_id, reporter_id FROM discipleship_reports WHERE id = $1 AND church_id = $2
 	`, reportID, churchID).Scan(&supervisorID, &reporterID)
@@ -562,7 +570,7 @@ func (h *DiscipleshipReportsHandler) ApproveReport(c echo.Context) error {
 	var userRole string
 	q.QueryRow("SELECT role FROM users WHERE id = $1 AND church_id = $2", userID, churchID).Scan(&userRole)
 
-	if supervisorID != userID && !utils.IsAdminRole(userRole) {
+	if supervisorID.String != userID && !utils.IsAdminRole(userRole) {
 		return c.JSON(http.StatusForbidden, map[string]string{
 			"error": "No tienes permisos para aprobar este reporte",
 		})

--- a/apps/backend-go/handlers/discipleship_reports.go
+++ b/apps/backend-go/handlers/discipleship_reports.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -337,17 +338,19 @@ func autoUpdateGoalProgressFromReport(db *config.Database, reporterID, reportID 
 
 		tx, err := db.DB.Begin()
 		if err != nil {
+			log.Printf("[autoUpdateGoalProgressFromReport] begin tx failed for assignment %s: %v", a.id, err)
 			continue
 		}
 
 		// Insert / update progress (idempotent per assignment + report)
 		_, err = tx.Exec(`
-			INSERT INTO goal_manual_progress (assignment_id, reporter_id, report_id, value_reported)
-			VALUES ($1, $2, $3, $4)
+			INSERT INTO goal_manual_progress (assignment_id, reporter_id, report_id, value_reported, church_id)
+			VALUES ($1, $2, $3, $4, $5)
 			ON CONFLICT (assignment_id, report_id) DO UPDATE
 				SET value_reported = EXCLUDED.value_reported
-		`, a.id, reporterID, reportID, value)
+		`, a.id, reporterID, reportID, value, churchID)
 		if err != nil {
+			log.Printf("[autoUpdateGoalProgressFromReport] insert progress failed for assignment %s: %v", a.id, err)
 			tx.Rollback()
 			continue
 		}
@@ -361,29 +364,44 @@ func autoUpdateGoalProgressFromReport(db *config.Database, reporterID, reportID 
 			WHERE id = $1
 		`, a.id)
 
-		// Step B: walk up the ancestor chain and recompute each as SUM of its children
-		tx.Exec(`
-			WITH RECURSIVE ancestors AS (
-				SELECT parent_assignment_id AS id
-				FROM goal_assignments WHERE id = $1 AND parent_assignment_id IS NOT NULL
-				UNION ALL
-				SELECT ga.parent_assignment_id
-				FROM goal_assignments ga
-				JOIN ancestors anc ON ga.id = anc.id
-				WHERE ga.parent_assignment_id IS NOT NULL
-			)
-			UPDATE goal_assignments ga
-			SET current_value = COALESCE(
-				(SELECT SUM(c.current_value) FROM goal_assignments c WHERE c.parent_assignment_id = ga.id), 0),
-				updated_at = NOW()
-			FROM ancestors anc WHERE ga.id = anc.id
-		`, a.id)
+		// Step B: walk up the ancestor chain ONE LEVEL AT A TIME. A single
+		// recursive-CTE UPDATE across every ancestor at once looks correct but
+		// isn't: every row's SET subquery reads the table's snapshot from the
+		// START of that statement, so a grandparent's SUM sees its child's OLD
+		// value, not the value this same statement is also writing to that
+		// child — only the immediate parent ever ends up correct, everything
+		// above it silently stays 0. Sequential single-level UPDATEs each see
+		// the prior UPDATE's committed write within the same tx, so the sum
+		// actually climbs the tree instead of stalling one hop up.
+		var parentID sql.NullString
+		tx.QueryRow(`SELECT parent_assignment_id FROM goal_assignments WHERE id = $1`, a.id).Scan(&parentID)
+		for parentID.Valid {
+			current := parentID.String
+			tx.Exec(`
+				UPDATE goal_assignments
+				SET current_value = COALESCE(
+					(SELECT SUM(current_value) FROM goal_assignments WHERE parent_assignment_id = $1), 0),
+					updated_at = NOW()
+				WHERE id = $1
+			`, current)
+			parentID = sql.NullString{}
+			tx.QueryRow(`SELECT parent_assignment_id FROM goal_assignments WHERE id = $1`, current).Scan(&parentID)
+		}
 
-		// Step C: sync root total into discipleship_goals.current_value
+		// Step C: sync root total into discipleship_goals.current_value.
+		// Unlike goal_assignments.progress_percentage (a GENERATED column that
+		// recomputes itself), discipleship_goals.progress_percentage is a plain
+		// column — GoalCard.tsx renders it directly, so it has to be set here too,
+		// not just current_value.
 		tx.Exec(`
 			UPDATE discipleship_goals g
 			SET current_value = COALESCE(
-				(SELECT SUM(current_value) FROM goal_assignments WHERE goal_id = g.id AND parent_assignment_id IS NULL), 0)
+				(SELECT SUM(current_value) FROM goal_assignments WHERE goal_id = g.id AND parent_assignment_id IS NULL), 0),
+				progress_percentage = CASE WHEN g.target_value > 0 THEN
+					ROUND(COALESCE(
+						(SELECT SUM(current_value) FROM goal_assignments WHERE goal_id = g.id AND parent_assignment_id IS NULL), 0
+					)::numeric / g.target_value * 100, 2)
+				ELSE 0 END
 			WHERE g.id = $1 AND g.church_id = $2
 		`, a.goalID, churchID)
 

--- a/apps/backend-go/handlers/discipleship_reports.go
+++ b/apps/backend-go/handlers/discipleship_reports.go
@@ -336,6 +336,19 @@ func autoUpdateGoalProgressFromReport(db *config.Database, reporterID, reportID 
 			continue
 		}
 
+		// Solo las HOJAS de la cascada toman su valor de un reporte directo. Un
+		// nodo intermedio (ej. un supervisor auxiliar) es una suma de sus hijos,
+		// NO su propio reporte — si un supervisor que además es asignado manda su
+		// reporte de supervisión, su valor extraído (a menudo 0, porque el
+		// reporte de supervisión no trae los campos de asistencia que agrega un
+		// objetivo de tipo attendance) pisaría la suma cascadeada de sus líderes.
+		// Los intermedios se recalculan solos por el Step B de las hojas.
+		var childCount int
+		db.DB.QueryRow(`SELECT COUNT(*) FROM goal_assignments WHERE parent_assignment_id = $1`, a.id).Scan(&childCount)
+		if childCount > 0 {
+			continue
+		}
+
 		tx, err := db.DB.Begin()
 		if err != nil {
 			log.Printf("[autoUpdateGoalProgressFromReport] begin tx failed for assignment %s: %v", a.id, err)

--- a/apps/backend-go/handlers/zones.go
+++ b/apps/backend-go/handlers/zones.go
@@ -646,7 +646,13 @@ func (h *ZonesHandler) GetMapData(c echo.Context) error {
 		COALESCE((
 			SELECT MAX(r.submitted_at)::text FROM discipleship_reports r
 			WHERE (r.report_data->>'group_id')::uuid = g.id AND r.church_id = z.church_id
-		), '') as last_report_date
+		), '') as last_report_date,
+		EXISTS (
+			SELECT 1 FROM discipleship_reports r
+			WHERE (r.report_data->>'group_id')::uuid = g.id
+			AND r.church_id = z.church_id
+			AND r.status = 'submitted'
+		) as has_pending_report
 	FROM zones z
 	LEFT JOIN users zu ON z.supervisor_id = zu.id
 	LEFT JOIN discipleship_groups g ON g.zone_id = z.id AND g.church_id = z.church_id
@@ -714,7 +720,7 @@ func (h *ZonesHandler) GetMapData(c echo.Context) error {
 			&group.ZoneName, &group.MeetingDay, &group.MeetingTime, &group.MeetingLocation, &group.MeetingAddress,
 			&group.Latitude, &group.Longitude,
 			&group.MemberCount, &group.ActiveMembers, &group.Status, &group.LeaderName, &group.SupervisorName,
-			&group.LastReportDate,
+			&group.LastReportDate, &group.HasPendingReport,
 		)
 		if err != nil {
 			c.Logger().Error("Error scanning map data:", err)

--- a/apps/backend-go/handlers/zones.go
+++ b/apps/backend-go/handlers/zones.go
@@ -642,7 +642,11 @@ func (h *ZonesHandler) GetMapData(c echo.Context) error {
 		COALESCE(g.active_members, 0) as active_members,
 		COALESCE(g.status, '') as status,
 		COALESCE(gl.first_name || ' ' || gl.last_name, 'Sin líder') as leader_name,
-		COALESCE(gs.first_name || ' ' || gs.last_name, '') as group_supervisor_name
+		COALESCE(gs.first_name || ' ' || gs.last_name, '') as group_supervisor_name,
+		COALESCE((
+			SELECT MAX(r.submitted_at)::text FROM discipleship_reports r
+			WHERE (r.report_data->>'group_id')::uuid = g.id AND r.church_id = z.church_id
+		), '') as last_report_date
 	FROM zones z
 	LEFT JOIN users zu ON z.supervisor_id = zu.id
 	LEFT JOIN discipleship_groups g ON g.zone_id = z.id AND g.church_id = z.church_id
@@ -710,6 +714,7 @@ func (h *ZonesHandler) GetMapData(c echo.Context) error {
 			&group.ZoneName, &group.MeetingDay, &group.MeetingTime, &group.MeetingLocation, &group.MeetingAddress,
 			&group.Latitude, &group.Longitude,
 			&group.MemberCount, &group.ActiveMembers, &group.Status, &group.LeaderName, &group.SupervisorName,
+			&group.LastReportDate,
 		)
 		if err != nil {
 			c.Logger().Error("Error scanning map data:", err)

--- a/apps/backend-go/handlers/zones.go
+++ b/apps/backend-go/handlers/zones.go
@@ -18,6 +18,54 @@ func NewZonesHandler() *ZonesHandler {
 	return &ZonesHandler{}
 }
 
+// zoneGrowthHealthSQL calcula, para una zona `z` en el WHERE externo, growth_rate y
+// health_index en vivo. Antes estos campos ni existían en la respuesta del backend —
+// el frontend los inventaba en 0 directamente (ver discipleship-analytics.service.ts).
+//
+//   - growth_rate: mismo criterio ya usado en dashboard.go (MonthlyGrowth) llevado a
+//     nivel de zona — compara miembros activos hoy contra miembros de grupos que ya
+//     existían hace 30 días (proxy de "cuántos había entonces", no un snapshot real).
+//   - health_index: promedio simple 0-100 entre asistencia real (últimos 30 días) y
+//     salud espiritual (mismos 13 indicadores del reporte semanal que ya se usan en
+//     discipulado, reescalados a /100). Es una definición nueva — antes no existía
+//     ningún cálculo de "salud" de zona en el backend.
+const zoneGrowthHealthSQL = `
+	COALESCE(
+		((SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE zone_id = z.id AND status = 'active')::float
+		- (SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE zone_id = z.id AND status = 'active' AND created_at <= NOW() - INTERVAL '30 days')::float)
+		/ NULLIF((SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE zone_id = z.id AND status = 'active' AND created_at <= NOW() - INTERVAL '30 days'), 0) * 100
+	, 0) as growth_rate,
+	COALESCE((
+		COALESCE((
+			SELECT ROUND(AVG(CASE WHEN a.present THEN 100.0 ELSE 0.0 END), 2)
+			FROM discipleship_attendance a
+			JOIN discipleship_groups ga ON a.group_id = ga.id
+			WHERE ga.zone_id = z.id AND a.meeting_date >= CURRENT_DATE - INTERVAL '30 days'
+		), 0)
+		+
+		COALESCE((
+			SELECT AVG(
+				CASE WHEN COALESCE((r.report_data->>'attendance_nd')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'attendance_dm')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'attendance_friends')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'attendance_kids')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'group_discipleships')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'group_evangelism')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'leader_new_disciples_care')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'leader_mature_disciples_care')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'spiritual_journal_days')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN COALESCE((r.report_data->>'leader_evangelism')::int, 0) > 0 THEN 1 ELSE 0 END +
+				CASE WHEN (r.report_data->>'service_attendance_sunday')::boolean THEN 1 ELSE 0 END +
+				CASE WHEN (r.report_data->>'service_attendance_prayer')::boolean THEN 1 ELSE 0 END +
+				CASE WHEN (r.report_data->>'doctrine_attendance')::boolean THEN 1 ELSE 0 END
+			) * 100.0 / 13.0
+			FROM discipleship_reports r
+			JOIN discipleship_groups gr ON (r.report_data->>'group_id')::uuid = gr.id
+			WHERE gr.zone_id = z.id AND r.period_end >= CURRENT_DATE - INTERVAL '28 days'
+		), 0)
+	) / 2.0, 0) as health_index
+`
+
 type geoJSONGeometry struct {
 	Type        string           `json:"type"`
 	Coordinates *json.RawMessage `json:"coordinates"`
@@ -71,7 +119,13 @@ func (h *ZonesHandler) GetZones(c echo.Context) error {
 		z.boundaries, COALESCE(z.center_lat, 0) as center_lat, COALESCE(z.center_lng, 0) as center_lng, z.is_active,
 		(SELECT COUNT(*) FROM discipleship_groups WHERE zone_id = z.id AND status = 'active') as total_groups,
 		(SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE zone_id = z.id AND status = 'active') as total_members,
-		COALESCE(z.avg_attendance, 0) as avg_attendance,
+		COALESCE((
+			SELECT ROUND(AVG(CASE WHEN a.present THEN 100.0 ELSE 0.0 END), 2)
+			FROM discipleship_attendance a
+			JOIN discipleship_groups gz ON a.group_id = gz.id
+			WHERE gz.zone_id = z.id AND a.meeting_date >= CURRENT_DATE - INTERVAL '30 days'
+		), 0) as avg_attendance,
+		` + zoneGrowthHealthSQL + `,
 		z.created_at, z.updated_at,
 		COALESCE(u.first_name || ' ' || u.last_name, '') as
 		supervisor_name
@@ -121,6 +175,7 @@ func (h *ZonesHandler) GetZones(c echo.Context) error {
 			&z.ID, &z.Name, &z.Description, &z.Color, &z.SupervisorID,
 			&z.Boundaries, &z.CenterLat, &z.CenterLng, &z.IsActive,
 			&z.TotalGroups, &z.TotalMembers, &z.AvgAttendance,
+			&z.GrowthRate, &z.HealthIndex,
 			&z.CreatedAt, &z.UpdatedAt, &z.SupervisorName,
 		)
 		if err != nil {
@@ -148,7 +203,13 @@ func (h *ZonesHandler) GetZone(c echo.Context) error {
 		z.boundaries, COALESCE(z.center_lat, 0) as center_lat, COALESCE(z.center_lng, 0) as center_lng, z.is_active,
 		(SELECT COUNT(*) FROM discipleship_groups WHERE zone_id = z.id AND status = 'active') as total_groups,
 		(SELECT COALESCE(SUM(member_count), 0) FROM discipleship_groups WHERE zone_id = z.id AND status = 'active') as total_members,
-		COALESCE(z.avg_attendance, 0) as avg_attendance,
+		COALESCE((
+			SELECT ROUND(AVG(CASE WHEN a.present THEN 100.0 ELSE 0.0 END), 2)
+			FROM discipleship_attendance a
+			JOIN discipleship_groups gz ON a.group_id = gz.id
+			WHERE gz.zone_id = z.id AND a.meeting_date >= CURRENT_DATE - INTERVAL '30 days'
+		), 0) as avg_attendance,
+		` + zoneGrowthHealthSQL + `,
 		z.created_at, z.updated_at,
 		COALESCE(u.first_name || ' ' || u.last_name, '') as supervisor_name
 		FROM zones z
@@ -161,6 +222,7 @@ func (h *ZonesHandler) GetZone(c echo.Context) error {
 		&z.ID, &z.Name, &z.Description, &z.Color, &z.SupervisorID,
 		&z.Boundaries, &z.CenterLat, &z.CenterLng, &z.IsActive,
 		&z.TotalGroups, &z.TotalMembers, &z.AvgAttendance,
+		&z.GrowthRate, &z.HealthIndex,
 		&z.CreatedAt, &z.UpdatedAt, &z.SupervisorName,
 	)
 

--- a/apps/backend-go/main.go
+++ b/apps/backend-go/main.go
@@ -17,9 +17,21 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
+// localDevOrigins son los orígenes de frontend que se usan en desarrollo
+// local en esta máquina (SionERP en :5173/:5174, BonDev en :8080). Sirven de
+// default cuando CORS_ORIGINS no está seteado — production siempre lo setea
+// explícito (ver deploy), así que este fallback solo corre local.
+var localDevOrigins = []string{
+	"http://localhost:5173",
+	"http://localhost:5174",
+	"http://localhost:8080",
+	"http://localhost:8081",
+}
+
 // corsAllowOrigins resuelve la lista de orígenes permitidos desde
-// CORS_ORIGINS (coma-separado). Sin setear, devuelve ["*"] — el
-// comportamiento previo, sin cambios de default.
+// CORS_ORIGINS (coma-separado). Sin setear, devuelve localDevOrigins — antes
+// caía a ["*"], que es exactamente la combinación que el spec de CORS
+// prohíbe con AllowCredentials=true.
 //
 // Gotcha real (encontrado en vivo, 2026-07-24): "*" + AllowCredentials=true
 // es una combinación que el spec de CORS prohíbe — el browser bloquea
@@ -27,13 +39,14 @@ import (
 // (falla con net::ERR_FAILED, sin mensaje útil en la Network tab más allá
 // de eso). Esto rompe, por ejemplo, el acceso federado (BonDev): la cookie
 // httpOnly de sesión nunca llega si el frontend corre en un origen
-// distinto al backend (dev local: :5173 vs :8181). Setear CORS_ORIGINS con
-// los orígenes reales (ej. "http://localhost:5173,https://sionerp.app")
-// arregla esto sin tocar código.
+// distinto al backend (dev local: :5173 vs :8181). Con CORS_ORIGINS sin
+// setear, arrancar el backend "a mano" (sin pasar por .claude/launch.json)
+// caía en "*" y rompía el login apenas el frontend corría en un puerto
+// distinto al de siempre (ej. :8080) — de ahí el default explícito.
 func corsAllowOrigins() []string {
 	v := os.Getenv("CORS_ORIGINS")
 	if v == "" {
-		return []string{"*"}
+		return localDevOrigins
 	}
 	var origins []string
 	for _, o := range strings.Split(v, ",") {
@@ -42,7 +55,7 @@ func corsAllowOrigins() []string {
 		}
 	}
 	if len(origins) == 0 {
-		return []string{"*"}
+		return localDevOrigins
 	}
 	return origins
 }

--- a/apps/backend-go/models/discipleship.go
+++ b/apps/backend-go/models/discipleship.go
@@ -195,15 +195,16 @@ type CreateMultiplicationRequest struct {
 // =====================================================
 
 type DiscipleshipAnalytics struct {
-	TotalGroups       int                  `json:"total_groups"`
-	TotalMembers      int                  `json:"total_members"`
-	AverageAttendance float64              `json:"average_attendance"`
-	GrowthRate        float64              `json:"growth_rate"`
-	ActiveLeaders     int                  `json:"active_leaders"`
-	Multiplications   int                  `json:"multiplications"`
-	SpiritualHealth   float64              `json:"spiritual_health"`
-	PendingAlerts     int                  `json:"pending_alerts"`
-	GroupPerformance  []GroupPerformance   `json:"group_performance,omitempty"`
+	TotalGroups            int                `json:"total_groups"`
+	TotalMembers           int                `json:"total_members"`
+	AverageAttendance      float64            `json:"average_attendance"`
+	GrowthRate             float64            `json:"growth_rate"`
+	ActiveLeaders          int                `json:"active_leaders"`
+	Multiplications        int                `json:"multiplications"`
+	SpiritualHealth        float64            `json:"spiritual_health"`
+	PendingAlerts          int                `json:"pending_alerts"`
+	AuxiliarySupervisors   int                `json:"auxiliary_supervisors"`
+	GroupPerformance       []GroupPerformance `json:"group_performance,omitempty"`
 }
 
 type GroupPerformance struct {

--- a/apps/backend-go/models/zone.go
+++ b/apps/backend-go/models/zone.go
@@ -18,6 +18,8 @@ type Zone struct {
 	TotalGroups   int              `json:"total_groups"`
 	TotalMembers  int              `json:"total_members"`
 	AvgAttendance float64          `json:"avg_attendance"`
+	GrowthRate    float64          `json:"growth_rate"`
+	HealthIndex   float64          `json:"health_index"`
 	CreatedAt     time.Time        `json:"created_at"`
 	UpdatedAt     time.Time        `json:"updated_at"`
 }

--- a/apps/backend-go/models/zone.go
+++ b/apps/backend-go/models/zone.go
@@ -80,6 +80,7 @@ type ZoneMapGroup struct {
 	Status          string  `json:"status"`
 	LeaderName      string  `json:"leader_name"`
 	SupervisorName  string  `json:"supervisor_name.omitempty"`
+	LastReportDate  string  `json:"last_report_date"`
 }
 
 type ZoneMapData struct {

--- a/apps/backend-go/models/zone.go
+++ b/apps/backend-go/models/zone.go
@@ -81,6 +81,9 @@ type ZoneMapGroup struct {
 	LeaderName      string  `json:"leader_name"`
 	SupervisorName  string  `json:"supervisor_name.omitempty"`
 	LastReportDate  string  `json:"last_report_date"`
+	// HasPendingReport: el grupo tiene un reporte enviado (status='submitted')
+	// todavía sin aprobar. En el mapa, su marcador titila hasta que lo aprueban.
+	HasPendingReport bool `json:"has_pending_report"`
 }
 
 type ZoneMapData struct {

--- a/apps/backend-go/routes/routes.go
+++ b/apps/backend-go/routes/routes.go
@@ -224,6 +224,7 @@ func SetupRoutes(e *echo.Echo) {
 
 		// Analytics
 		discipleship.GET("/analytics", discipleshipHandler.GetAnalytics)
+		discipleship.GET("/analytics/timeline", discipleshipHandler.GetActivityTimeline)
 		// Las siguientes rutas se integraron en /analytics
 		// discipleship.GET("/analytics/zones", discipleshipHandler.GetZoneStats)
 		// discipleship.GET("/analytics/performance", discipleshipHandler.GetGroupPerformance)

--- a/scripts/prod-fix-orphaned-report-supervisors.sql
+++ b/scripts/prod-fix-orphaned-report-supervisors.sql
@@ -1,0 +1,47 @@
+-- ─────────────────────────────────────────────────────────────────────────
+-- Fix: discipleship_reports.supervisor_id huérfano
+-- ─────────────────────────────────────────────────────────────────────────
+-- Bug real, no específico de una demo: CreateReport() completa
+-- supervisor_id leyendo discipleship_hierarchy en el momento del envío, pero
+-- cualquier reporte insertado por fuera de ese endpoint (bulk seed, importes,
+-- migraciones manuales) se queda con supervisor_id = NULL — y GetReports()
+-- filtra la cola de "pendientes de revisar" por supervisor_id = yo, así que
+-- esos reportes nunca le llegan a nadie. Verificado en local: 928 de 929
+-- reportes de una sola iglesia estaban en este estado.
+--
+-- Esta migración de datos es segura de re-correr (solo toca filas con
+-- supervisor_id IS NULL) y aplica a TODAS las iglesias del sistema, no solo
+-- a la que estés demoing — es la misma fuente de verdad
+-- (discipleship_hierarchy) que ya usa el código real.
+--
+-- Uso:
+--   psql "$DATABASE_URL" -f scripts/prod-fix-orphaned-report-supervisors.sql
+--
+-- Antes de correr contra producción: hacé un SELECT COUNT(*) del WHERE de
+-- abajo para ver cuántas filas va a tocar, y confirmá que tenés un backup
+-- reciente (Supabase hace backups automáticos, pero medí el impacto primero).
+
+BEGIN;
+
+-- Preview — cuántas filas se van a actualizar (no cambia nada todavía)
+SELECT COUNT(*) AS reportes_a_corregir
+FROM discipleship_reports r
+JOIN discipleship_hierarchy h
+  ON r.reporter_id = h.user_id AND r.church_id = h.church_id
+WHERE r.supervisor_id IS NULL
+  AND h.supervisor_id IS NOT NULL;
+
+UPDATE discipleship_reports r
+SET supervisor_id = h.supervisor_id
+FROM discipleship_hierarchy h
+WHERE r.reporter_id = h.user_id
+  AND r.church_id = h.church_id
+  AND r.supervisor_id IS NULL
+  AND h.supervisor_id IS NOT NULL;
+
+COMMIT;
+
+-- Nota: esto NO toca el status de los reportes (quedan como estaban:
+-- draft/submitted/approved/needs_attention). A diferencia del seed local, en
+-- producción los reportes 'submitted' son revisiones reales pendientes de un
+-- humano — no se aprueban en bloque acá.

--- a/scripts/prod-seed-goal-cascade.py
+++ b/scripts/prod-seed-goal-cascade.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Crea un objetivo real + su cascada de asignaciones (Coordinador → Sup.
+General → Sup. Auxiliar → Líder) para UNA zona, contra el backend real —
+mismo camino de código que usa la app en producción, ningún atajo por SQL
+directo. No crea cuentas, no renombra a nadie, no toca contraseñas: usa el
+login real de quien ya tiene sesión en esa jerarquía.
+
+Requiere que quien ejecuta el script tenga las credenciales reales de UN
+usuario con visibilidad total del módulo (pastor/staff, o el propio
+Coordinador de la zona — ambos ya tienen "canSeeAll" en el backend) para:
+  1) leer /discipleship/hierarchy y ubicar la cadena líder→...→coordinador
+     de la zona pedida,
+  2) crear el objetivo,
+  3) crear la cascada de asignaciones.
+
+Uso:
+    python3 scripts/prod-seed-goal-cascade.py \\
+        --supabase-url https://TU-PROYECTO.supabase.co \\
+        --supabase-anon-key eyJ... \\
+        --api-url https://sionerp.onrender.com \\
+        --email pastor@tuiglesia.com \\
+        --password '********' \\
+        --zone "OESTE 1" \\
+        --goal-type attendance \\
+        --title "Asistencia mensual — Zona OESTE 1" \\
+        --target-metric asistencia_total \\
+        --target-value 40 \\
+        --deadline 2026-09-30
+
+Variables de entorno equivalentes (evita pasar la password por argv):
+    SEED_SUPABASE_URL, SEED_SUPABASE_ANON_KEY, SEED_API_URL,
+    SEED_EMAIL, SEED_PASSWORD
+
+Salida: crea el objetivo + 4 niveles de asignación (target_value se reparte
+igual en cada nivel salvo el líder, que recibe target-value/4 redondeado —
+ajustá con --leader-target si querés un número distinto). Cada asignación
+dispara la notificación real al asignado (ver commit "notifica a todos los
+involucrados..."). No somete ningún reporte — eso lo hace el líder de
+verdad, en vivo, durante la demo: es justamente el momento que hace subir la
+cascada y es más elocuente hacerlo en pantalla que simularlo acá.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def env_default(flag_env, argv_val):
+    return argv_val if argv_val is not None else os.environ.get(flag_env)
+
+
+def die(msg):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def http(method, url, headers=None, payload=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            body = r.read().decode()
+            return r.status, (json.loads(body) if body else {})
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        try:
+            return e.code, json.loads(body)
+        except Exception:
+            return e.code, {"raw": body[:500]}
+
+
+def login(supabase_url, anon_key, email, password):
+    st, body = http(
+        "POST",
+        f"{supabase_url}/auth/v1/token?grant_type=password",
+        headers={"apikey": anon_key, "Content-Type": "application/json"},
+        payload={"email": email, "password": password},
+    )
+    if st != 200 or "access_token" not in body:
+        die(f"Login falló ({st}): {body}")
+    return body["access_token"]
+
+
+def api(method, api_url, token, path, payload=None):
+    return http(
+        method,
+        f"{api_url}/api/v1{path}",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        payload=payload,
+    )
+
+
+LEVEL_NAME = {1: "líder", 2: "auxiliar", 3: "general", 4: "coordinador"}
+
+
+def resolve_chain(api_url, token, zone_name, email_overrides):
+    st, rows = api("GET", api_url, token, "/discipleship/hierarchy")
+    if st != 200 or not isinstance(rows, list):
+        die(f"No se pudo leer /discipleship/hierarchy ({st}): {rows}")
+
+    by_level = {1: [], 2: [], 3: [], 4: []}
+    for r in rows:
+        lvl = r.get("hierarchy_level")
+        if lvl in by_level and (r.get("zone_name") or "").strip().upper() == zone_name.strip().upper():
+            by_level[lvl].append(r)
+
+    missing = [lvl for lvl in (1, 2, 3, 4) if not by_level[lvl]]
+    if missing:
+        die(
+            f"No encontré usuario(s) de nivel {missing} en la zona {zone_name!r}. "
+            f"Revisá el nombre exacto de la zona (case-insensitive) o completá "
+            f"la jerarquía en /dashboard/discipleship antes de correr esto."
+        )
+
+    chain = {}
+    for lvl in (1, 2, 3, 4):
+        candidates = by_level[lvl]
+        override_email = email_overrides.get(lvl)
+        if override_email:
+            matches = [c for c in candidates if c["user_email"].strip().lower() == override_email.strip().lower()]
+            if not matches:
+                die(
+                    f"--{LEVEL_NAME[lvl]}-email {override_email!r} no aparece como nivel {lvl} "
+                    f"en la zona {zone_name!r}."
+                )
+            chosen = matches[0]
+        else:
+            chosen = candidates[0]
+            if len(candidates) > 1:
+                print(
+                    f"  aviso: {len(candidates)} usuarios de nivel {lvl} en la zona "
+                    f"{zone_name!r} — usando a {chosen['user_name']!r} "
+                    f"({chosen['user_email']}). Pasá --{LEVEL_NAME[lvl]}-email si "
+                    f"querés otro."
+                )
+        chain[lvl] = chosen
+        print(f"  nivel {lvl}: {chosen['user_name']} <{chosen['user_email']}>")
+    return chain
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--supabase-url")
+    p.add_argument("--supabase-anon-key")
+    p.add_argument("--api-url")
+    p.add_argument("--email")
+    p.add_argument("--password")
+    p.add_argument("--zone", required=True, help="Nombre exacto de la zona (ej. 'OESTE 1')")
+    p.add_argument("--goal-type", default="attendance",
+                    choices=["growth", "attendance", "conversions", "baptisms",
+                             "new_groups", "multiplications", "spiritual_health", "personalizado"])
+    p.add_argument("--title", required=True)
+    p.add_argument("--description", default="")
+    p.add_argument("--target-metric", required=True)
+    p.add_argument("--target-value", type=float, required=True)
+    p.add_argument("--deadline", required=True, help="YYYY-MM-DD")
+    p.add_argument("--priority", type=int, default=2)
+    p.add_argument("--measurement-type", default="automatic", choices=["automatic", "manual"])
+    p.add_argument("--leader-target-value", type=float, default=None,
+                    help="Target del líder, si querés uno distinto al del resto de la cascada")
+    p.add_argument("--leader-email", help="Desambiguar qué líder usar si la zona tiene varios")
+    p.add_argument("--aux-email", help="Desambiguar qué sup. auxiliar usar si la zona tiene varios")
+    p.add_argument("--general-email", help="Desambiguar qué sup. general usar si la zona tiene varios")
+    p.add_argument("--coordinador-email", help="Desambiguar qué coordinador usar si la zona tiene varios")
+    args = p.parse_args()
+
+    supabase_url = env_default("SEED_SUPABASE_URL", args.supabase_url)
+    anon_key = env_default("SEED_SUPABASE_ANON_KEY", args.supabase_anon_key)
+    api_url = env_default("SEED_API_URL", args.api_url)
+    email = env_default("SEED_EMAIL", args.email)
+    password = env_default("SEED_PASSWORD", args.password)
+
+    missing_cfg = [n for n, v in [
+        ("--supabase-url/SEED_SUPABASE_URL", supabase_url),
+        ("--supabase-anon-key/SEED_SUPABASE_ANON_KEY", anon_key),
+        ("--api-url/SEED_API_URL", api_url),
+        ("--email/SEED_EMAIL", email),
+        ("--password/SEED_PASSWORD", password),
+    ] if not v]
+    if missing_cfg:
+        die("Faltan parámetros: " + ", ".join(missing_cfg))
+
+    print(f"Login como {email} ...")
+    token = login(supabase_url, anon_key, email, password)
+    print("  OK\n")
+
+    print(f"Resolviendo cadena jerárquica de la zona {args.zone!r} ...")
+    email_overrides = {1: args.leader_email, 2: args.aux_email, 3: args.general_email, 4: args.coordinador_email}
+    chain = resolve_chain(api_url, token, args.zone, email_overrides)
+    print()
+
+    zone_id = chain[4].get("zone_id") or chain[3].get("zone_id")
+
+    print(f"Creando objetivo {args.title!r} ...")
+    st, goal = api("POST", api_url, token, "/discipleship/goals", {
+        "goal_type": args.goal_type,
+        "title": args.title,
+        "description": args.description,
+        "target_metric": args.target_metric,
+        "target_value": int(args.target_value),  # CreateGoalRequest.TargetValue es int en el backend
+        "deadline": args.deadline,
+        "zone_id": zone_id or None,
+        "priority": args.priority,
+        "measurement_type": args.measurement_type,
+    })
+    if st != 201:
+        die(f"CreateGoal falló ({st}): {goal}")
+    goal_id = goal["goal_id"]
+    print(f"  goal_id = {goal_id}\n")
+
+    leader_target = args.leader_target_value if args.leader_target_value is not None else args.target_value / 4
+
+    print("Creando cascada de asignaciones ...")
+    parent_id = None
+    targets = {4: args.target_value, 3: args.target_value, 2: args.target_value, 1: leader_target}
+    for lvl in (4, 3, 2, 1):
+        user = chain[lvl]
+        st, body = api("POST", api_url, token, f"/discipleship/goals/{goal_id}/assignments", {
+            "assignments": [{
+                "assigned_to": user["user_id"],
+                "target_value": targets[lvl],
+                "parent_assignment_id": parent_id,
+            }]
+        })
+        if st != 201 or not body.get("created"):
+            die(f"Assignment nivel {lvl} falló ({st}): {body}")
+        parent_id = body["created"][0]["id"]
+        print(f"  nivel {lvl} ({user['user_name']}): target={targets[lvl]} -> assignment_id={parent_id}")
+
+    print(f"""
+Listo. Objetivo creado con cascada completa en la zona {args.zone!r}.
+  - Cada asignado ya recibió su notificación ("Se te asignó un objetivo").
+  - Para ver la cascada moverse en vivo: pedile al líder que someta su
+    reporte semanal real desde /dashboard/discipleship — el progreso sube
+    solo, líder → auxiliar → general → coordinador, y las notificaciones de
+    "nuevo reporte" / "reporte aprobado" / "se recibió un reporte en tu
+    equipo" salen exactamente en ese momento, no antes.
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/components/dashboard/DiscipleshipAnalyticsSection.tsx
+++ b/src/components/dashboard/DiscipleshipAnalyticsSection.tsx
@@ -113,12 +113,14 @@ export const DiscipleshipAnalyticsSection = ({
     return 'text-muted-foreground';
   };
 
-  // Datos para el radar chart de salud espiritual por zona
+  // Datos para el radar chart de salud espiritual por zona — el eje va 0-10
+  // (PolarRadiusAxis domain={[0, 10]}), así que healthIndex y avgAttendance
+  // (ambos 0-100) se normalizan /10. Antes "asistencia" usaba /20*10 (=/2),
+  // que para cualquier asistencia > 20% ya se salía del eje y quedaba recortada.
   const spiritualHealthRadarData = zoneStats.map(zone => ({
     zone: zone.zoneName.replace('Zona ', ''),
-    salud: zone.healthIndex || 0,
-    asistencia: (zone.avgAttendance / 20) * 10,
-    crecimiento: Math.max(0, zone.growthRate / 2),
+    salud: (zone.healthIndex || 0) / 10,
+    asistencia: (zone.avgAttendance || 0) / 10,
   }));
 
   // Formatear tendencias semanales con fechas legibles

--- a/src/components/discipleship/DiscipleshipMap.tsx
+++ b/src/components/discipleship/DiscipleshipMap.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/drawer';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
+import { supabase } from '@/integrations/supabase/client';
 import { useMobileMode } from '@/hooks/useMobileMode';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import { ZonesService } from '@/services/zones.service';
@@ -80,11 +81,10 @@ const TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const TILE_ATTRIBUTION =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
-// Cada cuánto se refresca el mapa para detectar reportes nuevos (ripple) y
-// actualizar el contador EN VIVO / la línea de tiempo. No hay push real
-// (Supabase Realtime) todavía — polling es el fallback explícito que
-// contempla el propio diseño.
-const LIVE_POLL_MS = 30_000;
+// Poll de RESPALDO del mapa. Realtime (suscripción a discipleship_reports) es
+// el camino rápido; este intervalo solo cubre el caso de que Realtime no
+// conecte, y además se pausa cuando la pestaña está oculta.
+const LIVE_POLL_MS = 60_000;
 
 // ── Actividad de reporte (estado real, no inventado) ─────────
 // El diseño original pedía un semáforo de "creció / sin cambios / sin
@@ -411,23 +411,22 @@ export default function DiscipleshipMap({
     setInternalSelectedZoneId(selectedZoneId ?? null);
   }, [selectedZoneId]);
 
-  // Cargar zonas + grupos, con polling para refrescar el estado en vivo
-  // (titileo de reportes pendientes, contador EN VIVO) sin resetear el
-  // viewport del usuario. El titileo lo decide has_pending_report del backend,
-  // así que no hace falta maquinaria de timeouts en el cliente.
+  // Datos del mapa en vivo: carga inicial + Realtime (refresco instantáneo al
+  // cambiar un reporte) + polling de respaldo pausado cuando la pestaña está
+  // oculta. El titileo lo decide has_pending_report del backend, así que no
+  // hace falta maquinaria de timeouts en el cliente.
   useEffect(() => {
     let cancelled = false;
 
-    const load = async (isFirstLoad: boolean) => {
+    const loadZones = async (isFirstLoad: boolean) => {
       try {
         if (isFirstLoad) setLoading(true);
         const response = await ZonesService.getMapData({ is_active: true });
         if (cancelled) return;
         const zones = response.zones || [];
-
         // Solo re-renderizar si la data realmente cambió. Sin este guard, cada
-        // poll reemplaza el array completo y remonta todos los marcadores (nuevos
-        // L.divIcon → setIcon → reinicia animaciones) = el pestañeo cada 30s.
+        // refresco reemplaza el array completo y remonta todos los marcadores
+        // (nuevos L.divIcon → setIcon → reinicia animaciones) = pestañeo.
         const sig = JSON.stringify(zones);
         if (sig !== lastZonesSig.current) {
           lastZonesSig.current = sig;
@@ -438,17 +437,6 @@ export default function DiscipleshipMap({
       }
     };
 
-    void load(true);
-    const interval = setInterval(() => void load(false), LIVE_POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, []);
-
-  // Línea de tiempo (24h reales) — mismo ciclo de refresco que el mapa.
-  useEffect(() => {
-    let cancelled = false;
     const loadTimeline = async () => {
       try {
         const buckets = await DiscipleshipService.getActivityTimeline();
@@ -461,11 +449,66 @@ export default function DiscipleshipMap({
         console.error('Error loading activity timeline:', err);
       }
     };
+
+    const refresh = () => {
+      void loadZones(false);
+      void loadTimeline();
+    };
+
+    // Carga inicial
+    void loadZones(true);
     void loadTimeline();
-    const interval = setInterval(loadTimeline, LIVE_POLL_MS);
+
+    // Realtime: un cambio en discipleship_reports (nuevo reporte, aprobación o
+    // rechazo) refresca al instante — sin esperar el próximo poll. Scopeado por
+    // iglesia vía el JWT (la policy reports_realtime_church_staff filtra por
+    // church_id). Debounce para agrupar ráfagas en un solo refresh.
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    const setupRealtime = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user || cancelled) return;
+      const churchId = (user.app_metadata as { church_id?: string } | undefined)?.church_id;
+      channel = supabase
+        .channel('map-reports')
+        .on(
+          'postgres_changes',
+          {
+            event: '*',
+            schema: 'public',
+            table: 'discipleship_reports',
+            ...(churchId ? { filter: `church_id=eq.${churchId}` } : {}),
+          },
+          () => {
+            if (cancelled) return;
+            if (debounce) clearTimeout(debounce);
+            debounce = setTimeout(refresh, 400);
+          }
+        )
+        .subscribe();
+    };
+    void setupRealtime();
+
+    // Polling de respaldo (por si Realtime no conecta, ej. dev sin websockets):
+    // solo cuando la pestaña está visible, para no generar "recargas" en background.
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'visible') refresh();
+    }, LIVE_POLL_MS);
+
+    // Al volver a la pestaña, refrescar una vez (pudo cambiar mientras no mirabas).
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+
     return () => {
       cancelled = true;
       clearInterval(interval);
+      if (debounce) clearTimeout(debounce);
+      document.removeEventListener('visibilitychange', onVisible);
+      if (channel) void supabase.removeChannel(channel);
     };
   }, []);
 

--- a/src/components/discipleship/DiscipleshipMap.tsx
+++ b/src/components/discipleship/DiscipleshipMap.tsx
@@ -398,6 +398,9 @@ export default function DiscipleshipMap({
   const [activityBuckets, setActivityBuckets] = useState<number[]>(new Array(24).fill(0));
   const lastReportByGroup = useRef<Map<string, string>>(new Map());
   const pulseTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // Firma de la última tanda de zonas renderizada — para saltar el re-render
+  // cuando el poll trae exactamente lo mismo (evita el pestañeo de marcadores).
+  const lastZonesSig = useRef<string>('');
 
   // Map navigation state
   const [fitToBounds, setFitToBounds] = useState<{ bounds: L.LatLngBounds; key: string } | null>(
@@ -424,7 +427,6 @@ export default function DiscipleshipMap({
         const response = await ZonesService.getMapData({ is_active: true });
         if (cancelled) return;
         const zones = response.zones || [];
-        setZoneData(zones);
 
         // Diff contra el poll anterior: si last_report_date cambió, ese grupo
         // "acaba de reportar" — dispara el ripple ~10s. No dispara en la
@@ -465,6 +467,17 @@ export default function DiscipleshipMap({
         lastReportByGroup.current = new Map(
           zones.flatMap(zd => zd.groups.map(g => [g.id, g.last_report_date || '']))
         );
+
+        // Solo re-renderizar si la data realmente cambió. Sin este guard, cada
+        // poll reemplaza el array completo y remonta todos los marcadores (nuevos
+        // L.divIcon → setIcon → reinicia animaciones) = el pestañeo cada 30s.
+        // Cuando SÍ cambia (nuevo reporte), re-renderiza una vez, que es justo
+        // cuando querés que aparezca el ripple.
+        const sig = JSON.stringify(zones);
+        if (sig !== lastZonesSig.current) {
+          lastZonesSig.current = sig;
+          setZoneData(zones);
+        }
       } finally {
         if (isFirstLoad) setLoading(false);
       }
@@ -489,7 +502,11 @@ export default function DiscipleshipMap({
     const loadTimeline = async () => {
       try {
         const buckets = await DiscipleshipService.getActivityTimeline();
-        if (!cancelled) setActivityBuckets(buckets);
+        if (cancelled) return;
+        // Mantener la misma referencia si los 24 buckets son idénticos → sin re-render.
+        setActivityBuckets(prev =>
+          prev.length === buckets.length && prev.every((v, i) => v === buckets[i]) ? prev : buckets
+        );
       } catch (err) {
         console.error('Error loading activity timeline:', err);
       }

--- a/src/components/discipleship/DiscipleshipMap.tsx
+++ b/src/components/discipleship/DiscipleshipMap.tsx
@@ -85,8 +85,6 @@ const TILE_ATTRIBUTION =
 // (Supabase Realtime) todavía — polling es el fallback explícito que
 // contempla el propio diseño.
 const LIVE_POLL_MS = 30_000;
-// Cuánto dura el "ripple" visual de un grupo que acaba de reportar.
-const PULSE_DURATION_MS = 10_000;
 
 // ── Actividad de reporte (estado real, no inventado) ─────────
 // El diseño original pedía un semáforo de "creció / sin cambios / sin
@@ -394,10 +392,7 @@ export default function DiscipleshipMap({
   const [selectedPerson, setSelectedPerson] = useState<MapUser | null>(null);
 
   // Tiempo real (polling, ver comentario en LIVE_POLL_MS)
-  const [pulsingGroupIds, setPulsingGroupIds] = useState<Set<string>>(new Set());
   const [activityBuckets, setActivityBuckets] = useState<number[]>(new Array(24).fill(0));
-  const lastReportByGroup = useRef<Map<string, string>>(new Map());
-  const pulseTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   // Firma de la última tanda de zonas renderizada — para saltar el re-render
   // cuando el poll trae exactamente lo mismo (evita el pestañeo de marcadores).
   const lastZonesSig = useRef<string>('');
@@ -416,8 +411,10 @@ export default function DiscipleshipMap({
     setInternalSelectedZoneId(selectedZoneId ?? null);
   }, [selectedZoneId]);
 
-  // Cargar zonas + grupos, con polling para detectar reportes nuevos (ripple)
-  // y refrescar el contador EN VIVO sin resetear el viewport del usuario.
+  // Cargar zonas + grupos, con polling para refrescar el estado en vivo
+  // (titileo de reportes pendientes, contador EN VIVO) sin resetear el
+  // viewport del usuario. El titileo lo decide has_pending_report del backend,
+  // así que no hace falta maquinaria de timeouts en el cliente.
   useEffect(() => {
     let cancelled = false;
 
@@ -428,51 +425,9 @@ export default function DiscipleshipMap({
         if (cancelled) return;
         const zones = response.zones || [];
 
-        // Diff contra el poll anterior: si last_report_date cambió, ese grupo
-        // "acaba de reportar" — dispara el ripple ~10s. No dispara en la
-        // primera carga (no hay "anterior" con qué comparar todavía).
-        if (!isFirstLoad) {
-          const newlyReported: string[] = [];
-          for (const zd of zones) {
-            for (const g of zd.groups) {
-              const prev = lastReportByGroup.current.get(g.id);
-              if (g.last_report_date && prev !== undefined && prev !== g.last_report_date) {
-                newlyReported.push(g.id);
-              }
-            }
-          }
-          if (newlyReported.length > 0) {
-            setPulsingGroupIds(prevSet => {
-              const next = new Set(prevSet);
-              newlyReported.forEach(id => next.add(id));
-              return next;
-            });
-            newlyReported.forEach(id => {
-              const existing = pulseTimeouts.current.get(id);
-              if (existing) clearTimeout(existing);
-              pulseTimeouts.current.set(
-                id,
-                setTimeout(() => {
-                  setPulsingGroupIds(prevSet => {
-                    const next = new Set(prevSet);
-                    next.delete(id);
-                    return next;
-                  });
-                  pulseTimeouts.current.delete(id);
-                }, PULSE_DURATION_MS)
-              );
-            });
-          }
-        }
-        lastReportByGroup.current = new Map(
-          zones.flatMap(zd => zd.groups.map(g => [g.id, g.last_report_date || '']))
-        );
-
         // Solo re-renderizar si la data realmente cambió. Sin este guard, cada
         // poll reemplaza el array completo y remonta todos los marcadores (nuevos
         // L.divIcon → setIcon → reinicia animaciones) = el pestañeo cada 30s.
-        // Cuando SÍ cambia (nuevo reporte), re-renderiza una vez, que es justo
-        // cuando querés que aparezca el ripple.
         const sig = JSON.stringify(zones);
         if (sig !== lastZonesSig.current) {
           lastZonesSig.current = sig;
@@ -485,14 +440,9 @@ export default function DiscipleshipMap({
 
     void load(true);
     const interval = setInterval(() => void load(false), LIVE_POLL_MS);
-    // Copia local del ref para el cleanup (regla react-hooks/exhaustive-deps:
-    // el .current puede cambiar antes de que corra la limpieza).
-    const timeouts = pulseTimeouts.current;
     return () => {
       cancelled = true;
       clearInterval(interval);
-      timeouts.forEach(t => clearTimeout(t));
-      timeouts.clear();
     };
   }, []);
 
@@ -721,7 +671,8 @@ export default function DiscipleshipMap({
           if (isNaN(lat) || isNaN(lng) || !isFinite(lat) || !isFinite(lng)) return null;
           const status = getActivityStatus(group.last_report_date);
           const isSelected = selectedGroup?.id === group.id;
-          const isPulsing = pulsingGroupIds.has(group.id);
+          // Titila mientras el reporte del grupo esté pendiente de aprobación.
+          const isPulsing = !!group.has_pending_report;
           return (
             <Marker
               key={`group-${group.id}`}
@@ -804,15 +755,26 @@ export default function DiscipleshipMap({
                       {formatRelativeTime(reportDate)}
                     </span>
                   </div>
-                  <Badge
-                    className="mt-1 w-fit text-[9.5px] font-bold tracking-wide border-0"
-                    style={{
-                      backgroundColor: `${ACTIVITY_COLORS[status]}1f`,
-                      color: ACTIVITY_COLORS[status],
-                    }}
-                  >
-                    {ACTIVITY_LABELS[status]}
-                  </Badge>
+                  <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                    <Badge
+                      className="w-fit text-[9.5px] font-bold tracking-wide border-0"
+                      style={{
+                        backgroundColor: `${ACTIVITY_COLORS[status]}1f`,
+                        color: ACTIVITY_COLORS[status],
+                      }}
+                    >
+                      {ACTIVITY_LABELS[status]}
+                    </Badge>
+                    {selectedGroup.has_pending_report && (
+                      <Badge className="w-fit text-[9.5px] font-bold tracking-wide border-0 bg-amber-500/15 text-amber-600 dark:text-amber-400 flex items-center gap-1">
+                        <span
+                          className="w-1.5 h-1.5 rounded-full bg-amber-500"
+                          style={{ animation: 'jetro-live-dot 1.4s ease-in-out infinite' }}
+                        />
+                        REPORTE PENDIENTE
+                      </Badge>
+                    )}
+                  </div>
                 </div>
               </div>
             );

--- a/src/components/discipleship/DiscipleshipMap.tsx
+++ b/src/components/discipleship/DiscipleshipMap.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import {
   Drawer,
   DrawerContent,
@@ -7,9 +7,7 @@ import {
   DrawerTitle,
   DrawerDescription,
 } from '@/components/ui/drawer';
-import { Label } from '@/components/ui/label';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Switch } from '@/components/ui/switch';
+import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { useMobileMode } from '@/hooks/useMobileMode';
 import { DiscipleshipService } from '@/services/discipleship.service';
@@ -21,7 +19,7 @@ import type {
   ZoneMapData,
   ZoneMapGroup,
 } from '@/types/discipleship.types';
-import { Calendar, Layers, MapPin, Search, User as UserIcon, Users } from 'lucide-react';
+import { Layers, MapPin, Search, User as UserIcon, Users } from 'lucide-react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -65,6 +63,8 @@ interface DiscipleshipMapProps {
   selectedZoneId?: string | null;
   onZoneSelect?: (zoneId: string | null, groups: DiscipleshipGroup[]) => void;
   heightClassName?: string;
+  /** Título de la vista (breadcrumb queda a cargo de la página, no del widget). Sin título: solo controles. */
+  title?: string;
 }
 
 // ── Constantes ──────────────────────────────────────────────
@@ -80,26 +80,116 @@ const TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const TILE_ATTRIBUTION =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
+// Cada cuánto se refresca el mapa para detectar reportes nuevos (ripple) y
+// actualizar el contador EN VIVO / la línea de tiempo. No hay push real
+// (Supabase Realtime) todavía — polling es el fallback explícito que
+// contempla el propio diseño.
+const LIVE_POLL_MS = 30_000;
+// Cuánto dura el "ripple" visual de un grupo que acaba de reportar.
+const PULSE_DURATION_MS = 10_000;
+
+// ── Actividad de reporte (estado real, no inventado) ─────────
+// El diseño original pedía un semáforo de "creció / sin cambios / sin
+// reportar" basado en delta de miembros — dato que hoy no existe (no hay
+// snapshots históricos de member_count). Se reutiliza el mismo semáforo de
+// 3 colores pero con un significado que SÍ es 100% real: recencia del
+// último reporte (`last_report_date`, MAX(submitted_at) real del backend).
+// Es, además, la señal más útil para un pastor haciendo seguimiento.
+type ActivityStatus = 'recent' | 'aging' | 'silent';
+
+const ACTIVITY_COLORS: Record<ActivityStatus, string> = {
+  recent: '#22c55e',
+  aging: '#f59e0b',
+  silent: '#ef4444',
+};
+
+const ACTIVITY_LABELS: Record<ActivityStatus, string> = {
+  recent: 'REPORTÓ ESTA SEMANA',
+  aging: 'REPORTÓ ESTE MES',
+  silent: 'SIN REPORTAR',
+};
+
+/**
+ * Postgres devuelve el timestamptz como "YYYY-MM-DD HH:MM:SS.ffffff+00", que
+ * new Date() NO parsea: el offset viene en 2 dígitos (`+00`, no `+00:00`) y la
+ * fracción trae microsegundos. Ambos dan Invalid Date. Normalizamos:
+ *  - espacio → 'T'
+ *  - microsegundos → milisegundos (.755019 → .755)
+ *  - offset de 2 dígitos → ±HH:MM (+00 → +00:00)
+ */
+function parseBackendTimestamp(raw: string | undefined): Date | null {
+  if (!raw) return null;
+  const s = raw
+    .replace(' ', 'T')
+    .replace(/(\.\d{3})\d+/, '$1')
+    .replace(/([+-]\d{2})$/, '$1:00');
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function getActivityStatus(lastReportDate: string | undefined): ActivityStatus {
+  const d = parseBackendTimestamp(lastReportDate);
+  if (!d) return 'silent';
+  const daysAgo = (Date.now() - d.getTime()) / 86_400_000;
+  if (daysAgo <= 7) return 'recent';
+  if (daysAgo <= 30) return 'aging';
+  return 'silent';
+}
+
+function formatRelativeTime(date: Date | null): string {
+  if (!date) return 'Sin reportes aún';
+  const minutes = Math.floor((Date.now() - date.getTime()) / 60_000);
+  if (minutes < 1) return 'ahora mismo';
+  if (minutes < 60) return `hace ${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `hace ${hours} h`;
+  const days = Math.floor(hours / 24);
+  return `hace ${days} d`;
+}
+
+/** Diámetro del marcador de grupo: escala con miembros, con piso y techo. */
+function groupMarkerSize(members: number): number {
+  return Math.min(30, Math.max(14, 12 + members * 0.9));
+}
+
 // ── SVG Markers (as HTML strings for divIcon) ──────────────
 
-// Pin en forma de gota (teardrop) con una casita blanca adentro. El ancla es la
-// PUNTA inferior, así que marca el punto exacto en el mapa. `w` = ancho en px;
-// el alto se deriva a ~1.3x. La sombra va en el wrapper para no colisionar ids de SVG.
-function houseIconHtml(color: string, w: number, highlight = false): string {
-  const h = Math.round(w * 1.32);
-  const ring = highlight
-    ? `<circle cx="15" cy="14" r="12.5" fill="none" stroke="#ffffff" stroke-width="1" stroke-opacity="0.9"/>`
+// Marcador de grupo: círculo de color = estado de reporte, diámetro = miembros.
+// Reemplaza el pin-casita anterior — así lo pide el rediseño "mapa en vivo".
+function groupCircleHtml(
+  color: string,
+  size: number,
+  isSelected: boolean,
+  pulsing: boolean
+): string {
+  const ring = isSelected
+    ? `<div style="position:absolute;inset:-5px;border-radius:999px;border:2px solid #fff;opacity:.9;"></div>`
     : '';
-  return `<div style="width:${w}px;height:${h}px;filter:drop-shadow(0 2px 2px rgba(15,23,42,.35));${
-    highlight ? 'animation:jetro-pin-pop .25s ease-out;' : ''
-  }">
-    <svg width="${w}" height="${h}" viewBox="0 0 30 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M15 1.5C7.8 1.5 2 7.2 2 14.2c0 8.1 13 24.3 13 24.3s13-16.2 13-24.3C28 7.2 22.2 1.5 15 1.5Z" fill="${color}" stroke="#ffffff" stroke-width="2.4"/>
-      ${ring}
-      <path d="M15 7.6 22 13v6.1a.8.8 0 0 1-.8.8H8.8a.8.8 0 0 1-.8-.8V13l7-5.4Z" fill="#ffffff"/>
-      <rect x="12.7" y="14.6" width="4.6" height="5.3" rx="0.7" fill="${color}"/>
-    </svg>
+  const ripple = pulsing
+    ? `<div class="jetro-group-pulse" style="border-color:${color}"></div>
+       <div class="jetro-group-pulse jetro-group-pulse-delay" style="border-color:${color}"></div>`
+    : '';
+  return `<div class="jetro-group-marker" style="position:relative;width:${size}px;height:${size}px;">
+    ${ripple}
+    ${ring}
+    <div style="width:100%;height:100%;border-radius:999px;background:${color};border:2.5px solid #fff;box-shadow:0 2px 6px rgba(15,23,42,.4);"></div>
   </div>`;
+}
+
+function createGroupIcon(
+  color: string,
+  size: number,
+  isSelected: boolean,
+  pulsing: boolean
+): L.DivIcon {
+  const boxSize = size + 10; // margen para el ring/ripple sin recortar
+  return L.divIcon({
+    html: groupCircleHtml(color, size, isSelected, pulsing),
+    className: '',
+    iconSize: [boxSize, boxSize],
+    iconAnchor: [boxSize / 2, boxSize / 2],
+    popupAnchor: [0, -boxSize / 2],
+  });
 }
 
 // Badge circular para personas (más chico, sin punta — marca aproximada).
@@ -111,17 +201,6 @@ function personIconHtml(size: number): string {
       <path d="M6.5 17.8c0-3 2.6-5 5.5-5s5.5 2 5.5 5" fill="#ffffff"/>
     </svg>
   </div>`;
-}
-
-function createHouseIcon(color: string, w: number, highlight = false): L.DivIcon {
-  const h = Math.round(w * 1.32);
-  return L.divIcon({
-    html: houseIconHtml(color, w, highlight),
-    className: '',
-    iconSize: [w, h],
-    iconAnchor: [w / 2, h], // punta inferior
-    popupAnchor: [0, -h + 4],
-  });
 }
 
 function createPersonIcon(size: number): L.DivIcon {
@@ -291,7 +370,8 @@ function PopupCloseHandler({ onClose }: { onClose: () => void }) {
 export default function DiscipleshipMap({
   selectedZoneId,
   onZoneSelect,
-  heightClassName = 'h-[620px]',
+  heightClassName = 'h-[440px] lg:h-[580px]',
+  title,
 }: DiscipleshipMapProps) {
   const isMobileApp = useMobileMode();
   const mapRef = useRef<L.Map | null>(null);
@@ -313,6 +393,12 @@ export default function DiscipleshipMap({
   const [selectedGroup, setSelectedGroup] = useState<ZoneMapGroup | null>(null);
   const [selectedPerson, setSelectedPerson] = useState<MapUser | null>(null);
 
+  // Tiempo real (polling, ver comentario en LIVE_POLL_MS)
+  const [pulsingGroupIds, setPulsingGroupIds] = useState<Set<string>>(new Set());
+  const [activityBuckets, setActivityBuckets] = useState<number[]>(new Array(24).fill(0));
+  const lastReportByGroup = useRef<Map<string, string>>(new Map());
+  const pulseTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
   // Map navigation state
   const [fitToBounds, setFitToBounds] = useState<{ bounds: L.LatLngBounds; key: string } | null>(
     null
@@ -327,18 +413,93 @@ export default function DiscipleshipMap({
     setInternalSelectedZoneId(selectedZoneId ?? null);
   }, [selectedZoneId]);
 
-  // Cargar zonas + grupos
+  // Cargar zonas + grupos, con polling para detectar reportes nuevos (ripple)
+  // y refrescar el contador EN VIVO sin resetear el viewport del usuario.
   useEffect(() => {
-    const load = async () => {
+    let cancelled = false;
+
+    const load = async (isFirstLoad: boolean) => {
       try {
-        setLoading(true);
+        if (isFirstLoad) setLoading(true);
         const response = await ZonesService.getMapData({ is_active: true });
-        setZoneData(response.zones || []);
+        if (cancelled) return;
+        const zones = response.zones || [];
+        setZoneData(zones);
+
+        // Diff contra el poll anterior: si last_report_date cambió, ese grupo
+        // "acaba de reportar" — dispara el ripple ~10s. No dispara en la
+        // primera carga (no hay "anterior" con qué comparar todavía).
+        if (!isFirstLoad) {
+          const newlyReported: string[] = [];
+          for (const zd of zones) {
+            for (const g of zd.groups) {
+              const prev = lastReportByGroup.current.get(g.id);
+              if (g.last_report_date && prev !== undefined && prev !== g.last_report_date) {
+                newlyReported.push(g.id);
+              }
+            }
+          }
+          if (newlyReported.length > 0) {
+            setPulsingGroupIds(prevSet => {
+              const next = new Set(prevSet);
+              newlyReported.forEach(id => next.add(id));
+              return next;
+            });
+            newlyReported.forEach(id => {
+              const existing = pulseTimeouts.current.get(id);
+              if (existing) clearTimeout(existing);
+              pulseTimeouts.current.set(
+                id,
+                setTimeout(() => {
+                  setPulsingGroupIds(prevSet => {
+                    const next = new Set(prevSet);
+                    next.delete(id);
+                    return next;
+                  });
+                  pulseTimeouts.current.delete(id);
+                }, PULSE_DURATION_MS)
+              );
+            });
+          }
+        }
+        lastReportByGroup.current = new Map(
+          zones.flatMap(zd => zd.groups.map(g => [g.id, g.last_report_date || '']))
+        );
       } finally {
-        setLoading(false);
+        if (isFirstLoad) setLoading(false);
       }
     };
-    void load();
+
+    void load(true);
+    const interval = setInterval(() => void load(false), LIVE_POLL_MS);
+    // Copia local del ref para el cleanup (regla react-hooks/exhaustive-deps:
+    // el .current puede cambiar antes de que corra la limpieza).
+    const timeouts = pulseTimeouts.current;
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      timeouts.forEach(t => clearTimeout(t));
+      timeouts.clear();
+    };
+  }, []);
+
+  // Línea de tiempo (24h reales) — mismo ciclo de refresco que el mapa.
+  useEffect(() => {
+    let cancelled = false;
+    const loadTimeline = async () => {
+      try {
+        const buckets = await DiscipleshipService.getActivityTimeline();
+        if (!cancelled) setActivityBuckets(buckets);
+      } catch (err) {
+        console.error('Error loading activity timeline:', err);
+      }
+    };
+    void loadTimeline();
+    const interval = setInterval(loadTimeline, LIVE_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, []);
 
   // Cargar usuarios con coordenadas (usa endpoint de discipulado, no requiere staff+)
@@ -422,16 +583,22 @@ export default function DiscipleshipMap({
     return mapUsers.filter(u => u.zone_name === zoneName);
   }, [mapUsers, internalSelectedZoneId, zoneData]);
 
-  // Obtener color de zona para un grupo
-  const getGroupZoneColor = useCallback(
-    (group: ZoneMapGroup): string => {
-      for (const zd of zoneData) {
-        if (zd.groups.some(g => g.id === group.id)) {
-          return zd.zone.color || '#3b82f6';
-        }
-      }
-      return '#3b82f6';
-    },
+  const totalGroups = useMemo(
+    () => zoneData.reduce((acc, item) => acc + item.groups.length, 0),
+    [zoneData]
+  );
+  const totalMembers = useMemo(
+    () => zoneData.reduce((acc, item) => acc + (item.zone.total_members || 0), 0),
+    [zoneData]
+  );
+  // "activos" del pill EN VIVO: miembros activos reales, sumados de todos los
+  // grupos cargados (no solo los visibles) — así el contador no salta al filtrar por zona.
+  const liveActiveCount = useMemo(
+    () =>
+      zoneData.reduce(
+        (acc, item) => acc + item.groups.reduce((a, g) => a + (g.active_members || 0), 0),
+        0
+      ),
     [zoneData]
   );
 
@@ -529,19 +696,25 @@ export default function DiscipleshipMap({
         }}
       />
 
-      {/* Marcadores de Grupos (casitas) */}
+      {/* Marcadores de Grupos (círculos: color = estado de reporte, tamaño = miembros) */}
       {showGroups &&
         visibleGroups.map(group => {
           const lat = Number(group.latitude);
           const lng = Number(group.longitude);
           if (isNaN(lat) || isNaN(lng) || !isFinite(lat) || !isFinite(lng)) return null;
-          const zoneColor = getGroupZoneColor(group);
+          const status = getActivityStatus(group.last_report_date);
           const isSelected = selectedGroup?.id === group.id;
+          const isPulsing = pulsingGroupIds.has(group.id);
           return (
             <Marker
               key={`group-${group.id}`}
               position={[lat, lng]}
-              icon={createHouseIcon(zoneColor, isSelected ? 30 : 22, isSelected)}
+              icon={createGroupIcon(
+                ACTIVITY_COLORS[status],
+                groupMarkerSize(group.active_members || group.member_count || 0),
+                isSelected,
+                isPulsing
+              )}
               zIndexOffset={isSelected ? 1000 : 0}
               eventHandlers={{
                 click: () => {
@@ -575,71 +748,58 @@ export default function DiscipleshipMap({
           position={[Number(selectedGroup.latitude), Number(selectedGroup.longitude)]}
           closeOnClick={false}
           autoClose={false}
-          maxWidth={300}
+          maxWidth={240}
         >
-          <div className="p-3 min-w-[220px] bg-background rounded-xl shadow-2xl border border-border overflow-hidden">
-            <div className="flex items-center gap-2 mb-3 pb-2 border-b border-border/50">
-              <div className="p-1.5 bg-blue-500/10 rounded-lg">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                  <path
-                    d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
-                    fill="#3b82f6"
-                    fillOpacity="0.85"
-                    stroke="#3b82f6"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
+          {(() => {
+            const status = getActivityStatus(selectedGroup.last_report_date);
+            const reportDate = parseBackendTimestamp(selectedGroup.last_report_date);
+            return (
+              <div className="w-[220px] bg-background rounded-2xl shadow-2xl border border-border overflow-hidden">
+                <div className="flex items-center gap-2 px-3.5 py-3 border-b border-border/50">
+                  <span
+                    className="w-2.5 h-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: ACTIVITY_COLORS[status] }}
                   />
-                  <path
-                    d="M9 21V13H15V21"
-                    fill="white"
-                    fillOpacity="0.9"
-                    stroke="#3b82f6"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </div>
-              <p className="font-bold text-sm tracking-tight truncate">
-                {selectedGroup.group_name}
-              </p>
-            </div>
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <UserIcon className="w-3.5 h-3.5 text-muted-foreground" />
-                <p className="text-xs text-muted-foreground">
-                  <span className="font-semibold text-foreground">Líder:</span>{' '}
-                  {selectedGroup.leader_name || 'Sin asignar'}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Users className="w-3.5 h-3.5 text-muted-foreground" />
-                <p className="text-xs text-muted-foreground">
-                  <span className="font-semibold text-foreground">Miembros:</span>{' '}
-                  {selectedGroup.active_members || 0}/{selectedGroup.member_count || 0}
-                </p>
-              </div>
-              {selectedGroup.meeting_location && (
-                <div className="flex items-center gap-2">
-                  <MapPin className="w-3.5 h-3.5 text-muted-foreground" />
-                  <p className="text-xs text-muted-foreground line-clamp-1">
-                    <span className="font-semibold text-foreground">Ubicación:</span>{' '}
-                    {selectedGroup.meeting_location}
+                  <p className="font-bold text-xs tracking-tight truncate">
+                    {selectedGroup.group_name}
                   </p>
                 </div>
-              )}
-              {selectedGroup.meeting_day && (
-                <div className="flex items-center gap-2">
-                  <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
-                  <p className="text-xs text-muted-foreground">
-                    <span className="font-semibold text-foreground">Reunión:</span>{' '}
-                    {selectedGroup.meeting_day}
-                  </p>
+                <div className="px-3.5 py-3 flex flex-col gap-2">
+                  <div className="flex items-center justify-between text-[11px]">
+                    <span className="text-muted-foreground font-medium flex items-center gap-1.5">
+                      <UserIcon className="w-3 h-3" /> Líder
+                    </span>
+                    <span className="font-semibold text-foreground truncate max-w-[130px]">
+                      {selectedGroup.leader_name || 'Sin asignar'}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between text-[11px]">
+                    <span className="text-muted-foreground font-medium flex items-center gap-1.5">
+                      <Users className="w-3 h-3" /> Miembros
+                    </span>
+                    <span className="font-semibold text-foreground">
+                      {selectedGroup.active_members || 0}/{selectedGroup.member_count || 0}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between text-[11px]">
+                    <span className="text-muted-foreground font-medium">Último reporte</span>
+                    <span className="font-semibold text-foreground">
+                      {formatRelativeTime(reportDate)}
+                    </span>
+                  </div>
+                  <Badge
+                    className="mt-1 w-fit text-[9.5px] font-bold tracking-wide border-0"
+                    style={{
+                      backgroundColor: `${ACTIVITY_COLORS[status]}1f`,
+                      color: ACTIVITY_COLORS[status],
+                    }}
+                  >
+                    {ACTIVITY_LABELS[status]}
+                  </Badge>
                 </div>
-              )}
-            </div>
-          </div>
+              </div>
+            );
+          })()}
         </Popup>
       )}
 
@@ -689,7 +849,7 @@ export default function DiscipleshipMap({
     </>
   );
 
-  // ── Lista de zonas (compartida: Card de escritorio / Drawer de mobile) ──
+  // ── Lista de zonas (compartida: Drawer de mobile / chips de escritorio) ──
   const zoneListBody = (
     <div className="space-y-3">
       {/* Botón "Todas las zonas" */}
@@ -715,7 +875,7 @@ export default function DiscipleshipMap({
                 !internalSelectedZoneId ? 'text-blue-100' : 'text-muted-foreground'
               )}
             >
-              {zoneData.reduce((acc, item) => acc + item.groups.length, 0)} grupos totales
+              {totalGroups} grupos totales
             </p>
           </div>
           <div
@@ -761,26 +921,7 @@ export default function DiscipleshipMap({
                   </p>
                   <div className="flex items-center gap-3 mt-1.5">
                     <div className="flex items-center gap-1">
-                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                        <path
-                          d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
-                          fill={isSelected ? '#3b82f6' : '#94a3b8'}
-                          fillOpacity="0.85"
-                          stroke={isSelected ? '#3b82f6' : '#94a3b8'}
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                        <path
-                          d="M9 21V13H15V21"
-                          fill="white"
-                          fillOpacity="0.9"
-                          stroke={isSelected ? '#3b82f6' : '#94a3b8'}
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
+                      <Users className="w-3 h-3 text-muted-foreground" />
                       <span className="text-[10px] font-bold text-muted-foreground">
                         {item.groups.length}
                       </span>
@@ -823,28 +964,13 @@ export default function DiscipleshipMap({
                     }}
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 bg-background rounded-lg shadow-sm border border-border/50 group-hover/cell:border-blue-500/30 transition-colors">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                          <path
-                            d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
-                            fill={item.zone.color}
-                            fillOpacity="0.85"
-                            stroke={item.zone.color}
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                          <path
-                            d="M9 21V13H15V21"
-                            fill="white"
-                            fillOpacity="0.9"
-                            stroke={item.zone.color}
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                        </svg>
-                      </div>
+                      <span
+                        className="w-2.5 h-2.5 rounded-full shrink-0"
+                        style={{
+                          backgroundColor:
+                            ACTIVITY_COLORS[getActivityStatus(group.last_report_date)],
+                        }}
+                      />
                       <div className="min-w-0">
                         <p className="text-xs font-bold truncate group-hover/cell:text-blue-600 transition-colors">
                           {group.group_name}
@@ -865,8 +991,8 @@ export default function DiscipleshipMap({
   );
 
   // ── Layout mobile: mapa a pantalla completa + toggles flotantes + hoja inferior ──
+  // (rediseño "mapa en vivo" aplica a escritorio; mobile queda como hoy, entrega aparte)
   if (isMobileApp) {
-    const totalGroups = zoneData.reduce((acc, item) => acc + item.groups.length, 0);
     return (
       <div className="relative w-full h-[calc(100dvh-172px)] rounded-2xl overflow-hidden border border-border">
         <MapContainer
@@ -934,185 +1060,246 @@ export default function DiscipleshipMap({
     );
   }
 
-  // ── Layout de escritorio ──
+  // ── Layout de escritorio: "mapa en tiempo real" — un solo Card a ancho completo ──
   return (
-    <div className="grid gap-6 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_380px]">
-      {/* ── Mapa ── */}
-      <Card className="overflow-hidden border-border bg-card shadow-xl rounded-2xl relative group border-none lg:border-solid">
-        <CardContent className="p-0 relative">
-          <div className={cn('w-full transition-all duration-500', heightClassName)}>
-            <MapContainer
-              center={DEFAULT_CENTER}
-              zoom={DEFAULT_ZOOM}
-              className="w-full h-full"
-              zoomControl={false}
-              ref={map => {
-                mapRef.current = map;
-              }}
-            >
-              {mapLayers}
-
-              {/* Floating Toolbar Top Left */}
-              <div
-                className="leaflet-top leaflet-left"
-                style={{ position: 'absolute', top: 16, left: 16, zIndex: 1000 }}
-              >
-                <div className="bg-background/80 backdrop-blur-md rounded-xl border border-border/50 p-2.5 shadow-lg flex items-center gap-4 transition-all hover:bg-background/90">
-                  <div className="flex items-center gap-2">
-                    <div className="p-1 bg-blue-500/10 rounded-lg">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                        <path
-                          d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
-                          fill="#3b82f6"
-                          fillOpacity="0.85"
-                          stroke="#3b82f6"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                        <path
-                          d="M9 21V13H15V21"
-                          fill="white"
-                          fillOpacity="0.9"
-                          stroke="#3b82f6"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
-                    </div>
-                    <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                      Grupos
-                    </span>
-                  </div>
-                  <div className="h-4 w-[1px] bg-border" />
-                  <div className="flex items-center gap-2">
-                    <div className="p-1 bg-indigo-500/10 rounded-lg">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                        <circle
-                          cx="12"
-                          cy="7"
-                          r="4"
-                          fill="#6366f1"
-                          stroke="#4f46e5"
-                          strokeWidth="1.5"
-                        />
-                        <path
-                          d="M5.5 21C5.5 17.41 8.41 14.5 12 14.5C15.59 14.5 18.5 17.41 18.5 21"
-                          fill="#6366f1"
-                          fillOpacity="0.6"
-                          stroke="#4f46e5"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                        />
-                      </svg>
-                    </div>
-                    <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                      Personas
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </MapContainer>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* ── Sidebar ── */}
-      <Card className="border-border bg-card shadow-xl rounded-2xl flex flex-col overflow-hidden border-none lg:border-solid">
-        <CardHeader className="space-y-4 pb-4 bg-muted/30 border-b border-border">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Layers className="w-5 h-5 text-blue-500" />
-              <CardTitle className="text-xl font-bold tracking-tight">Capas</CardTitle>
-            </div>
-            {internalSelectedZoneId ? (
-              <Badge className="bg-blue-500/10 text-blue-600 border-blue-200 dark:border-blue-800 hover:bg-blue-500/20 transition-colors">
-                {selectedZone?.zone.name}
-              </Badge>
-            ) : (
-              <Badge variant="outline" className="text-muted-foreground">
-                Global
-              </Badge>
-            )}
-          </div>
-
-          {/* Toggles de capas - Rediseñados */}
-          <div className="grid grid-cols-2 gap-2">
-            <div
+    <Card className="jetro-live-map overflow-hidden border-border bg-card shadow-xl rounded-2xl">
+      {/* Header: título + controles */}
+      <div className="flex items-center justify-between gap-3 flex-wrap px-4 sm:px-5 pt-4 pb-3">
+        {title ? (
+          <h2 className="text-base sm:text-lg font-bold tracking-tight text-foreground">{title}</h2>
+        ) : (
+          <div />
+        )}
+        <div className="flex items-center gap-2">
+          {/* Segmented Grupos / Personas — multi-toggle, no exclusivo */}
+          <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
+            <button
+              type="button"
+              onClick={() => setShowGroups(v => !v)}
               className={cn(
-                'flex items-center justify-between p-2 rounded-xl border transition-all',
+                'rounded-full px-3 py-1 text-[11px] font-bold transition-colors',
                 showGroups
-                  ? 'bg-blue-500/5 border-blue-200 dark:border-blue-800 shadow-sm'
-                  : 'bg-muted/50 border-transparent'
+                  ? 'bg-blue-600 text-white'
+                  : 'text-muted-foreground hover:bg-blue-600/[.06]'
               )}
             >
-              <Label htmlFor="show-groups" className="cursor-pointer flex items-center gap-2">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                  <path
-                    d="M3 10.5L12 3L21 10.5V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V10.5Z"
-                    fill={showGroups ? '#3b82f6' : '#94a3b8'}
-                    fillOpacity="0.85"
-                    stroke={showGroups ? '#3b82f6' : '#94a3b8'}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M9 21V13H15V21"
-                    fill="white"
-                    fillOpacity="0.9"
-                    stroke={showGroups ? '#3b82f6' : '#94a3b8'}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-                <span className="text-xs font-medium">Grupos</span>
-              </Label>
-              <Switch
-                id="show-groups"
-                checked={showGroups}
-                onCheckedChange={setShowGroups}
-                className="scale-75"
-              />
-            </div>
-            <div
+              Grupos
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowPeople(v => !v)}
               className={cn(
-                'flex items-center justify-between p-2 rounded-xl border transition-all',
+                'rounded-full px-3 py-1 text-[11px] font-bold transition-colors',
                 showPeople
-                  ? 'bg-indigo-500/5 border-indigo-200 dark:border-indigo-800 shadow-sm'
-                  : 'bg-muted/50 border-transparent'
+                  ? 'bg-blue-600 text-white'
+                  : 'text-muted-foreground hover:bg-blue-600/[.06]'
               )}
             >
-              <Label htmlFor="show-people" className="cursor-pointer flex items-center gap-2">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                  <circle cx="12" cy="7" r="4" fill="#6366f1" stroke="#4f46e5" strokeWidth="1.5" />
-                  <path
-                    d="M5.5 21C5.5 17.41 8.41 14.5 12 14.5C15.59 14.5 18.5 17.41 18.5 21"
-                    fill="#6366f1"
-                    fillOpacity="0.6"
-                    stroke="#4f46e5"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </svg>
-                <span className="text-xs font-medium">Personas</span>
-              </Label>
-              <Switch
-                id="show-people"
-                checked={showPeople}
-                onCheckedChange={setShowPeople}
-                className="scale-75"
-              />
+              Personas
+            </button>
+          </div>
+
+          {/* Pill EN VIVO */}
+          <div className="flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5">
+            <span
+              className="w-2 h-2 rounded-full bg-green-500"
+              style={{ animation: 'jetro-live-dot 1.4s ease-in-out infinite' }}
+            />
+            <span className="text-[11px] font-bold text-green-700 dark:text-green-400">
+              EN VIVO
+            </span>
+            <span className="w-px h-3 bg-border" />
+            <span className="text-xs font-bold text-foreground">{liveActiveCount}</span>
+            <span className="text-[11px] font-medium text-muted-foreground">activos</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Mapa */}
+      <CardContent className="p-0 relative">
+        <div className={cn('w-full relative', heightClassName)}>
+          {loading && zoneData.length === 0 && (
+            <Skeleton className="absolute inset-0 z-[900] rounded-none" />
+          )}
+
+          <MapContainer
+            center={DEFAULT_CENTER}
+            zoom={DEFAULT_ZOOM}
+            className="w-full h-full relative z-[500]"
+            zoomControl={false}
+            ref={map => {
+              mapRef.current = map;
+            }}
+          >
+            {mapLayers}
+          </MapContainer>
+
+          {/* Overlay de radar: decorativo, "sistema escuchando" — no representa datos puntuales.
+              Va por ENCIMA del mapa (z-[600]) con pointer-events-none: el barrido cónico
+              semitransparente tiñe las tiles (mix-blend multiply en claro) sin bloquear los
+              clicks de los marcadores. La animación se apaga sola vía prefers-reduced-motion. */}
+          <div
+            className="pointer-events-none absolute inset-0 z-[600] flex items-center justify-center overflow-hidden"
+            aria-hidden="true"
+          >
+            <div className="relative w-[620px] h-[620px] max-w-none">
+              <div className="absolute inset-[140px] rounded-full border border-dashed border-green-500/20 dark:border-green-400/20" />
+              <div className="absolute inset-0 rounded-full border border-dashed border-green-500/30 dark:border-green-400/25" />
+              <div className="jetro-radar-sweep absolute inset-0 rounded-full" />
             </div>
           </div>
-        </CardHeader>
 
-        <CardContent className="pt-0">
-          <ScrollArea className="h-[460px] pr-4">{zoneListBody}</ScrollArea>
-        </CardContent>
-      </Card>
-    </div>
+          {/* Chip de resumen (overlay top-left) */}
+          <div className="absolute top-4 left-4 z-[1000] rounded-xl border border-black/5 dark:border-white/10 bg-white/[.93] dark:bg-white/[.07] backdrop-blur-md px-3.5 py-2.5 shadow-sm dark:shadow-none">
+            <p className="text-[11px] font-bold text-foreground">
+              {totalGroups} grupos · {totalMembers} miembros
+            </p>
+            <p className="text-[10px] font-medium text-muted-foreground">
+              {zoneData.length} zona{zoneData.length !== 1 ? 's' : ''} · radar activo
+            </p>
+          </div>
+        </div>
+      </CardContent>
+
+      {/* Línea de tiempo (24h reales) */}
+      <div className="px-4 sm:px-5 pt-3.5 pb-1.5 border-t border-border">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] font-bold text-foreground">Actividad · últimas 24 h</span>
+          <span className="text-[10px] font-medium text-muted-foreground hidden sm:inline">
+            reportes reales enviados por hora
+          </span>
+        </div>
+        <div className="flex items-end gap-[3px] h-[46px] mt-4 relative">
+          {activityBuckets.map((count, i) => {
+            const max = Math.max(1, ...activityBuckets);
+            const heightPct = Math.max(6, (count / max) * 100);
+            const isRecent = i >= 20; // últimas 4 horas
+            const isNow = i === 23;
+            return (
+              <div key={i} className="flex-1 relative h-full flex items-end">
+                {isNow && (
+                  <>
+                    <div className="absolute -top-1.5 bottom-0 right-0 w-[2px] bg-foreground dark:bg-green-400" />
+                    <span className="absolute -top-4 right-0 translate-x-1/2 whitespace-nowrap rounded px-1.5 py-0.5 text-[9px] font-bold bg-foreground text-background dark:bg-green-400 dark:text-green-950">
+                      AHORA
+                    </span>
+                  </>
+                )}
+                <div
+                  className={cn(
+                    'w-full rounded-sm transition-[height] duration-500',
+                    isRecent ? 'bg-blue-500 dark:bg-green-400' : 'bg-slate-300 dark:bg-slate-500/35'
+                  )}
+                  style={{ height: `${heightPct}%` }}
+                  title={`${count} reporte${count !== 1 ? 's' : ''}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+        <div className="flex justify-between mt-1.5">
+          {['00:00', '06:00', '12:00', '18:00', '24:00'].map(label => (
+            <span
+              key={label}
+              className="font-mono text-[9.5px] font-medium text-muted-foreground/70"
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Leyenda inferior: chips de zona + escalas — scrollea horizontal si no entra */}
+      <div className="px-4 sm:px-5 pt-3 pb-4 flex items-center gap-3.5 overflow-x-auto">
+        <button
+          type="button"
+          onClick={() => handleSelectZone(null)}
+          className={cn(
+            'shrink-0 flex items-center gap-2 rounded-[10px] border px-3 py-1.5 transition-colors',
+            !internalSelectedZoneId
+              ? 'border-blue-500 bg-blue-500/[.08]'
+              : 'border-border bg-muted/40 hover:bg-muted'
+          )}
+        >
+          <span className="text-[10.5px] font-bold text-foreground">Todas las zonas</span>
+        </button>
+        {loading && zoneData.length === 0
+          ? [1, 2, 3].map(i => (
+              <div
+                key={i}
+                className="shrink-0 h-[30px] w-28 rounded-[10px] bg-muted animate-pulse"
+              />
+            ))
+          : zoneData.map(item => {
+              const isSelected = item.zone.id === internalSelectedZoneId;
+              return (
+                <button
+                  key={item.zone.id}
+                  type="button"
+                  onClick={() => handleSelectZone(item)}
+                  className={cn(
+                    'shrink-0 flex items-center gap-2 rounded-[10px] border px-3 py-1.5 transition-colors',
+                    isSelected ? 'bg-muted/40' : 'border-border bg-muted/40 hover:bg-muted'
+                  )}
+                  style={
+                    isSelected
+                      ? { borderColor: item.zone.color, background: `${item.zone.color}14` }
+                      : undefined
+                  }
+                >
+                  <span
+                    className="w-[9px] h-[9px] rounded-full shrink-0"
+                    style={{ backgroundColor: item.zone.color }}
+                  />
+                  <span className="flex flex-col items-start leading-tight">
+                    <span className="text-[10.5px] font-bold text-foreground">
+                      {item.zone.name}
+                    </span>
+                    <span className="text-[9.5px] font-medium text-muted-foreground">
+                      {item.groups.length} grupos · {item.zone.total_members || 0} miembros
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+
+        <span className="shrink-0 w-px h-[30px] bg-border" />
+
+        <div className="shrink-0 flex items-center gap-3">
+          <span className="text-[9.5px] font-bold tracking-wide text-muted-foreground">
+            REPORTES
+          </span>
+          {(['recent', 'aging', 'silent'] as ActivityStatus[]).map(status => (
+            <div key={status} className="flex items-center gap-1.5">
+              <span
+                className="w-2.5 h-2.5 rounded-full"
+                style={{ backgroundColor: ACTIVITY_COLORS[status] }}
+              />
+              <span className="text-[10px] font-medium text-muted-foreground whitespace-nowrap">
+                {status === 'recent' && 'esta semana'}
+                {status === 'aging' && 'este mes'}
+                {status === 'silent' && 'sin reportar'}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <span className="shrink-0 w-px h-[30px] bg-border" />
+
+        <div className="shrink-0 flex items-center gap-2.5">
+          <span className="text-[9.5px] font-bold tracking-wide text-muted-foreground">TAMAÑO</span>
+          {[10, 16, 24].map(size => (
+            <span
+              key={size}
+              className="rounded-full bg-slate-300 dark:bg-slate-500"
+              style={{ width: size, height: size }}
+            />
+          ))}
+          <span className="text-[10px] font-medium text-muted-foreground whitespace-nowrap">
+            = miembros del grupo
+          </span>
+        </div>
+      </div>
+    </Card>
   );
 }

--- a/src/components/mobile/screens/DashboardScreen.tsx
+++ b/src/components/mobile/screens/DashboardScreen.tsx
@@ -35,6 +35,8 @@ interface MobileDashboardScreenProps {
   actions: QuickActionItem[];
   modules: ModuleLink[];
   activity: RecentActivity[];
+  /** Admin/pastor/staff únicamente — el feed es de toda la iglesia, no de "lo mío". */
+  canSeeActivity?: boolean;
   loading: boolean;
   onNavigate: (to: string) => void;
   onActivityClick: (activity: RecentActivity) => void;
@@ -118,6 +120,7 @@ export function MobileDashboardScreen({
   actions,
   modules,
   activity,
+  canSeeActivity = true,
   loading,
   onNavigate,
   onActivityClick,
@@ -207,7 +210,9 @@ export function MobileDashboardScreen({
         </div>
       )}
 
-      {/* ── Actividad reciente (4 items) ── */}
+      {/* ── Actividad reciente (4 items) — admin/pastor/staff únicamente ── */}
+      {canSeeActivity && (
+        <>
       <MobileSectionHeader title="Actividad reciente" />
       {loading ? (
         <div className="space-y-2 px-4">
@@ -233,6 +238,8 @@ export function MobileDashboardScreen({
             />
           ))}
         </div>
+      )}
+        </>
       )}
 
       {/* ── Módulos ── */}

--- a/src/hooks/useDiscipleshipAnalytics.ts
+++ b/src/hooks/useDiscipleshipAnalytics.ts
@@ -18,6 +18,7 @@ export const useDiscipleshipAnalytics = (zoneName?: string) => {
     activeLeaders: 0,
     multiplications: 0,
     spiritualHealth: 0,
+    auxiliarySupervisors: 0,
     dateRange: { from: '', to: '' },
   });
 

--- a/src/hooks/useDiscipleshipData.ts
+++ b/src/hooks/useDiscipleshipData.ts
@@ -106,11 +106,16 @@ export function useDiscipleshipData(options: UseDiscipleshipDataOptions) {
       }
 
       if (level >= 2) {
-        promises.pendingReports = DiscipleshipService.getReports({ status: 'submitted' }).then(data => data.slice(0, 10));
+        // El backend devuelve null (no []) cuando la cola queda vacía — un slice
+        // nil de Go serializa así. Sin el (data || []), un "0 pendientes" real
+        // tira "Cannot read properties of null (reading 'slice')", que el catch
+        // genérico de abajo traga en silencio y deja pendingReports pegado en su
+        // valor anterior (el reporte recién aprobado "sigue" en la cola).
+        promises.pendingReports = DiscipleshipService.getReports({ status: 'submitted' }).then(data => (data || []).slice(0, 10));
       }
 
       if (level >= 5) {
-        promises.alerts = DiscipleshipService.getAlerts({ resolved: false }).then(data => data.slice(0, 10));
+        promises.alerts = DiscipleshipService.getAlerts({ resolved: false }).then(data => (data || []).slice(0, 10));
       }
 
       if (level === 2) {
@@ -134,7 +139,11 @@ export function useDiscipleshipData(options: UseDiscipleshipDataOptions) {
         Object.entries(promises).map(async ([key, promise]) => {
           try {
             return [key, await promise] as [string, any];
-          } catch {
+          } catch (err) {
+            // No tragar el error en silencio: si esto falla, `key` se queda
+            // pegado en su valor anterior (ver pendingReports arriba) — sin este
+            // log, esa clase de bug es invisible hasta que alguien lo pisa.
+            console.error(`Error loading discipleship data field "${key}":`, err);
             return [key, null] as [string, any];
           }
         })

--- a/src/hooks/useDiscipleshipData.ts
+++ b/src/hooks/useDiscipleshipData.ts
@@ -10,10 +10,12 @@ interface DashboardStats {
   multiplications?: number;
   average_attendance?: number;
   spiritual_health?: number;
+  growth_rate?: number;
   pending_alerts?: number;
   pending_reports?: number;
   groups_under_supervision?: number;
   subordinates_count?: number;
+  auxiliary_supervisors?: number;
   zone_name?: string;
 }
 
@@ -79,11 +81,14 @@ export function useDiscipleshipData(options: UseDiscipleshipDataOptions) {
         promises.weeklyTrends = DiscipleshipAnalyticsService.getWeeklyTrends(weeks).then(trends =>
           trends.map((t: any) => ({
             name: new Date(t.week_start).toLocaleDateString('es', { month: 'short', day: 'numeric' }),
-            miembros: t.total_attendance,
+            // "asistencia" es el nombre correcto — el dato es la suma de presentes
+            // declarados en los reportes de la semana, no un conteo de miembros.
             asistencia: t.total_attendance,
             visitantes: t.total_visitors,
             conversiones: t.total_conversions,
-            grupos: t.groups_reporting,
+            // Grupos que reportaron esa semana, NO el total de grupos activos
+            // (ese dato no lo calcula este endpoint).
+            reportando: t.groups_reporting,
           }))
         );
       }

--- a/src/hooks/useNotificationsData.ts
+++ b/src/hooks/useNotificationsData.ts
@@ -7,9 +7,16 @@ export function useNotificationsData() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(false);
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+  const lastFetchAt = useRef(0);
 
   // ── Fetch HTTP (carga inicial y reconexión) ─────────────────────────────────
-  const fetchAll = useCallback(async () => {
+  // throttle: Supabase reintenta el canal en loop cuando Realtime no conecta
+  // (ej. dev local), y cada reintento fallido emite CHANNEL_ERROR. Sin este
+  // throttle, el refetch de fallback se disparaba en cada reintento → inundación
+  // de GET /notifications. Máximo un refetch de fallback cada 60s.
+  const fetchAll = useCallback(async (opts?: { throttle?: boolean }) => {
+    if (opts?.throttle && Date.now() - lastFetchAt.current < 60_000) return;
+    lastFetchAt.current = Date.now();
     try {
       setLoading(true);
       const data = await NotificationService.getAll();
@@ -29,7 +36,9 @@ export function useNotificationsData() {
       // Fetch inicial mientras se conecta el canal
       fetchAll();
 
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user || cancelled) return;
 
       const channel = supabase
@@ -38,36 +47,34 @@ export function useNotificationsData() {
         .on(
           'postgres_changes',
           {
-            event:  'INSERT',
+            event: 'INSERT',
             schema: 'public',
-            table:  'notifications',
+            table: 'notifications',
             filter: `user_id=eq.${user.id}`,
           },
           ({ new: row }) => {
             setNotifications(prev => [row as Notification, ...prev]);
-          },
+          }
         )
         // Notificación marcada como leída en otra pestaña → sincronizar
         .on(
           'postgres_changes',
           {
-            event:  'UPDATE',
+            event: 'UPDATE',
             schema: 'public',
-            table:  'notifications',
+            table: 'notifications',
             filter: `user_id=eq.${user.id}`,
           },
           ({ new: row }) => {
             const updated = row as Notification;
-            setNotifications(prev =>
-              prev.map(n => (n.id === updated.id ? updated : n)),
-            );
-          },
+            setNotifications(prev => prev.map(n => (n.id === updated.id ? updated : n)));
+          }
         )
         .subscribe(status => {
           if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
-            // Canal caído → refetch por HTTP como fallback
-            console.warn('[notifications] Realtime error, refetching via HTTP');
-            if (!cancelled) fetchAll();
+            // Canal caído → refetch por HTTP como fallback, pero throttled: el
+            // canal reintenta solo y re-emite este estado en cada intento.
+            if (!cancelled) fetchAll({ throttle: true });
           }
         });
 

--- a/src/index.css
+++ b/src/index.css
@@ -171,3 +171,85 @@ All colors MUST be HSL.
     transform: scale(1);
   }
 }
+
+/* Mapa en vivo (DiscipleshipMap): punto del pill "EN VIVO" */
+@keyframes jetro-live-dot {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+/* Mapa en vivo: ondas concéntricas cuando un grupo acaba de reportar */
+@keyframes jetro-pulse-ring {
+  0% {
+    transform: scale(0.5);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(2.8);
+    opacity: 0;
+  }
+}
+
+/* Mapa en vivo: barrido cónico del overlay de radar */
+@keyframes jetro-radar-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Mapa en vivo: latido ambiental sutil de los marcadores de grupo */
+@keyframes jetro-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.12);
+  }
+}
+
+/* Barrido cónico del radar (overlay decorativo del mapa en vivo). */
+.jetro-radar-sweep {
+  background: conic-gradient(from 0deg, rgba(34, 197, 94, 0.26), transparent 70deg);
+  mix-blend-mode: multiply;
+  animation: jetro-radar-spin 4s linear infinite;
+}
+:root[data-theme='dark'] .jetro-radar-sweep,
+.dark .jetro-radar-sweep {
+  background: conic-gradient(from 0deg, rgba(74, 222, 128, 0.22), transparent 70deg);
+  mix-blend-mode: normal;
+}
+
+/* Ondas concéntricas cuando un grupo acaba de reportar. Centradas en el
+   marcador (34×34), color heredado inline del estado del grupo. */
+.jetro-group-pulse {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  border: 2px solid;
+  border-radius: 999px;
+  animation: jetro-pulse-ring 1.5s ease-out infinite;
+  pointer-events: none;
+}
+.jetro-group-pulse-delay {
+  animation-delay: 0.5s;
+}
+
+/* Latido ambiental de cada marcador de grupo ("sistema en vivo"). Se apaga
+   solo con prefers-reduced-motion. El ripple/ring van en hijos aparte, así
+   que el scale acá no los pisa. */
+.jetro-group-marker {
+  animation: jetro-breathe 3s ease-in-out infinite;
+  transform-origin: center;
+}

--- a/src/lib/iso-week.ts
+++ b/src/lib/iso-week.ts
@@ -26,6 +26,23 @@ export interface IsoWeekBounds {
  *   2026-01-01 → "2026-W01"
  *   2026-01-04 (Sunday) → "2025-W53"  (same as 2025-12-29, the preceding Monday)
  */
+/**
+ * Parses a date-only value (e.g. a `period_start`/`period_end` from the API,
+ * which the backend sends as `"2026-08-17T00:00:00Z"` — UTC midnight) as a
+ * LOCAL calendar date, not a UTC instant.
+ *
+ * `new Date("2026-08-17T00:00:00Z")` is a specific instant, not "August 17".
+ * In any timezone behind UTC (all of the Americas), that instant falls on
+ * the PREVIOUS local day — e.g. in America/Caracas (UTC-4) it renders as
+ * "Sun Aug 16, 20:00". Since ISO weeks treat Sunday as belonging to the
+ * PRECEDING Monday's week, every date-only value silently rolls back into
+ * the wrong week for any user south of the Atlantic. Anchoring at local
+ * noon keeps the calendar date stable regardless of timezone offset.
+ */
+export function parseDateOnly(dateStr: string): Date {
+  return new Date(`${dateStr.slice(0, 10)}T12:00:00`);
+}
+
 export function getIsoWeek(date: Date): string {
   const week = getISOWeek(date);
   const year = getISOWeekYear(date);

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -6,6 +6,10 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { AuditLogModal } from '@/components/AuditLogModal';
 import { MobileDashboardScreen } from '@/components/mobile/screens/DashboardScreen';
+
+// Mapa: pesado (Leaflet). El Inicio es la primera pantalla que carga, así que
+// lo bajamos por demanda para no meter Leaflet en el bundle crítico del dashboard.
+const DiscipleshipMap = lazy(() => import('@/components/discipleship/DiscipleshipMap'));
 import { useAuth } from '@/hooks/useAuth';
 import { useDashboardStats } from '@/hooks/useDashboardStats';
 import { useMobileMode } from '@/hooks/useMobileMode';
@@ -333,6 +337,15 @@ const DashboardHome = () => {
               </button>
             ))}
           </div>
+        )}
+
+        {/* ── Mapa de zonas y células (staff+/pastor, con módulo de zonas) ──────
+            Vista global de la iglesia sobre el mapa: reemplaza en protagonismo
+            al feed de actividad, que baja debajo. */}
+        {canSeeSystemActivity && installedModules.includes('zones') && (
+          <Suspense fallback={<Skeleton className="w-full h-[580px] rounded-2xl" />}>
+            <DiscipleshipMap title="Mapa de zonas y células" />
+          </Suspense>
         )}
 
         {/* ── Two column grid ───────────────────────────────────────────────── */}

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -13,6 +13,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { AuditLog } from '@/types/audit.types';
 import { RecentActivity } from '@/services/dashboard.service';
 import { cn } from '@/lib/utils';
+import { ROLE_LEVELS } from '@/lib/permissions';
 import {
   Activity,
   AlertTriangle,
@@ -156,6 +157,12 @@ const DashboardHome = () => {
       })
     : '—';
 
+  // Actividad reciente son altas/bajas/ediciones de usuarios de TODA la iglesia
+  // — un supervisor o servidor no tiene por qué verla. El backend ya no manda
+  // el feed para esos roles (devuelve []), esto además evita mostrar la tarjeta
+  // vacía "Sin actividad reciente" a alguien que nunca debería verla.
+  const canSeeSystemActivity = ROLE_LEVELS[currentUserRole ?? ''] >= ROLE_LEVELS.staff;
+
   const visibleActions = QUICK_ACTIONS.filter(a => {
     if (!currentUserRole || !a.roles.includes(currentUserRole)) return false;
     if (a.module && !installedModules.includes(a.module)) return false;
@@ -225,6 +232,7 @@ const DashboardHome = () => {
           actions={visibleActions}
           modules={moduleLinks}
           activity={recentActivity}
+          canSeeActivity={canSeeSystemActivity}
           loading={loading}
           onNavigate={navigate}
           onActivityClick={handleActivityClick}
@@ -329,58 +337,60 @@ const DashboardHome = () => {
 
         {/* ── Two column grid ───────────────────────────────────────────────── */}
         <div className="grid gap-4 lg:grid-cols-3">
-          {/* Activity feed — takes 2/3 */}
-          <Card className="lg:col-span-2 border-0 bg-[var(--glass-background)] backdrop-blur-lg shadow-[var(--shadow-glass)]">
-            <CardHeader className="p-4 pb-2">
-              <CardTitle className="text-base font-semibold flex items-center gap-2">
-                <Activity className="h-4 w-4 text-primary" />
-                Actividad reciente
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="p-4 pt-2">
-              {loading ? (
-                <div className="space-y-3">
-                  {[1, 2, 3, 4, 5].map(i => (
-                    <Skeleton key={i} className="h-12 w-full rounded-xl" />
-                  ))}
-                </div>
-              ) : recentActivity.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-10 gap-2 text-muted-foreground">
-                  <Activity className="h-8 w-8 opacity-20" />
-                  <p className="text-sm">Sin actividad reciente</p>
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  {recentActivity.slice(0, 8).map((activity, i) => (
-                    <div
-                      key={activity.id ?? i}
-                      onClick={() => handleActivityClick(activity)}
-                      className="flex items-center gap-3 p-3 rounded-xl bg-gradient-to-r from-accent/40 to-transparent border border-border/50 hover:from-accent/60 transition-colors cursor-pointer"
-                    >
+          {/* Activity feed — takes 2/3. Admin/pastor/staff only (ver canSeeSystemActivity). */}
+          {canSeeSystemActivity && (
+            <Card className="lg:col-span-2 border-0 bg-[var(--glass-background)] backdrop-blur-lg shadow-[var(--shadow-glass)]">
+              <CardHeader className="p-4 pb-2">
+                <CardTitle className="text-base font-semibold flex items-center gap-2">
+                  <Activity className="h-4 w-4 text-primary" />
+                  Actividad reciente
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-4 pt-2">
+                {loading ? (
+                  <div className="space-y-3">
+                    {[1, 2, 3, 4, 5].map(i => (
+                      <Skeleton key={i} className="h-12 w-full rounded-xl" />
+                    ))}
+                  </div>
+                ) : recentActivity.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-10 gap-2 text-muted-foreground">
+                    <Activity className="h-8 w-8 opacity-20" />
+                    <p className="text-sm">Sin actividad reciente</p>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {recentActivity.slice(0, 8).map((activity, i) => (
                       <div
-                        className={cn(
-                          'w-2.5 h-2.5 rounded-full shrink-0',
-                          activityDot(activity.type)
-                        )}
-                      />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium truncate">{activity.action}</p>
-                        <p className="text-xs text-muted-foreground truncate">
-                          por {activity.user}
-                        </p>
+                        key={activity.id ?? i}
+                        onClick={() => handleActivityClick(activity)}
+                        className="flex items-center gap-3 p-3 rounded-xl bg-gradient-to-r from-accent/40 to-transparent border border-border/50 hover:from-accent/60 transition-colors cursor-pointer"
+                      >
+                        <div
+                          className={cn(
+                            'w-2.5 h-2.5 rounded-full shrink-0',
+                            activityDot(activity.type)
+                          )}
+                        />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium truncate">{activity.action}</p>
+                          <p className="text-xs text-muted-foreground truncate">
+                            por {activity.user}
+                          </p>
+                        </div>
+                        <span className="text-xs text-muted-foreground whitespace-nowrap shrink-0">
+                          {activity.time}
+                        </span>
                       </div>
-                      <span className="text-xs text-muted-foreground whitespace-nowrap shrink-0">
-                        {activity.time}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
-          {/* Module summary — takes 1/3 */}
-          <div className="space-y-3">
+          {/* Module summary — takes 1/3, o el ancho completo si no hay feed de actividad */}
+          <div className={cn('space-y-3', !canSeeSystemActivity && 'lg:col-span-3')}>
             {/* Discipleship */}
             {installedModules.includes('discipleship') && (
               <Card

--- a/src/pages/dashboard/MusicPage.tsx
+++ b/src/pages/dashboard/MusicPage.tsx
@@ -18,8 +18,6 @@ import {
   Users,
 } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -48,22 +46,27 @@ import type {
 } from '@/types/music.types';
 import MusicMembers from './music/MusicMembers';
 import MusicInstruments from './music/MusicInstruments';
-import { DirectorMusicHero } from './music/MusicHero';
+import { DirectorMusicHero, MusicEmpty, StatTile } from './music/MusicHero';
 import { ServidorMusicHero } from './music/ServidorHero';
 import { ChannelAudios } from './music/ChannelAudios';
 import { ServidorRepertoire } from './music/ServidorRepertoire';
 import { RepertoireList } from './music/RepertoireList';
 import { MusicFab } from './music/MusicFab';
 import { InstrumentChip, resolveCategory } from './music/instrument-visual';
-import { EVENT_TYPE_COLOR, EVENT_TYPE_LABEL } from './music/event-visual';
+import {
+  EVENT_TYPE_COLOR,
+  EVENT_TYPE_LABEL,
+  EVENT_TYPE_TONE,
+  toneStyle,
+} from './music/event-visual';
 import { useMusicAccess } from './music/use-music-access';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import './music/music-theme.css';
 
-const STATE_VARIANT: Record<AssignmentState, 'default' | 'secondary' | 'destructive'> = {
-  asignado: 'secondary',
-  confirmado: 'default',
-  no_puedo: 'destructive',
+const STATE_TAG: Record<AssignmentState, string> = {
+  asignado: 'music-tag',
+  confirmado: 'music-tag music-tag-ok',
+  no_puedo: 'music-tag music-tag-warn',
 };
 
 const STATE_LABEL: Record<AssignmentState, string> = {
@@ -80,10 +83,10 @@ const FUNCION_LABEL: Record<string, string> = {
 };
 
 const FUNCION_DOT: Record<string, string> = {
-  corista: 'bg-pink-500',
-  musico: 'bg-violet-500',
-  tecnico: 'bg-cyan-500',
-  danzarina: 'bg-amber-500',
+  corista: 'bg-pink-400',
+  musico: 'bg-amber-400',
+  tecnico: 'bg-emerald-400',
+  danzarina: 'bg-fuchsia-400',
 };
 
 function daysUntil(iso: string): number {
@@ -107,6 +110,38 @@ function today(): string {
 }
 
 // ─────────────────────────────────────────────
+// Chrome compartido de sección: eyebrow + título serif + acción.
+// Reemplaza al <Card> de shadcn dentro del módulo — la card gris con título
+// bold es exactamente el patrón que hace que todos los módulos se vean igual.
+// ─────────────────────────────────────────────
+function Panel({
+  title,
+  eyebrow,
+  action,
+  children,
+  className,
+}: {
+  title: string;
+  eyebrow?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={cn('music-panel p-4 sm:p-5', className)}>
+      <header className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          {eyebrow && <p className="music-eyebrow">{eyebrow}</p>}
+          <h2 className="music-heading mt-1.5 text-xl leading-none sm:text-2xl">{title}</h2>
+        </div>
+        {action && <div className="shrink-0">{action}</div>}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+// ─────────────────────────────────────────────
 // CRONOGRAMA — vista lista + vista calendario
 // ─────────────────────────────────────────────
 function CronogramaTab({
@@ -122,45 +157,44 @@ function CronogramaTab({
     queryFn: () => MusicService.getEvents(),
   });
 
+  const views = [
+    { key: 'list' as const, label: 'Lista', Icon: List },
+    { key: 'calendar' as const, label: 'Calendario', Icon: CalendarDays },
+  ];
+
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-        <CardTitle className="text-base">Cronograma</CardTitle>
-        <div className="flex gap-1 rounded-md border border-border p-0.5">
-          <Button
-            size="sm"
-            variant={view === 'list' ? 'default' : 'ghost'}
-            className="h-7 gap-1"
-            onClick={() => setView('list')}
-          >
-            <List className="h-3.5 w-3.5" />
-            Lista
-          </Button>
-          <Button
-            size="sm"
-            variant={view === 'calendar' ? 'default' : 'ghost'}
-            className="h-7 gap-1"
-            onClick={() => setView('calendar')}
-          >
-            <CalendarDays className="h-3.5 w-3.5" />
-            Calendario
-          </Button>
+    <Panel
+      eyebrow="Agenda del equipo"
+      title="Cronograma"
+      action={
+        <div className="flex gap-1 rounded-full border border-border bg-black/25 p-1">
+          {views.map(({ key, label, Icon }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setView(key)}
+              data-active={view === key}
+              className="music-pill music-pill-ghost"
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {label}
+            </button>
+          ))}
         </div>
-      </CardHeader>
-      <CardContent>
-        {isLoading ? (
-          <div className="space-y-3">
-            {[1, 2, 3].map(i => (
-              <Skeleton key={i} className="h-20 w-full" />
-            ))}
-          </div>
-        ) : view === 'list' ? (
-          <CronogramaList events={events} isDirector={isDirector} onOpenEvent={onOpenEvent} />
-        ) : (
-          <CronogramaCalendar events={events} onOpenEvent={onOpenEvent} />
-        )}
-      </CardContent>
-    </Card>
+      }
+    >
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : view === 'list' ? (
+        <CronogramaList events={events} isDirector={isDirector} onOpenEvent={onOpenEvent} />
+      ) : (
+        <CronogramaCalendar events={events} onOpenEvent={onOpenEvent} />
+      )}
+    </Panel>
   );
 }
 
@@ -176,13 +210,13 @@ function CronogramaList({
   const upcoming = events.filter(e => e.eventDate >= today()).slice(0, 30);
   if (upcoming.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-8">
+      <p className="py-8 text-center text-sm text-muted-foreground">
         No hay cultos próximos. {isDirector && 'Generá el trimestre desde la pestaña Cultos.'}
       </p>
     );
   }
   return (
-    <div className="space-y-2">
+    <div className="music-stagger space-y-2">
       {upcoming.map(ev => (
         <EventListRow key={ev.id} event={ev} onOpenEvent={onOpenEvent} />
       ))}
@@ -208,45 +242,53 @@ function EventListRow({
 
   const confirmed = assignments.filter(a => a.state === 'confirmado').length;
   const declined = assignments.filter(a => a.state === 'no_puedo').length;
+  const dCount = daysUntil(event.eventDate);
 
   return (
     <button
       type="button"
       onClick={() => onOpenEvent(event)}
-      className="w-full text-left rounded-lg border border-border p-3 hover:bg-muted/50 transition-colors group"
+      style={toneStyle(EVENT_TYPE_TONE[event.eventType])}
+      className="music-row relative block w-full overflow-hidden p-3 pl-5 text-left"
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span
-              className={cn('h-2 w-2 rounded-full shrink-0', EVENT_TYPE_COLOR[event.eventType])}
-            />
-            <span className="text-sm font-semibold capitalize">
-              {formatEventDate(event.eventDate)}
+      <span className="music-spine" />
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="w-11 shrink-0 text-center">
+            <span className="music-num block text-lg font-semibold leading-none text-[hsl(var(--music-tone))]">
+              {dCount >= 0 ? dCount : '—'}
             </span>
-            <Badge variant="outline" className="text-xs">
-              {EVENT_TYPE_LABEL[event.eventType]}
-            </Badge>
-            {event.published && (
-              <Badge variant="secondary" className="text-xs">
-                Publicado
-              </Badge>
-            )}
+            <span className="music-eyebrow music-eyebrow-xs mt-1 block">
+              {dCount === 0 ? 'hoy' : 'días'}
+            </span>
           </div>
-          {event.title && (
-            <p className="text-sm text-muted-foreground mt-1 truncate">{event.title}</p>
-          )}
+          <div className="min-w-0">
+            <p className="text-sm font-semibold capitalize">{formatEventDate(event.eventDate)}</p>
+            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+              <span className="music-tag music-tag-tone">
+                {EVENT_TYPE_LABEL[event.eventType]}
+              </span>
+              {event.published && <span className="music-tag music-tag-ok">Publicado</span>}
+              {event.title && (
+                <span className="truncate text-xs text-muted-foreground">{event.title}</span>
+              )}
+            </div>
+          </div>
         </div>
-        <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
+        <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">
             <Users className="h-3.5 w-3.5" />
-            {assignments.length}
-            {confirmed > 0 && <span className="text-green-600">·{confirmed}✓</span>}
-            {declined > 0 && <span className="text-destructive">·{declined}✗</span>}
+            <span className="music-num">{assignments.length}</span>
+            {confirmed > 0 && (
+              <span className="music-num text-emerald-700 dark:text-emerald-300">
+                ·{confirmed}✓
+              </span>
+            )}
+            {declined > 0 && <span className="music-num text-destructive">·{declined}✗</span>}
           </span>
           <span className="flex items-center gap-1">
             <Music2 className="h-3.5 w-3.5" />
-            {songs.length}
+            <span className="music-num">{songs.length}</span>
           </span>
         </div>
       </div>
@@ -306,7 +348,7 @@ function CronogramaCalendar({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <p className="text-sm font-semibold capitalize">{monthLabel}</p>
+        <p className="music-heading text-lg capitalize leading-none">{monthLabel}</p>
         <div className="flex gap-1">
           <Button size="icon" variant="outline" className="h-7 w-7" onClick={prevMonth}>
             <ChevronLeft className="h-4 w-4" />
@@ -319,9 +361,11 @@ function CronogramaCalendar({
           </Button>
         </div>
       </div>
-      <div className="grid grid-cols-7 gap-1 text-center text-xs text-muted-foreground">
+      <div className="grid grid-cols-7 gap-1 text-center">
         {['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'].map(d => (
-          <div key={d}>{d}</div>
+          <div key={d} className="music-eyebrow music-eyebrow-xs py-1">
+            {d}
+          </div>
         ))}
       </div>
       <div className="grid grid-cols-7 gap-1">
@@ -330,7 +374,7 @@ function CronogramaCalendar({
           const inMonth = dayNum >= 1 && dayNum <= daysInMonth;
           if (!inMonth)
             return (
-              <div key={i} className="min-h-[3.5rem] rounded-md bg-muted/20 sm:aspect-square" />
+              <div key={i} className="min-h-[3.5rem] rounded-lg bg-white/[0.015] sm:aspect-square" />
             );
           const iso = `${cursor.year}-${String(cursor.month + 1).padStart(2, '0')}-${String(dayNum).padStart(2, '0')}`;
           const dayEvents = eventsByDate.get(iso) ?? [];
@@ -339,15 +383,15 @@ function CronogramaCalendar({
             <div
               key={i}
               className={cn(
-                'min-h-[3.5rem] rounded-md border border-border p-1 flex flex-col gap-0.5 overflow-hidden sm:aspect-square',
-                isToday && 'ring-2 ring-primary',
-                dayEvents.length === 0 && 'bg-card',
-                dayEvents.length > 0 && 'bg-muted/30'
+                'flex min-h-[3.5rem] flex-col gap-0.5 overflow-hidden rounded-lg border p-1 transition-colors sm:aspect-square',
+                isToday
+                  ? 'border-primary/60 bg-primary/[0.07]'
+                  : 'border-border/60 bg-black/20 hover:border-border'
               )}
             >
               <span
                 className={cn(
-                  'text-[10px] font-semibold',
+                  'music-num text-[10px] font-semibold',
                   isToday ? 'text-primary' : 'text-muted-foreground'
                 )}
               >
@@ -359,17 +403,16 @@ function CronogramaCalendar({
                     key={ev.id}
                     type="button"
                     onClick={() => onOpenEvent(ev)}
-                    className={cn(
-                      'text-[10px] leading-tight rounded px-1 py-0.5 text-white text-left truncate hover:opacity-80',
-                      EVENT_TYPE_COLOR[ev.eventType]
-                    )}
+                    style={toneStyle(EVENT_TYPE_TONE[ev.eventType])}
+                    className="music-press truncate rounded px-1 py-0.5 text-left text-[10px] font-medium leading-tight text-[hsl(var(--music-tone))]"
                     title={`${EVENT_TYPE_LABEL[ev.eventType]}${ev.title ? ` — ${ev.title}` : ''}`}
                   >
+                    <span className="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[hsl(var(--music-tone))] align-middle" />
                     {ev.title || EVENT_TYPE_LABEL[ev.eventType]}
                   </button>
                 ))}
                 {dayEvents.length > 2 && (
-                  <span className="text-[9px] text-muted-foreground px-1">
+                  <span className="music-num px-1 text-[9px] text-muted-foreground">
                     +{dayEvents.length - 2}
                   </span>
                 )}
@@ -378,10 +421,10 @@ function CronogramaCalendar({
           );
         })}
       </div>
-      <div className="flex gap-3 text-xs text-muted-foreground pt-1">
+      <div className="flex gap-4 pt-1">
         {(Object.keys(EVENT_TYPE_COLOR) as MusicEventType[]).map(t => (
-          <span key={t} className="flex items-center gap-1">
-            <span className={cn('h-2 w-2 rounded-full', EVENT_TYPE_COLOR[t])} />
+          <span key={t} className="music-eyebrow flex items-center gap-1.5">
+            <span className={cn('h-1.5 w-1.5 rounded-full', EVENT_TYPE_COLOR[t])} />
             {EVENT_TYPE_LABEL[t]}
           </span>
         ))}
@@ -433,7 +476,7 @@ function CreateEventDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="music-shell">
         <DialogHeader>
-          <DialogTitle>Nuevo culto</DialogTitle>
+          <DialogTitle className="music-heading text-2xl">Nuevo culto</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleCreate} className="space-y-4">
           <div className="space-y-1">
@@ -541,17 +584,13 @@ function CultosTab({
   const sorted = [...events].sort((a, b) => b.eventDate.localeCompare(a.eventDate));
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-        <CardTitle className="text-base">Cultos</CardTitle>
-        {isDirector && (
+    <Panel
+      eyebrow="Calendario litúrgico"
+      title="Cultos"
+      action={
+        isDirector && (
           <div className="flex gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setBatchOpen(true)}
-              className="gap-1"
-            >
+            <Button size="sm" variant="outline" onClick={() => setBatchOpen(true)} className="gap-1">
               <CalendarIcon className="h-4 w-4" />
               Trimestre
             </Button>
@@ -560,74 +599,75 @@ function CultosTab({
               Nuevo
             </Button>
           </div>
-        )}
-      </CardHeader>
-      <CardContent>
-        {isLoading ? (
-          <div className="space-y-2">
-            {[1, 2, 3].map(i => (
-              <Skeleton key={i} className="h-10 w-full" />
-            ))}
-          </div>
-        ) : sorted.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-6">
-            No hay cultos registrados.
-          </p>
-        ) : (
-          <div className="divide-y divide-border rounded-md border border-border">
-            {sorted.map(ev => (
-              <div key={ev.id} className="flex items-center justify-between px-3 py-2">
-                <button
-                  type="button"
-                  onClick={() => onOpenEvent(ev)}
-                  className="text-left flex-1 min-w-0 hover:opacity-70"
-                >
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className={cn('h-2 w-2 rounded-full', EVENT_TYPE_COLOR[ev.eventType])} />
-                    <span className="font-medium text-sm">{ev.eventDate}</span>
-                    <span className="text-muted-foreground text-xs">
-                      {EVENT_TYPE_LABEL[ev.eventType]}
-                    </span>
-                    {ev.title && <span className="text-sm truncate">— {ev.title}</span>}
-                  </div>
-                </button>
-                <div className="flex items-center gap-2 shrink-0 ml-2">
-                  {ev.published && (
-                    <Badge variant="secondary" className="text-xs">
-                      Publicado
-                    </Badge>
-                  )}
-                  {isDirector && (
-                    <ConfirmDialog
-                      trigger={
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="h-7 text-xs text-destructive"
-                          disabled={deleteMutation.isPending}
-                        >
-                          Eliminar
-                        </Button>
-                      }
-                      title="¿Eliminar culto?"
-                      description={`Se elimina el culto del ${ev.eventDate}${ev.title ? ` — "${ev.title}"` : ''} junto con su equipo asignado y su repertorio. No se puede deshacer.`}
-                      confirmLabel="Eliminar culto"
-                      onConfirm={() => deleteMutation.mutate(ev.id)}
-                    />
+        )
+      }
+    >
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-11 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : sorted.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">No hay cultos registrados.</p>
+      ) : (
+        <div className="music-stagger space-y-1.5">
+          {sorted.map(ev => (
+            <div
+              key={ev.id}
+              style={toneStyle(EVENT_TYPE_TONE[ev.eventType])}
+              className="music-row relative flex items-center justify-between overflow-hidden px-3 py-2.5 pl-5"
+            >
+              <span className="music-spine" />
+              <button
+                type="button"
+                onClick={() => onOpenEvent(ev)}
+                className="music-press min-w-0 flex-1 text-left"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="music-num text-sm font-semibold">{ev.eventDate}</span>
+                  <span className="music-tag music-tag-tone">
+                    {EVENT_TYPE_LABEL[ev.eventType]}
+                  </span>
+                  {ev.title && (
+                    <span className="truncate text-sm text-muted-foreground">{ev.title}</span>
                   )}
                 </div>
+              </button>
+              <div className="ml-2 flex shrink-0 items-center gap-2">
+                {ev.published && <span className="music-tag music-tag-ok">Publicado</span>}
+                {isDirector && (
+                  <ConfirmDialog
+                    trigger={
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 text-xs text-destructive"
+                        disabled={deleteMutation.isPending}
+                      >
+                        Eliminar
+                      </Button>
+                    }
+                    title="¿Eliminar culto?"
+                    description={`Se elimina el culto del ${ev.eventDate}${ev.title ? ` — "${ev.title}"` : ''} junto con su equipo asignado y su repertorio. No se puede deshacer.`}
+                    confirmLabel="Eliminar culto"
+                    onConfirm={() => deleteMutation.mutate(ev.id)}
+                  />
+                )}
               </div>
-            ))}
-          </div>
-        )}
-      </CardContent>
+            </div>
+          ))}
+        </div>
+      )}
 
       <CreateEventDialog open={createOpen} onOpenChange={setCreateOpen} />
 
       <Dialog open={batchOpen} onOpenChange={setBatchOpen}>
         <DialogContent className="music-shell">
           <DialogHeader>
-            <DialogTitle>Generar trimestre</DialogTitle>
+            <DialogTitle className="music-heading text-2xl">
+              Generar trimestre
+            </DialogTitle>
           </DialogHeader>
           <form onSubmit={handleBatch} className="space-y-4">
             <p className="text-sm text-muted-foreground">
@@ -672,7 +712,7 @@ function CultosTab({
           </form>
         </DialogContent>
       </Dialog>
-    </Card>
+    </Panel>
   );
 }
 
@@ -690,47 +730,33 @@ function CancionesTab() {
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-3 gap-3">
-        <div className="rounded-xl border border-border p-3 sm:p-4">
-          <div className="flex items-center gap-2 mb-1 text-muted-foreground">
-            <Music2 className="h-3.5 w-3.5" />
-            <span className="text-xs font-medium">En catálogo</span>
-          </div>
-          <p className="text-xl sm:text-2xl font-bold tabular-nums">{stats.length}</p>
-        </div>
-        <div className="rounded-xl border border-border p-3 sm:p-4">
-          <div className="flex items-center gap-2 mb-1 text-muted-foreground">
-            <TrendingUp className="h-3.5 w-3.5" />
-            <span className="text-xs font-medium">Veces tocadas</span>
-          </div>
-          <p className="text-xl sm:text-2xl font-bold tabular-nums">{totalPlays}</p>
-        </div>
-        <div
-          className={cn(
-            'rounded-xl border p-3 sm:p-4',
-            neverPlayed > 0 ? 'border-amber-500/30 bg-amber-500/10' : 'border-border'
-          )}
-        >
-          <div className="flex items-center gap-2 mb-1 text-muted-foreground">
-            <CalendarIcon className="h-3.5 w-3.5" />
-            <span className="text-xs font-medium">Sin uso</span>
-          </div>
-          <p className="text-xl sm:text-2xl font-bold tabular-nums">{neverPlayed}</p>
-        </div>
+      <div className="music-stagger grid grid-cols-3 gap-3">
+        <StatTile
+          label="En catálogo"
+          value={stats.length}
+          icon={<Music2 className="h-3.5 w-3.5" />}
+          tone="primary"
+        />
+        <StatTile
+          label="Veces tocadas"
+          value={totalPlays}
+          icon={<TrendingUp className="h-3.5 w-3.5" />}
+        />
+        <StatTile
+          label="Sin uso"
+          value={neverPlayed}
+          icon={<CalendarIcon className="h-3.5 w-3.5" />}
+          tone={neverPlayed > 0 ? 'warning' : 'default'}
+        />
       </div>
 
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">Ranking del repertorio</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <RepertoireList
-            stats={stats}
-            isLoading={isLoading}
-            emptyHint="No hay canciones en el repertorio. Agregalas desde el detalle de cada culto."
-          />
-        </CardContent>
-      </Card>
+      <Panel eyebrow="Lo que más tocamos" title="Ranking del repertorio">
+        <RepertoireList
+          stats={stats}
+          isLoading={isLoading}
+          emptyHint="No hay canciones en el repertorio. Agregalas desde el detalle de cada culto."
+        />
+      </Panel>
     </div>
   );
 }
@@ -820,101 +846,100 @@ function ServidorView({ embedExtras = true }: { embedExtras?: boolean }) {
 
   return (
     <div className="space-y-4">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Mis cultos</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {loadingAssignments ? (
-            <div className="space-y-2">
-              {[1, 2, 3].map(i => (
-                <Skeleton key={i} className="h-10 w-full" />
-              ))}
-            </div>
-          ) : upcomingAssignments.length === 0 ? (
-            <p className="text-sm text-muted-foreground text-center py-6">
-              No tenés cultos próximos asignados.
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {upcomingAssignments.map(a => {
-                const d = a.eventDate ? daysUntil(a.eventDate) : null;
-                return (
-                  <div key={a.id} className="rounded-xl border border-border bg-card p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="flex items-center gap-3 min-w-0">
-                        <div className="flex h-12 w-12 shrink-0 flex-col items-center justify-center rounded-lg bg-primary/15 text-primary">
-                          <span className="text-base font-bold leading-none tabular-nums">
-                            {d != null && d >= 0 ? d : '—'}
-                          </span>
-                          <span className="text-[9px] uppercase tracking-wide opacity-80">
-                            {d === 0 ? 'hoy' : 'días'}
-                          </span>
-                        </div>
-                        <div className="min-w-0">
-                          <div className="flex items-center gap-1.5">
-                            <span
-                              className={cn(
-                                'h-2 w-2 rounded-full shrink-0',
-                                FUNCION_DOT[a.funcion] ?? 'bg-muted-foreground'
-                              )}
-                            />
-                            <p className="text-sm font-semibold truncate">
-                              {FUNCION_LABEL[a.funcion] ?? a.funcion}
-                            </p>
-                          </div>
-                          <p className="text-xs text-muted-foreground capitalize truncate">
-                            {a.eventDate ? formatEventDate(a.eventDate) : a.eventId}
-                            {a.eventType ? ` · ${EVENT_TYPE_LABEL[a.eventType]}` : ''}
-                          </p>
-                          {a.instrument && (
-                            <div className="mt-1.5">
-                              <InstrumentChip
-                                name={a.instrument}
-                                category={resolveCategory(a.instrument, instruments)}
-                              />
-                            </div>
-                          )}
-                        </div>
+      <Panel eyebrow="Tu agenda" title="Mis cultos">
+        {loadingAssignments ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map(i => (
+              <Skeleton key={i} className="h-16 w-full rounded-xl" />
+            ))}
+          </div>
+        ) : upcomingAssignments.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No tenés cultos próximos asignados.
+          </p>
+        ) : (
+          <div className="music-stagger space-y-2">
+            {upcomingAssignments.map(a => {
+              const d = a.eventDate ? daysUntil(a.eventDate) : null;
+              const tone = EVENT_TYPE_TONE[a.eventType ?? 'domingo'] ?? EVENT_TYPE_TONE.domingo;
+              return (
+                <div
+                  key={a.id}
+                  style={toneStyle(tone)}
+                  className="music-row relative overflow-hidden p-3 pl-5"
+                >
+                  <span className="music-spine" />
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="w-11 shrink-0 text-center">
+                        <span className="music-num block text-lg font-semibold leading-none text-[hsl(var(--music-tone))]">
+                          {d != null && d >= 0 ? d : '—'}
+                        </span>
+                        <span className="music-eyebrow music-eyebrow-xs mt-1 block">
+                          {d === 0 ? 'hoy' : 'días'}
+                        </span>
                       </div>
-                      <Badge variant={STATE_VARIANT[a.state]} className="text-xs shrink-0">
-                        {STATE_LABEL[a.state]}
-                      </Badge>
-                    </div>
-                    {a.state !== AssignmentStates.no_puedo && (
-                      <div className="mt-3 flex gap-2">
-                        {a.state === AssignmentStates.asignado && (
-                          <Button
-                            size="sm"
-                            className="h-8 flex-1"
-                            onClick={() =>
-                              updateMutation.mutate({ id: a.id, data: { state: 'confirmado' } })
-                            }
-                            disabled={updateMutation.isPending}
-                          >
-                            Confirmar
-                          </Button>
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span
+                            className={cn(
+                              'h-1.5 w-1.5 shrink-0 rounded-full',
+                              FUNCION_DOT[a.funcion] ?? 'bg-muted-foreground'
+                            )}
+                          />
+                          <p className="text-sm font-semibold">
+                            {FUNCION_LABEL[a.funcion] ?? a.funcion}
+                          </p>
+                        </div>
+                        <p className="truncate text-xs capitalize text-muted-foreground">
+                          {a.eventDate ? formatEventDate(a.eventDate) : a.eventId}
+                          {a.eventType ? ` · ${EVENT_TYPE_LABEL[a.eventType]}` : ''}
+                        </p>
+                        {a.instrument && (
+                          <div className="mt-1.5">
+                            <InstrumentChip
+                              name={a.instrument}
+                              category={resolveCategory(a.instrument, instruments)}
+                            />
+                          </div>
                         )}
+                      </div>
+                    </div>
+                    <span className={cn('shrink-0', STATE_TAG[a.state])}>{STATE_LABEL[a.state]}</span>
+                  </div>
+                  {a.state !== AssignmentStates.no_puedo && (
+                    <div className="mt-3 flex gap-2">
+                      {a.state === AssignmentStates.asignado && (
                         <Button
                           size="sm"
-                          variant="outline"
                           className="h-8 flex-1"
                           onClick={() =>
-                            updateMutation.mutate({ id: a.id, data: { state: 'no_puedo' } })
+                            updateMutation.mutate({ id: a.id, data: { state: 'confirmado' } })
                           }
                           disabled={updateMutation.isPending}
                         >
-                          No puedo
+                          Confirmar
                         </Button>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-8 flex-1 border-white/15 bg-transparent hover:bg-white/5"
+                        onClick={() =>
+                          updateMutation.mutate({ id: a.id, data: { state: 'no_puedo' } })
+                        }
+                        disabled={updateMutation.isPending}
+                      >
+                        No puedo
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Panel>
 
       {embedExtras && (
         <>
@@ -923,56 +948,58 @@ function ServidorView({ embedExtras = true }: { embedExtras?: boolean }) {
         </>
       )}
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-          <CardTitle className="text-base">Mis indisponibilidades</CardTitle>
+      <Panel
+        eyebrow="Cuándo no estás"
+        title="Mis indisponibilidades"
+        action={
           <Button size="sm" onClick={() => setUnavailOpen(true)} className="gap-1">
             <Plus className="h-4 w-4" />
             Agregar
           </Button>
-        </CardHeader>
-        <CardContent>
-          {loadingUnavail ? (
-            <div className="space-y-2">
-              {[1, 2].map(i => (
-                <Skeleton key={i} className="h-10 w-full" />
-              ))}
-            </div>
-          ) : myUnavailability.length === 0 ? (
-            <p className="text-sm text-muted-foreground text-center py-6">
-              No tenés indisponibilidades registradas.
-            </p>
-          ) : (
-            <div className="divide-y divide-border rounded-md border border-border">
-              {myUnavailability.map(u => (
-                <div key={u.id} className="flex items-center justify-between px-3 py-3">
-                  <div>
-                    <p className="text-sm">
-                      {u.startDate}
-                      {u.endDate ? ` → ${u.endDate}` : ' (indefinida)'}
-                    </p>
-                    {u.reason && <p className="text-xs text-muted-foreground">{u.reason}</p>}
-                  </div>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="h-7 text-xs text-destructive"
-                    onClick={() => deleteUnavailMutation.mutate(u.id)}
-                    disabled={deleteUnavailMutation.isPending}
-                  >
-                    Eliminar
-                  </Button>
+        }
+      >
+        {loadingUnavail ? (
+          <div className="space-y-2">
+            {[1, 2].map(i => (
+              <Skeleton key={i} className="h-11 w-full rounded-xl" />
+            ))}
+          </div>
+        ) : myUnavailability.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No tenés indisponibilidades registradas.
+          </p>
+        ) : (
+          <div className="music-stagger space-y-1.5">
+            {myUnavailability.map(u => (
+              <div key={u.id} className="music-row flex items-center justify-between px-3 py-2.5">
+                <div className="min-w-0">
+                  <p className="music-num text-sm">
+                    {u.startDate}
+                    {u.endDate ? ` → ${u.endDate}` : ' (indefinida)'}
+                  </p>
+                  {u.reason && <p className="text-xs text-muted-foreground">{u.reason}</p>}
                 </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs text-destructive"
+                  onClick={() => deleteUnavailMutation.mutate(u.id)}
+                  disabled={deleteUnavailMutation.isPending}
+                >
+                  Eliminar
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </Panel>
 
       <Dialog open={unavailOpen} onOpenChange={setUnavailOpen}>
         <DialogContent className="music-shell">
           <DialogHeader>
-            <DialogTitle>Registrar indisponibilidad</DialogTitle>
+            <DialogTitle className="music-heading text-2xl">
+              Registrar indisponibilidad
+            </DialogTitle>
           </DialogHeader>
           <form onSubmit={handleUnavailSubmit} className="space-y-4">
             <div className="space-y-1">
@@ -1022,30 +1049,33 @@ function ServidorView({ embedExtras = true }: { embedExtras?: boolean }) {
 }
 
 // ─────────────────────────────────────────────
-// SERVIDOR mobile — app-like internal navigation (sticky segmented control)
+// SERVIDOR mobile — segmented control con indicador que se desliza
 // ─────────────────────────────────────────────
+const SERVIDOR_TABS = [
+  { key: 'inicio' as const, label: 'Inicio', Icon: Home },
+  { key: 'cultos' as const, label: 'Mis cultos', Icon: CalendarDays },
+  { key: 'repertorio' as const, label: 'Repertorio', Icon: ListMusic },
+];
+
 function ServidorMobile() {
   const [screen, setScreen] = useState<'inicio' | 'cultos' | 'repertorio'>('inicio');
-  const tabs = [
-    { key: 'inicio' as const, label: 'Inicio', Icon: Home },
-    { key: 'cultos' as const, label: 'Mis cultos', Icon: CalendarDays },
-    { key: 'repertorio' as const, label: 'Repertorio', Icon: ListMusic },
-  ];
+  const activeIndex = SERVIDOR_TABS.findIndex(t => t.key === screen);
+
   return (
     <div className="space-y-4">
-      <div className="sticky top-14 z-30 -mx-4 bg-background/80 px-4 py-2 backdrop-blur">
-        <div className="grid grid-cols-3 gap-1 rounded-2xl bg-muted/40 p-1">
-          {tabs.map(({ key, label, Icon }) => (
+      <div className="music-navbar sticky top-14 z-30 -mx-4 px-4 py-2">
+        <div
+          className="music-seg"
+          style={{ '--music-seg-index': String(activeIndex) } as React.CSSProperties}
+        >
+          <span className="music-seg-thumb" aria-hidden />
+          {SERVIDOR_TABS.map(({ key, label, Icon }) => (
             <button
               key={key}
               type="button"
               onClick={() => setScreen(key)}
-              className={cn(
-                'flex flex-col items-center gap-1 rounded-xl py-2 text-xs font-medium transition-colors',
-                screen === key
-                  ? 'bg-primary text-primary-foreground shadow'
-                  : 'text-muted-foreground active:bg-muted'
-              )}
+              data-active={screen === key}
+              className="music-seg-item"
             >
               <Icon className="h-4 w-4" />
               {label}
@@ -1067,7 +1097,7 @@ function ServidorMobile() {
 }
 
 // ─────────────────────────────────────────────
-// DIRECTOR mobile — app-like nav (sticky scrollable pills + dedicated screens)
+// DIRECTOR mobile — píldoras scrolleables + pantallas dedicadas
 // ─────────────────────────────────────────────
 function DirectorMobile({ onOpenEvent }: { onOpenEvent: (e: MusicEvent) => void }) {
   const [screen, setScreen] = useState<
@@ -1088,19 +1118,15 @@ function DirectorMobile({ onOpenEvent }: { onOpenEvent: (e: MusicEvent) => void 
 
   return (
     <div className="space-y-4">
-      <div className="sticky top-14 z-30 -mx-4 bg-background/80 px-4 py-2 backdrop-blur">
+      <div className="music-navbar sticky top-14 z-30 -mx-4 px-4 py-2">
         <div className="flex gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {tabs.map(({ key, label, Icon }) => (
             <button
               key={key}
               type="button"
               onClick={() => setScreen(key)}
-              className={cn(
-                'flex shrink-0 items-center gap-1.5 rounded-full px-4 py-2 text-sm font-medium transition-colors',
-                screen === key
-                  ? 'bg-primary text-primary-foreground shadow'
-                  : 'bg-muted/40 text-muted-foreground active:bg-muted'
-              )}
+              data-active={screen === key}
+              className="music-pill"
             >
               <Icon className="h-4 w-4" />
               {label}
@@ -1129,19 +1155,21 @@ function DirectorMobile({ onOpenEvent }: { onOpenEvent: (e: MusicEvent) => void 
 // ─────────────────────────────────────────────
 function NoMusicAccess() {
   return (
-    <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-border p-10 text-center">
-      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
-        <Music2 className="h-7 w-7 text-muted-foreground" />
-      </div>
-      <div>
-        <p className="font-semibold">No sos parte del equipo de música</p>
-        <p className="mx-auto max-w-xs text-sm text-muted-foreground">
-          Pedile al director que te agregue como integrante para ver tus cultos y asignaciones.
-        </p>
-      </div>
-    </div>
+    <MusicEmpty
+      icon={<Music2 className="h-6 w-6" />}
+      title="No sos parte del equipo de música"
+      hint="Pedile al director que te agregue como integrante para ver tus cultos y asignaciones."
+    />
   );
 }
+
+const DIRECTOR_TABS = [
+  { value: 'cronograma', label: 'Cronograma' },
+  { value: 'cultos', label: 'Cultos' },
+  { value: 'integrantes', label: 'Integrantes' },
+  { value: 'instrumentos', label: 'Instrumentos' },
+  { value: 'canciones', label: 'Canciones' },
+];
 
 export default function MusicPage() {
   const isMobileApp = useMobileMode();
@@ -1152,7 +1180,7 @@ export default function MusicPage() {
   const openEvent = (e: MusicEvent) => navigate(`/dashboard/music/eventos/${e.id}`);
 
   const servidorBody = loadingAccess ? (
-    <Skeleton className="h-44 w-full rounded-2xl" />
+    <Skeleton className="h-48 w-full rounded-3xl" />
   ) : !hasAccess ? (
     <NoMusicAccess />
   ) : (
@@ -1168,26 +1196,26 @@ export default function MusicPage() {
     <>
       <DirectorMusicHero onOpenEvent={openEvent} />
       <Tabs defaultValue="cronograma">
-        <TabsList className="w-full sm:w-auto flex overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          <TabsTrigger value="cronograma">Cronograma</TabsTrigger>
-          <TabsTrigger value="cultos">Cultos</TabsTrigger>
-          <TabsTrigger value="integrantes">Integrantes</TabsTrigger>
-          <TabsTrigger value="instrumentos">Instrumentos</TabsTrigger>
-          <TabsTrigger value="canciones">Canciones</TabsTrigger>
+        <TabsList className="music-tabs w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {DIRECTOR_TABS.map(t => (
+            <TabsTrigger key={t.value} value={t.value} className="music-tab">
+              {t.label}
+            </TabsTrigger>
+          ))}
         </TabsList>
-        <TabsContent value="cronograma" className="mt-4">
+        <TabsContent value="cronograma" className="music-rise mt-5">
           <CronogramaTab isDirector={isDirector} onOpenEvent={openEvent} />
         </TabsContent>
-        <TabsContent value="cultos" className="mt-4">
+        <TabsContent value="cultos" className="music-rise mt-5">
           <CultosTab isDirector={isDirector} onOpenEvent={openEvent} />
         </TabsContent>
-        <TabsContent value="integrantes" className="mt-4">
+        <TabsContent value="integrantes" className="music-rise mt-5">
           <MusicMembers isDirector={isDirector} />
         </TabsContent>
-        <TabsContent value="instrumentos" className="mt-4">
+        <TabsContent value="instrumentos" className="music-rise mt-5">
           <MusicInstruments isDirector={isDirector} />
         </TabsContent>
-        <TabsContent value="canciones" className="mt-4">
+        <TabsContent value="canciones" className="music-rise mt-5">
           <CancionesTab />
         </TabsContent>
       </Tabs>
@@ -1204,11 +1232,11 @@ export default function MusicPage() {
     return (
       <>
         <MobileScreen title="Música" subtitle={isDirector ? 'Equipo de alabanza' : 'Mis cultos'}>
-          <div className="music-shell music-aurora min-h-screen px-4 py-4 space-y-5">
+          <div className="music-shell music-aurora min-h-screen space-y-5 px-4 py-4">
             {isDirector ? (
               <DirectorMobile onOpenEvent={openEvent} />
             ) : loadingAccess ? (
-              <Skeleton className="h-44 w-full rounded-2xl" />
+              <Skeleton className="h-48 w-full rounded-3xl" />
             ) : !hasAccess ? (
               <NoMusicAccess />
             ) : (
@@ -1221,13 +1249,17 @@ export default function MusicPage() {
   }
 
   return (
-    <div className="music-shell music-aurora space-y-5 animate-fade-in p-3 sm:p-4 md:p-6 rounded-2xl">
-      <div>
-        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Música</h1>
-        <p className="text-sm text-muted-foreground">
-          {isDirector ? 'Gestión del equipo de alabanza' : 'Equipo de alabanza'}
-        </p>
-      </div>
+    <div className="music-shell music-aurora space-y-6 rounded-2xl p-3 sm:p-5 md:p-8">
+      <header className="music-rise">
+        <p className="music-eyebrow">Ministerio de alabanza</p>
+        <div className="mt-2 flex flex-wrap items-baseline justify-between gap-x-6 gap-y-1">
+          <h1 className="music-heading text-[2.5rem] leading-none sm:text-[3.25rem]">Música</h1>
+          <p className="text-sm text-muted-foreground">
+            {isDirector ? 'Gestión del equipo de alabanza' : 'Equipo de alabanza'}
+          </p>
+        </div>
+        <hr className="music-rule mt-4" />
+      </header>
       {body}
     </div>
   );

--- a/src/pages/dashboard/discipleship/AuxiliarySupervisorDashboard.tsx
+++ b/src/pages/dashboard/discipleship/AuxiliarySupervisorDashboard.tsx
@@ -26,7 +26,7 @@ import { useAuxiliarySupervisorData } from '@/hooks/useAuxiliarySupervisorData';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { DiscipleshipReport } from '@/types/discipleship.types';
 import { format } from 'date-fns';
-import { justEndedWeek } from '@/lib/iso-week';
+import { justEndedWeek, parseDateOnly } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
 import {
   CheckCircle,
@@ -107,7 +107,7 @@ const AuxiliarySupervisorDashboard: React.FC = React.memo(() => {
 
   // Validar si ya existe reporte para este período
   const hasCurrentPeriodReport = myReports.some((report: { period_start: string }) => {
-    const reportStart = new Date(report.period_start);
+    const reportStart = parseDateOnly(report.period_start);
     return reportStart >= periodStart && reportStart <= periodEnd;
   });
 
@@ -292,7 +292,7 @@ const AuxiliarySupervisorDashboard: React.FC = React.memo(() => {
                   >
                     <div>
                       <p className="font-medium">
-                        Semana del {format(new Date(report.period_start), 'dd MMM', { locale: es })}
+                        Semana del {format(parseDateOnly(report.period_start), 'dd MMM', { locale: es })}
                       </p>
                       <p className="text-sm text-muted-foreground">
                         Atención Nvos: {reportData?.new_disciples_care || 0} • VD:{' '}

--- a/src/pages/dashboard/discipleship/CoordinatorDashboard.tsx
+++ b/src/pages/dashboard/discipleship/CoordinatorDashboard.tsx
@@ -17,7 +17,7 @@ import { useCoordinatorData } from '@/hooks/useCoordinatorData';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { DiscipleshipReport } from '@/types/discipleship.types';
 import { format } from 'date-fns';
-import { justEndedWeek } from '@/lib/iso-week';
+import { justEndedWeek, parseDateOnly } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
 import { Award, Building2, CheckCircle, Clock, FileText, Loader2, Plus, Users } from 'lucide-react';
 import { CHART_COLORS } from '@/lib/chart-colors';
@@ -107,7 +107,7 @@ const CoordinatorDashboard: React.FC = React.memo(() => {
 
   // Validar si ya existe reporte para este período
   const hasCurrentPeriodReport = myReports.some((report: { period_start: string }) => {
-    const reportStart = new Date(report.period_start);
+    const reportStart = parseDateOnly(report.period_start);
     return reportStart >= periodStart && reportStart <= periodEnd;
   });
 
@@ -267,7 +267,7 @@ const CoordinatorDashboard: React.FC = React.memo(() => {
                     <div>
                       <p className="font-medium">
                         Semana del{' '}
-                        {format(new Date(report.period_start), 'dd MMM', { locale: es })}
+                        {format(parseDateOnly(report.period_start), 'dd MMM', { locale: es })}
                       </p>
                       <p className="text-sm text-muted-foreground">
                         Atención Nvos: {reportData?.new_disciples_care || 0} • VD:{' '}

--- a/src/pages/dashboard/discipleship/GeneralSupervisorDashboard.tsx
+++ b/src/pages/dashboard/discipleship/GeneralSupervisorDashboard.tsx
@@ -19,7 +19,7 @@ import { useGeneralSupervisorData } from '@/hooks/useGeneralSupervisorData';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { DiscipleshipReport } from '@/types/discipleship.types';
 import { format } from 'date-fns';
-import { justEndedWeek } from '@/lib/iso-week';
+import { justEndedWeek, parseDateOnly } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
 import {
   Building,
@@ -125,7 +125,7 @@ const GeneralSupervisorDashboard: React.FC = React.memo(() => {
 
   // Validar si ya existe reporte para este período
   const hasCurrentPeriodReport = myReports.some((report: { period_start: string }) => {
-    const reportStart = new Date(report.period_start);
+    const reportStart = parseDateOnly(report.period_start);
     return reportStart >= periodStart && reportStart <= periodEnd;
   });
 
@@ -358,7 +358,7 @@ const GeneralSupervisorDashboard: React.FC = React.memo(() => {
                   >
                     <div>
                       <p className="font-medium">
-                        Semana del {format(new Date(report.period_start), 'dd MMM', { locale: es })}
+                        Semana del {format(parseDateOnly(report.period_start), 'dd MMM', { locale: es })}
                       </p>
                       <p className="text-sm text-muted-foreground">
                         Atención Nvos: {reportData?.new_disciples_care || 0} • VD:{' '}

--- a/src/pages/dashboard/discipleship/LeaderDashboard.tsx
+++ b/src/pages/dashboard/discipleship/LeaderDashboard.tsx
@@ -12,7 +12,7 @@ import { useLeaderDiscipleshipData } from '@/hooks/useLeaderDiscipleshipData';
 import { DiscipleshipService } from '@/services/discipleship.service';
 import type { AttendanceWithDetails, GroupMemberWithDetails } from '@/types/discipleship.types';
 import { addDays, format, startOfISOWeek } from 'date-fns';
-import { getIsoWeek, justEndedWeek } from '@/lib/iso-week';
+import { getIsoWeek, justEndedWeek, parseDateOnly } from '@/lib/iso-week';
 import { es } from 'date-fns/locale';
 import {
   AlertTriangle,
@@ -136,7 +136,7 @@ export default function LeaderDashboard() {
 
   // Check if report for this week already exists
   const hasCurrentWeekReport = myReports.some((report: { period_start: string }) => {
-    const reportStart = new Date(report.period_start);
+    const reportStart = parseDateOnly(report.period_start);
     return reportStart >= lastWeekStart && reportStart <= currentWeekEnd;
   });
 
@@ -186,7 +186,7 @@ export default function LeaderDashboard() {
 
   // Semanas que ya tienen reporte (para el aviso de duplicado en el picker)
   const existingWeeks = myReports.map((r: { period_start: string }) =>
-    getIsoWeek(new Date(r.period_start))
+    getIsoWeek(parseDateOnly(r.period_start))
   );
   const selectedWeekReported = existingWeeks.includes(selectedWeek.isoWeek);
 
@@ -390,8 +390,8 @@ export default function LeaderDashboard() {
             >
               <div>
                 <p className="font-medium">
-                  Semana {format(new Date(report.period_start), 'dd MMM', { locale: es })} -{' '}
-                  {format(new Date(report.period_end), 'dd MMM', { locale: es })}
+                  Semana {format(parseDateOnly(report.period_start), 'dd MMM', { locale: es })} -{' '}
+                  {format(parseDateOnly(report.period_end), 'dd MMM', { locale: es })}
                 </p>
                 <p className="text-sm text-muted-foreground">
                   Asistencia: {reportData?.attendance || 0} • Conversiones:{' '}

--- a/src/pages/dashboard/discipleship/MinistryHealthTab.tsx
+++ b/src/pages/dashboard/discipleship/MinistryHealthTab.tsx
@@ -132,17 +132,19 @@ function getAttendanceConfig(pct: number): HealthConfig {
   };
 }
 
+// Umbrales alineados con getHealthConfig (misma escala /10 en ambos casos desde
+// que el backend unificó el reescalado de "salud espiritual" por grupo).
 function getGroupTempDot(temp: number): string {
-  if (temp >= 10) return 'bg-emerald-500';
-  if (temp >= 7) return 'bg-green-500';
-  if (temp >= 4) return 'bg-amber-500';
+  if (temp >= 7.5) return 'bg-emerald-500';
+  if (temp >= 5) return 'bg-green-500';
+  if (temp >= 2.5) return 'bg-amber-500';
   return 'bg-red-500';
 }
 
 function getGroupTempLabel(temp: number): string {
-  if (temp >= 10) return 'Excelente';
-  if (temp >= 7) return 'Bueno';
-  if (temp >= 4) return 'Regular';
+  if (temp >= 7.5) return 'Excelente';
+  if (temp >= 5) return 'Bueno';
+  if (temp >= 2.5) return 'Regular';
   return 'Bajo';
 }
 
@@ -225,7 +227,7 @@ function GroupRow({ group }: { group: GroupPerformance }) {
   const temp = group.spiritualTemp || 0;
   const dot = getGroupTempDot(temp);
   const label = getGroupTempLabel(temp);
-  const tempPct = Math.min(100, (temp / 13) * 100);
+  const tempPct = Math.min(100, (temp / 10) * 100);
 
   const daysSinceReport = group.lastReportDate
     ? Math.floor((Date.now() - new Date(group.lastReportDate).getTime()) / 86_400_000)
@@ -258,7 +260,7 @@ function GroupRow({ group }: { group: GroupPerformance }) {
             />
           </div>
           <span className="text-xs text-muted-foreground">
-            {temp.toFixed(1)}/13 · {label}
+            {temp.toFixed(1)}/10 · {label}
           </span>
         </div>
       </div>

--- a/src/pages/dashboard/discipleship/PastoralDashboard.tsx
+++ b/src/pages/dashboard/discipleship/PastoralDashboard.tsx
@@ -22,7 +22,9 @@ import {
   Clock,
   Crown,
   Loader2,
+  Network,
   PartyPopper,
+  TrendingDown,
   TrendingUp,
   Users,
   Zap,
@@ -49,6 +51,8 @@ interface DashboardStats {
   multiplications: number;
   average_attendance: number;
   spiritual_health: number;
+  growth_rate: number;
+  auxiliary_supervisors: number;
   pending_alerts: number;
   pending_reports: number;
 }
@@ -206,7 +210,7 @@ const PastoralDashboard: React.FC = React.memo(() => {
             />
             <Area
               type="monotone"
-              dataKey="miembros"
+              dataKey="asistencia"
               stroke="#3b82f6"
               strokeWidth={2}
               fill="url(#pgradAttendance)"
@@ -216,13 +220,13 @@ const PastoralDashboard: React.FC = React.memo(() => {
             />
             <Area
               type="monotone"
-              dataKey="grupos"
+              dataKey="reportando"
               stroke={CHART_COLORS.success}
               strokeWidth={2}
               fill="url(#pgradGroups)"
               dot={false}
               activeDot={{ r: 4, fill: CHART_COLORS.success, strokeWidth: 0 }}
-              name="Grupos Activos"
+              name="Reportaron esa semana"
             />
             <Area
               type="monotone"
@@ -500,6 +504,11 @@ const PastoralDashboard: React.FC = React.memo(() => {
           <MobileStatTile label="Miembros" value={stats.total_members || 0} />
           <MobileStatTile label="Multiplicaciones" value={stats.multiplications || 0} />
           <MobileStatTile label="Salud" value={`${(stats.spiritual_health || 0).toFixed(1)}/10`} />
+          <MobileStatTile
+            label="Crecimiento"
+            value={`${(stats.growth_rate || 0) > 0 ? '+' : ''}${(stats.growth_rate || 0).toFixed(1)}%`}
+          />
+          <MobileStatTile label="Sup. Aux" value={stats.auxiliary_supervisors || 0} />
         </div>
 
         {/* ── Sub-tabs ── */}
@@ -621,6 +630,41 @@ const PastoralDashboard: React.FC = React.memo(() => {
               {(stats.spiritual_health || 0).toFixed(1)}/10
             </div>
             <p className="text-xs text-muted-foreground truncate">Promedio general</p>
+          </CardContent>
+        </Card>
+
+        <Card
+          className={
+            (stats.growth_rate || 0) >= 0
+              ? 'border-emerald-200 bg-emerald-50/60 dark:border-emerald-900 dark:bg-emerald-950/20'
+              : 'border-red-200 bg-red-50/60 dark:border-red-900 dark:bg-red-950/20'
+          }
+        >
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 px-3 pt-3 sm:px-4 sm:pt-4 md:px-6 md:pt-6">
+            <CardTitle className="text-xs sm:text-sm font-medium">Crecimiento</CardTitle>
+            {(stats.growth_rate || 0) >= 0 ? (
+              <TrendingUp className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
+            ) : (
+              <TrendingDown className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
+            )}
+          </CardHeader>
+          <CardContent className="px-3 pb-3 sm:px-4 sm:pb-4 md:px-6 md:pb-6">
+            <div className="text-xl sm:text-2xl font-bold">
+              {(stats.growth_rate || 0) > 0 ? '+' : ''}
+              {(stats.growth_rate || 0).toFixed(1)}%
+            </div>
+            <p className="text-xs text-muted-foreground truncate">Miembros vs. hace 30 días</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border-cyan-200 bg-cyan-50/60 dark:border-cyan-900 dark:bg-cyan-950/20">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 px-3 pt-3 sm:px-4 sm:pt-4 md:px-6 md:pt-6">
+            <CardTitle className="text-xs sm:text-sm font-medium">Sup. Auxiliares</CardTitle>
+            <Network className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
+          </CardHeader>
+          <CardContent className="px-3 pb-3 sm:px-4 sm:pb-4 md:px-6 md:pb-6">
+            <div className="text-xl sm:text-2xl font-bold">{stats.auxiliary_supervisors || 0}</div>
+            <p className="text-xs text-muted-foreground truncate">En todo el ministerio</p>
           </CardContent>
         </Card>
       </div>

--- a/src/pages/dashboard/music/ChannelAudios.tsx
+++ b/src/pages/dashboard/music/ChannelAudios.tsx
@@ -48,14 +48,14 @@ export function ChannelAudios() {
   if (!configured) return null;
 
   return (
-    <div className="rounded-2xl border border-border bg-card p-4 sm:p-5">
-      <div className="mb-3 flex items-center gap-2">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/15 text-accent">
+    <div className="music-panel p-4 sm:p-5">
+      <div className="mb-4 flex items-center gap-3">
+        <span className="music-glyph music-glyph-spot">
           <Radio className="h-4 w-4" />
-        </div>
-        <div>
-          <p className="text-sm font-semibold leading-tight">Audios del canal</p>
-          <p className="text-xs text-muted-foreground">Descargá las pistas de Telegram</p>
+        </span>
+        <div className="min-w-0">
+          <p className="music-eyebrow">Descargá las pistas de Telegram</p>
+          <p className="music-heading mt-1 text-lg leading-none">Audios del canal</p>
         </div>
       </div>
 
@@ -80,12 +80,9 @@ export function ChannelAudios() {
           {search ? 'Sin resultados.' : 'Todavía no hay audios en el canal.'}
         </p>
       ) : (
-        <div className="space-y-1.5">
+        <div className="music-stagger space-y-1.5">
           {files.map(f => (
-            <div
-              key={f.id}
-              className="flex items-center gap-3 rounded-xl border border-border/60 bg-background/40 px-3 py-2"
-            >
+            <div key={f.id} className="music-row flex items-center gap-3 px-3 py-2.5">
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium">{f.title || f.fileName || 'Audio'}</p>
                 <p className="truncate text-xs text-muted-foreground">

--- a/src/pages/dashboard/music/EventDetail.tsx
+++ b/src/pages/dashboard/music/EventDetail.tsx
@@ -38,7 +38,7 @@ import type { User } from '@/types/user.types';
 import { ConfirmationProgress } from './MusicHero';
 import { UserSearchPicker } from './UserSearchPicker';
 import { InstrumentChip, resolveCategory } from './instrument-visual';
-import { EVENT_TYPE_LABEL } from './event-visual';
+import { EVENT_TYPE_LABEL, EVENT_TYPE_TONE, toneStyle } from './event-visual';
 
 const FUNCION_LABELS: Record<Funcion, string> = {
   corista: 'Coristas',
@@ -54,10 +54,10 @@ const FUNCION_SINGULAR: Record<Funcion, string> = {
   danzarina: 'Danzarina',
 };
 
-const STATE_VARIANT: Record<AssignmentState, 'default' | 'secondary' | 'destructive'> = {
-  asignado: 'secondary',
-  confirmado: 'default',
-  no_puedo: 'destructive',
+const STATE_TAG: Record<AssignmentState, string> = {
+  asignado: 'music-tag',
+  confirmado: 'music-tag music-tag-ok',
+  no_puedo: 'music-tag music-tag-warn',
 };
 
 const STATE_LABEL: Record<AssignmentState, string> = {
@@ -174,12 +174,17 @@ export function TeamSection({ event, isDirector }: { event: MusicEvent; isDirect
   }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold flex items-center gap-1.5">
-          <Users className="h-4 w-4 text-muted-foreground" />
-          Equipo
-        </h3>
+    <div className="music-panel space-y-3 p-4 sm:p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span className="music-glyph">
+            <Users className="h-4 w-4" />
+          </span>
+          <div>
+            <p className="music-eyebrow">Quién sirve</p>
+            <h3 className="music-heading mt-1 text-xl leading-none">Equipo</h3>
+          </div>
+        </div>
         {isDirector && (
           <Button
             size="sm"
@@ -266,10 +271,13 @@ export function TeamSection({ event, isDirector }: { event: MusicEvent; isDirect
           .filter(f => byFuncion[f]?.length)
           .map(f => (
             <div key={f}>
-              <p className="text-xs font-medium text-muted-foreground mb-1">{FUNCION_LABELS[f]}</p>
-              <div className="rounded-lg border border-border divide-y divide-border">
+              <div className="mb-2 flex items-center gap-2">
+                <span className="music-eyebrow">{FUNCION_LABELS[f]}</span>
+                <span className="h-px flex-1 bg-border" />
+              </div>
+              <div className="music-stagger space-y-1.5">
                 {byFuncion[f].map(a => (
-                  <div key={a.id} className="px-3 py-2">
+                  <div key={a.id} className="music-row px-3 py-2.5">
                     <div className="flex items-center justify-between gap-2">
                       <div className="min-w-0">
                         <p className="text-sm truncate">{a.memberName || a.memberId}</p>
@@ -283,9 +291,7 @@ export function TeamSection({ event, isDirector }: { event: MusicEvent; isDirect
                         )}
                       </div>
                       <div className="flex items-center gap-1.5 shrink-0">
-                        <Badge variant={STATE_VARIANT[a.state]} className="text-xs">
-                          {STATE_LABEL[a.state]}
-                        </Badge>
+                        <span className={STATE_TAG[a.state]}>{STATE_LABEL[a.state]}</span>
                         {isDirector && a.state === 'no_puedo' && (
                           <Button
                             size="sm"
@@ -408,12 +414,17 @@ export function SetlistSection({ event, isDirector }: { event: MusicEvent; isDir
   }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold flex items-center gap-1.5">
-          <Music2 className="h-4 w-4 text-muted-foreground" />
-          Repertorio
-        </h3>
+    <div className="music-panel space-y-3 p-4 sm:p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span className="music-glyph">
+            <Music2 className="h-4 w-4" />
+          </span>
+          <div>
+            <p className="music-eyebrow">Qué vamos a tocar</p>
+            <h3 className="music-heading mt-1 text-xl leading-none">Repertorio</h3>
+          </div>
+        </div>
         {isDirector && (
           <Button
             size="sm"
@@ -505,18 +516,16 @@ export function SetlistSection({ event, isDirector }: { event: MusicEvent; isDir
           Sin canciones en el repertorio.
         </p>
       ) : (
-        <div className="rounded-lg border border-border divide-y divide-border">
+        <div className="music-stagger space-y-1.5">
           {songs.map((s, i) => (
-            <div key={s.id} className="px-3 py-2 flex items-start justify-between gap-2">
+            <div key={s.id} className="music-row flex items-start justify-between gap-2 px-3 py-2.5">
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
-                  <span className="text-xs text-muted-foreground w-4 shrink-0">{i + 1}.</span>
+                  <span className="music-num w-5 shrink-0 text-xs text-muted-foreground">
+                    {String(i + 1).padStart(2, '0')}
+                  </span>
                   <p className="text-sm font-medium truncate">{s.songName}</p>
-                  {s.tono && (
-                    <Badge variant="outline" className="text-xs shrink-0">
-                      {s.tono}
-                    </Badge>
-                  )}
+                  {s.tono && <span className="music-key shrink-0">{s.tono}</span>}
                   {s.link && (
                     <a
                       href={s.link}
@@ -529,7 +538,7 @@ export function SetlistSection({ event, isDirector }: { event: MusicEvent; isDir
                     </a>
                   )}
                 </div>
-                {s.notes && <p className="text-xs text-muted-foreground ml-6 mt-0.5">{s.notes}</p>}
+                {s.notes && <p className="text-xs text-muted-foreground ml-7 mt-0.5">{s.notes}</p>}
               </div>
               {isDirector && (
                 <ConfirmDialog
@@ -623,6 +632,8 @@ export function EventDetailHeader({
     queryFn: () => MusicService.getEventSongs(event.id),
   });
 
+  const tone = EVENT_TYPE_TONE[event.eventType] ?? EVENT_TYPE_TONE.domingo;
+
   async function handleShareSetlist() {
     const lines: string[] = [];
     lines.push(`🎵 *Culto ${formatDateForShare(event.eventDate)}*`);
@@ -669,20 +680,18 @@ export function EventDetailHeader({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="music-stage space-y-4 p-5 pl-6 sm:p-7 sm:pl-8" style={toneStyle(tone)}>
+      <span className="music-spine" />
       <div>
-        <h1 className="text-2xl sm:text-3xl font-bold capitalize leading-tight tracking-tight">
+        <p className="music-eyebrow">Detalle del culto</p>
+        <h1 className="music-heading mt-2 text-[1.85rem] leading-[1.05] first-letter:uppercase sm:text-[2.6rem]">
           {formatEventDate(event.eventDate)}
         </h1>
-        <div className="flex items-center gap-2 pt-2 flex-wrap">
-          <Badge variant="outline" className="text-xs">
+        <div className="flex flex-wrap items-center gap-2 pt-3">
+          <span className="music-tag music-tag-tone">
             {EVENT_TYPE_LABEL[event.eventType] ?? event.eventType}
-          </Badge>
-          {event.published && (
-            <Badge variant="secondary" className="text-xs">
-              Publicado
-            </Badge>
-          )}
+          </span>
+          {event.published && <span className="music-tag music-tag-ok">Publicado</span>}
         </div>
       </div>
 
@@ -726,9 +735,9 @@ export function EventDetailHeader({
         )}
       </div>
 
-      <div className="rounded-xl border border-border bg-muted/30 p-4">
-        <ConfirmationProgress assignments={assignments} />
-      </div>
+      <hr className="music-rule" />
+
+      <ConfirmationProgress assignments={assignments} />
 
       {isDirector && (
         <div className="flex flex-wrap gap-2">

--- a/src/pages/dashboard/music/MusicEventDetailPage.tsx
+++ b/src/pages/dashboard/music/MusicEventDetailPage.tsx
@@ -13,13 +13,10 @@ import './music-theme.css';
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="space-y-3">
-        <Skeleton className="h-8 w-64" />
-        <Skeleton className="h-16 w-full rounded-xl" />
-      </div>
+      <Skeleton className="h-52 w-full rounded-3xl" />
       <div className="grid gap-6 lg:grid-cols-2">
-        <Skeleton className="h-64 w-full rounded-xl" />
-        <Skeleton className="h-64 w-full rounded-xl" />
+        <Skeleton className="h-64 w-full rounded-2xl" />
+        <Skeleton className="h-64 w-full rounded-2xl" />
       </div>
     </div>
   );
@@ -84,13 +81,13 @@ export default function MusicEventDetailPage() {
   }
 
   return (
-    <div className="music-shell music-aurora space-y-6 animate-fade-in p-3 sm:p-4 md:p-6 rounded-2xl">
+    <div className="music-shell music-aurora space-y-6 rounded-2xl p-3 sm:p-5 md:p-8">
       <button
         type="button"
         onClick={() => navigate('/dashboard/music')}
-        className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        className="music-press music-eyebrow inline-flex items-center gap-1.5 transition-colors hover:text-foreground"
       >
-        <ChevronLeft className="h-4 w-4" />
+        <ChevronLeft className="h-3.5 w-3.5" />
         Volver a Música
       </button>
       {body}

--- a/src/pages/dashboard/music/MusicFab.tsx
+++ b/src/pages/dashboard/music/MusicFab.tsx
@@ -23,12 +23,16 @@ export function MusicFab({
       type="button"
       onClick={onClick}
       className={cn(
-        'fixed bottom-24 right-4 z-30 flex items-center gap-2 rounded-full bg-primary px-4 py-3 text-primary-foreground shadow-lg shadow-primary/30 transition-[transform,opacity] duration-150 hover:opacity-90 active:scale-95 sm:right-6',
+        // Latón sobre tinta: el FAB es el único bloque sólido de dorado en
+        // pantalla, así que la acción principal se encuentra sin buscarla.
+        'music-press fixed bottom-24 right-4 z-30 flex items-center gap-2 rounded-full bg-primary px-4 py-3 text-primary-foreground',
+        'shadow-[0_10px_30px_-10px_hsl(var(--music-brass)/0.9)] ring-1 ring-inset ring-white/25',
+        'transition-[transform,box-shadow,filter] duration-150 hover:brightness-105 sm:right-6',
         className
       )}
     >
       <Icon className="h-4 w-4" />
-      <span className="text-sm font-semibold">{label}</span>
+      <span className="text-[0.7rem] font-bold uppercase tracking-[0.14em]">{label}</span>
     </button>
   );
 }

--- a/src/pages/dashboard/music/MusicHero.tsx
+++ b/src/pages/dashboard/music/MusicHero.tsx
@@ -10,13 +10,12 @@ import {
   Users,
   XCircle,
 } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { MusicService } from '@/services/music.service';
 import type { MusicAssignment, MusicEvent } from '@/types/music.types';
-import { EVENT_TYPE_GRADIENT, EVENT_TYPE_LABEL } from './event-visual';
+import { EVENT_TYPE_LABEL, EVENT_TYPE_TONE, toneStyle } from './event-visual';
 
 function daysUntil(iso: string): number {
   const target = new Date(`${iso}T00:00:00`);
@@ -46,7 +45,7 @@ function todayISO(): string {
 }
 
 // ─────────────────────────────────────────────
-// Confirmation progress bar
+// Confirmation progress — leyenda + medidor
 // ─────────────────────────────────────────────
 export function ConfirmationProgress({
   assignments,
@@ -64,34 +63,42 @@ export function ConfirmationProgress({
 
   if (total === 0) {
     return (
-      <p className={cn('text-xs text-muted-foreground', className)}>Sin equipo asignado todavía.</p>
+      <p className={cn('music-eyebrow', className)}>Sin equipo asignado todavía</p>
     );
   }
 
   return (
     <div className={className}>
-      <div className="flex items-center justify-between text-xs mb-1.5">
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+      <div className="mb-2 flex items-end justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1.5 text-emerald-700 dark:text-emerald-300">
             <CheckCircle2 className="h-3.5 w-3.5" />
-            <strong className="text-foreground">{confirmed}</strong> confirmados
+            <strong className="music-num text-sm font-semibold text-foreground">{confirmed}</strong>
+            <span className="music-eyebrow">confirmados</span>
           </span>
-          <span className="flex items-center gap-1">
+          <span className="flex items-center gap-1.5">
             <Clock className="h-3.5 w-3.5" />
-            <strong className="text-foreground">{pending}</strong> pendientes
+            <strong className="music-num text-sm font-semibold text-foreground">{pending}</strong>
+            <span className="music-eyebrow">pendientes</span>
           </span>
           {declined > 0 && (
-            <span className="flex items-center gap-1 text-destructive">
+            <span className="flex items-center gap-1.5 text-destructive">
               <XCircle className="h-3.5 w-3.5" />
-              <strong>{declined}</strong>
+              <strong className="music-num text-sm font-semibold">{declined}</strong>
             </span>
           )}
         </div>
-        <span className="font-semibold tabular-nums">{confirmedPct}%</span>
+        <span className="music-num text-lg font-semibold leading-none">{confirmedPct}%</span>
       </div>
-      <div className="h-2 w-full rounded-full bg-muted overflow-hidden flex">
-        <div className="h-full bg-emerald-500" style={{ width: `${confirmedPct}%` }} />
-        <div className="h-full bg-destructive" style={{ width: `${declinedPct}%` }} />
+      <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-white/[0.07] shadow-[inset_0_1px_1px_rgba(0,0,0,0.5)]">
+        <div
+          className="music-meter-fill h-full rounded-full bg-emerald-400"
+          style={{ width: `${confirmedPct}%` }}
+        />
+        <div
+          className="music-meter-fill h-full bg-destructive/80"
+          style={{ width: `${declinedPct}%` }}
+        />
       </div>
     </div>
   );
@@ -109,10 +116,10 @@ function TeamAvatars({ assignments, max = 5 }: { assignments: MusicAssignment[];
         <div
           key={a.id}
           className={cn(
-            'w-8 h-8 rounded-full ring-2 ring-background flex items-center justify-center text-[10px] font-semibold',
-            a.state === 'confirmado' && 'bg-emerald-500 text-white',
-            a.state === 'asignado' && 'bg-muted text-foreground',
-            a.state === 'no_puedo' && 'bg-destructive text-white opacity-70'
+            'music-num flex h-8 w-8 items-center justify-center rounded-full text-[10px] font-semibold ring-2 ring-[hsl(236_32%_9%)]',
+            a.state === 'confirmado' && 'bg-emerald-400 text-emerald-950',
+            a.state === 'asignado' && 'bg-white/10 text-foreground',
+            a.state === 'no_puedo' && 'bg-destructive/80 text-white opacity-70'
           )}
           title={`${a.memberName ?? ''} — ${a.funcion} (${a.state})`}
         >
@@ -120,7 +127,7 @@ function TeamAvatars({ assignments, max = 5 }: { assignments: MusicAssignment[];
         </div>
       ))}
       {overflow > 0 && (
-        <div className="w-8 h-8 rounded-full ring-2 ring-background bg-muted-foreground/20 flex items-center justify-center text-[10px] font-semibold">
+        <div className="music-num flex h-8 w-8 items-center justify-center rounded-full bg-white/[0.08] text-[10px] font-semibold ring-2 ring-[hsl(236_32%_9%)]">
           +{overflow}
         </div>
       )}
@@ -129,9 +136,9 @@ function TeamAvatars({ assignments, max = 5 }: { assignments: MusicAssignment[];
 }
 
 // ─────────────────────────────────────────────
-// Stat tile
+// Stat tile — lectura de consola, no tarjetita
 // ─────────────────────────────────────────────
-function StatTile({
+export function StatTile({
   label,
   value,
   icon,
@@ -142,25 +149,32 @@ function StatTile({
   icon: React.ReactNode;
   tone?: 'default' | 'primary' | 'warning' | 'success';
 }) {
-  const tones = {
-    default: 'bg-card',
-    primary: 'bg-primary/10 border-primary/30',
-    warning: 'bg-amber-500/10 border-amber-500/30',
-    success: 'bg-emerald-500/10 border-emerald-500/30',
+  const accents = {
+    default: 'text-muted-foreground',
+    primary: 'text-amber-700 dark:text-amber-300',
+    warning: 'text-orange-700 dark:text-orange-300',
+    success: 'text-emerald-700 dark:text-emerald-300',
+  };
+  const rules = {
+    default: 'bg-border',
+    primary: 'bg-amber-400/70',
+    warning: 'bg-orange-400/70',
+    success: 'bg-emerald-400/70',
   };
   return (
-    <div className={cn('rounded-xl border border-border p-3 sm:p-4', tones[tone])}>
-      <div className="flex items-center gap-2 mb-1 text-muted-foreground">
-        {icon}
-        <span className="text-xs font-medium">{label}</span>
+    <div className="music-panel relative overflow-hidden p-3 sm:p-4">
+      <span className={cn('absolute inset-x-0 top-0 h-px', rules[tone])} />
+      <div className="mb-2 flex items-center gap-1.5">
+        <span className={accents[tone]}>{icon}</span>
+        <span className="music-eyebrow">{label}</span>
       </div>
-      <p className="text-xl sm:text-2xl font-bold tabular-nums">{value}</p>
+      <p className="music-num text-2xl font-semibold leading-none sm:text-3xl">{value}</p>
     </div>
   );
 }
 
 // ─────────────────────────────────────────────
-// Next culto hero — uses real data for the director
+// Próximo culto — "marquesina"
 // ─────────────────────────────────────────────
 function NextCultoHeroCard({
   event,
@@ -179,82 +193,93 @@ function NextCultoHeroCard({
   });
 
   const dCount = daysUntil(event.eventDate);
-  const dLabel =
-    dCount === 0
-      ? 'Hoy'
-      : dCount === 1
-        ? 'Mañana'
-        : dCount > 1
-          ? `En ${dCount} días`
-          : `Hace ${Math.abs(dCount)} días`;
+  const dLabel = dCount === 1 ? 'día' : dCount > 1 ? 'días' : 'pasado';
+  const tone = EVENT_TYPE_TONE[event.eventType];
 
   return (
-    <div
-      className={cn(
-        'relative overflow-hidden rounded-2xl text-white shadow-lg',
-        'bg-gradient-to-br',
-        EVENT_TYPE_GRADIENT[event.eventType]
-      )}
-    >
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(255,255,255,0.18),transparent_60%)]" />
-      <div className="relative p-5 sm:p-6 space-y-4">
-        <div className="flex items-start justify-between gap-3">
+    <div className="music-stage music-rise" style={toneStyle(tone)}>
+      <span className="music-spine" />
+      <div className="relative space-y-5 p-5 pl-6 sm:p-7 sm:pl-8">
+        <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
-            <p className="text-xs uppercase tracking-wider opacity-80">Próximo culto</p>
-            <h2 className="text-2xl sm:text-3xl font-bold capitalize leading-tight mt-1">
+            <p className="music-eyebrow">Próximo culto</p>
+            <h2 className="music-heading mt-2 text-[1.85rem] leading-[1.05] first-letter:uppercase sm:text-[2.6rem]">
               {formatLongDate(event.eventDate)}
             </h2>
-            <div className="flex items-center gap-2 mt-2 flex-wrap">
-              <Badge className="bg-white/20 hover:bg-white/30 text-white border-0 backdrop-blur">
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <span className="music-tag music-tag-tone">
                 {EVENT_TYPE_LABEL[event.eventType]}
-              </Badge>
-              {event.title && <span className="text-sm opacity-90 truncate">{event.title}</span>}
-              {event.published && (
-                <Badge className="bg-emerald-400/30 text-white border-0 backdrop-blur">
-                  Publicado
-                </Badge>
+              </span>
+              {event.published && <span className="music-tag music-tag-ok">Publicado</span>}
+              {event.title && (
+                <span className="truncate text-sm text-muted-foreground">{event.title}</span>
               )}
             </div>
           </div>
-          <div className="text-right shrink-0">
-            <div className="text-3xl sm:text-4xl font-extrabold tabular-nums leading-none">
-              {dCount >= 0 ? dCount : '—'}
-            </div>
-            <p className="text-xs opacity-80 mt-1">{dLabel}</p>
+          <div className="shrink-0 text-right">
+            {dCount === 0 ? (
+              <span className="music-heading text-3xl leading-none text-[hsl(var(--music-tone))] sm:text-4xl">
+                Hoy
+              </span>
+            ) : (
+              <span className="music-num block text-[2.75rem] font-semibold leading-none text-[hsl(var(--music-tone))] sm:text-[3.5rem]">
+                {dCount > 0 ? dCount : Math.abs(dCount)}
+              </span>
+            )}
+            {dCount !== 0 && <p className="music-eyebrow mt-2">{dLabel}</p>}
           </div>
         </div>
 
-        <div className="bg-white/15 backdrop-blur rounded-xl p-3 sm:p-4 space-y-3">
-          <ConfirmationProgress
-            assignments={assignments}
-            className="text-white [&_*]:!text-white"
-          />
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <TeamAvatars assignments={assignments} />
-              <div className="text-xs">
-                <p className="opacity-80">Equipo</p>
-                <p className="font-semibold">
-                  {assignments.length} servidor{assignments.length === 1 ? '' : 'es'}
-                </p>
-              </div>
+        <hr className="music-rule" />
+
+        <ConfirmationProgress assignments={assignments} />
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <TeamAvatars assignments={assignments} />
+            <div>
+              <p className="music-eyebrow">Equipo</p>
+              <p className="music-num mt-1 text-sm font-semibold">
+                {assignments.length} servidor{assignments.length === 1 ? '' : 'es'}
+              </p>
             </div>
-            <div className="flex items-center gap-2 text-sm">
-              <Music2 className="h-4 w-4 opacity-80" />
-              <span className="font-semibold tabular-nums">{songs.length}</span>
-              <span className="opacity-80">canciones</span>
-            </div>
+          </div>
+          <div className="text-right">
+            <p className="music-eyebrow">Repertorio</p>
+            <p className="music-num mt-1 flex items-center justify-end gap-1.5 text-sm font-semibold">
+              <Music2 className="h-3.5 w-3.5 text-muted-foreground" />
+              {songs.length}
+            </p>
           </div>
         </div>
 
-        <Button
-          variant="secondary"
-          className="w-full bg-white text-slate-900 hover:bg-white/90 gap-2"
-          onClick={() => onOpen(event)}
-        >
+        <Button className="w-full gap-2" onClick={() => onOpen(event)}>
           Abrir detalle del culto
           <ArrowRight className="h-4 w-4" />
         </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Empty state compartido
+// ─────────────────────────────────────────────
+export function MusicEmpty({
+  icon,
+  title,
+  hint,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  hint?: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-border p-8 text-center">
+      <div className="music-glyph music-glyph-lg">{icon}</div>
+      <div className="space-y-1">
+        <p className="music-heading text-lg">{title}</p>
+        {hint && <p className="mx-auto max-w-xs text-sm text-muted-foreground">{hint}</p>}
       </div>
     </div>
   );
@@ -296,10 +321,10 @@ export function DirectorMusicHero({ onOpenEvent }: { onOpenEvent: (e: MusicEvent
   if (isLoading) {
     return (
       <div className="space-y-4">
-        <Skeleton className="h-48 w-full rounded-2xl" />
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Skeleton className="h-56 w-full rounded-3xl" />
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {[1, 2, 3, 4].map(i => (
-            <Skeleton key={i} className="h-20 rounded-xl" />
+            <Skeleton key={i} className="h-20 rounded-2xl" />
           ))}
         </div>
       </div>
@@ -311,27 +336,21 @@ export function DirectorMusicHero({ onOpenEvent }: { onOpenEvent: (e: MusicEvent
       {nextEvent ? (
         <NextCultoHeroCard event={nextEvent} onOpen={onOpenEvent} />
       ) : (
-        <div className="rounded-2xl border-2 border-dashed border-border p-8 text-center space-y-3">
-          <div className="w-12 h-12 mx-auto rounded-full bg-muted flex items-center justify-center">
-            <CalendarDays className="h-6 w-6 text-muted-foreground" />
-          </div>
-          <div>
-            <p className="font-semibold">No hay cultos próximos</p>
-            <p className="text-sm text-muted-foreground">
-              Generá el trimestre desde la pestaña Cultos para empezar.
-            </p>
-          </div>
-        </div>
+        <MusicEmpty
+          icon={<CalendarDays className="h-6 w-6" />}
+          title="No hay cultos próximos"
+          hint="Generá el trimestre desde la pestaña Cultos para empezar."
+        />
       )}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="music-stagger grid grid-cols-2 gap-3 sm:grid-cols-4">
         <StatTile
-          label="Integrantes activos"
+          label="Integrantes"
           value={activeMembers}
           icon={<Users className="h-3.5 w-3.5" />}
           tone="primary"
         />
         <StatTile
-          label="Cultos este mes"
+          label="Cultos del mes"
           value={cultosThisMonth}
           icon={<CalendarDays className="h-3.5 w-3.5" />}
         />
@@ -341,7 +360,7 @@ export function DirectorMusicHero({ onOpenEvent }: { onOpenEvent: (e: MusicEvent
           icon={<Music2 className="h-3.5 w-3.5" />}
         />
         <StatTile
-          label="Próximos cultos"
+          label="Próximos"
           value={upcoming.length}
           icon={<TrendingUp className="h-3.5 w-3.5" />}
           tone={upcoming.length === 0 ? 'warning' : 'success'}

--- a/src/pages/dashboard/music/MusicInstruments.tsx
+++ b/src/pages/dashboard/music/MusicInstruments.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Plus, Trash2 } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -93,22 +92,20 @@ export default function MusicInstruments({ isDirector }: { isDirector: boolean }
   }
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-        <div>
-          <CardTitle className="text-base">Instrumentos</CardTitle>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            El set de tu iglesia — voces, instrumentos y roles técnicos.
-          </p>
+    <section className="music-panel p-4 sm:p-5">
+      <header className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="music-eyebrow">Voces, instrumentos y roles técnicos</p>
+          <h2 className="music-heading mt-1.5 text-xl leading-none sm:text-2xl">Instrumentos</h2>
         </div>
         {isDirector && (
-          <Button size="sm" onClick={() => setAddOpen(true)} className="gap-1">
+          <Button size="sm" onClick={() => setAddOpen(true)} className="gap-1 shrink-0">
             <Plus className="h-4 w-4" />
             Agregar
           </Button>
         )}
-      </CardHeader>
-      <CardContent className="space-y-4">
+      </header>
+      <div className="space-y-5">
         {isLoading ? (
           <div className="space-y-2">
             {[1, 2, 3].map(i => (
@@ -125,18 +122,19 @@ export default function MusicInstruments({ isDirector }: { isDirector: boolean }
             const { Icon } = meta;
             return (
               <div key={cat}>
-                <div
-                  className={cn('mb-2 flex items-center gap-1.5 text-xs font-semibold', meta.text)}
-                >
+                <div className={cn('mb-2.5 flex items-center gap-2', meta.text)}>
                   <Icon className="h-3.5 w-3.5" />
-                  {meta.label}
+                  <span className="text-[0.625rem] font-bold uppercase leading-none tracking-[0.2em]">
+                    {meta.label}
+                  </span>
+                  <span className="h-px flex-1 bg-border" />
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {grouped.get(cat)!.map(ins => (
                     <div
                       key={ins.id}
                       className={cn(
-                        'flex items-center gap-2 rounded-full border border-border px-3 py-1.5',
+                        'music-row music-row-pill flex items-center gap-2 px-3 py-1.5',
                         !ins.isActive && 'opacity-50'
                       )}
                     >
@@ -178,12 +176,12 @@ export default function MusicInstruments({ isDirector }: { isDirector: boolean }
             );
           })
         )}
-      </CardContent>
+      </div>
 
       <Dialog open={addOpen} onOpenChange={setAddOpen}>
         <DialogContent className="music-shell">
           <DialogHeader>
-            <DialogTitle>Nuevo instrumento</DialogTitle>
+            <DialogTitle className="music-heading text-2xl">Nuevo instrumento</DialogTitle>
           </DialogHeader>
           <form onSubmit={handleAdd} className="space-y-4">
             <div className="space-y-1">
@@ -224,6 +222,6 @@ export default function MusicInstruments({ isDirector }: { isDirector: boolean }
           </form>
         </DialogContent>
       </Dialog>
-    </Card>
+    </section>
   );
 }

--- a/src/pages/dashboard/music/MusicMembers.tsx
+++ b/src/pages/dashboard/music/MusicMembers.tsx
@@ -6,9 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
@@ -318,19 +316,22 @@ export default function MusicMembers({ isDirector }: MusicMembersProps) {
   });
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-        <CardTitle className="text-base">Integrantes</CardTitle>
+    <section className="music-panel p-4 sm:p-5">
+      <header className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="music-eyebrow">Quiénes sirven</p>
+          <h2 className="music-heading mt-1.5 text-xl leading-none sm:text-2xl">Integrantes</h2>
+        </div>
         {isDirector && (
-          <Button size="sm" onClick={openCreate} className="gap-1">
+          <Button size="sm" onClick={openCreate} className="gap-1 shrink-0">
             <Plus className="h-4 w-4" />
             Agregar
           </Button>
         )}
-      </CardHeader>
-      <CardContent className="space-y-3">
+      </header>
+      <div className="space-y-3">
         <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
           <Input
             value={filter}
             onChange={e => setFilter(e.target.value)}
@@ -341,33 +342,27 @@ export default function MusicMembers({ isDirector }: MusicMembersProps) {
         {isLoading ? (
           <div className="space-y-2">
             {[1, 2, 3].map(i => (
-              <Skeleton key={i} className="h-12 w-full" />
+              <Skeleton key={i} className="h-14 w-full rounded-xl" />
             ))}
           </div>
         ) : filtered.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-6">
+          <p className="py-8 text-center text-sm text-muted-foreground">
             {members.length === 0 ? 'No hay integrantes registrados.' : 'Sin coincidencias.'}
           </p>
         ) : (
-          <div className="divide-y divide-border rounded-md border border-border">
+          <div className="music-stagger space-y-1.5">
             {filtered.map(m => (
-              <div key={m.id} className="flex items-center justify-between px-3 py-3">
+              <div key={m.id} className="music-row flex items-center justify-between px-3 py-3">
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
-                    <p className="font-medium text-sm truncate">{m.name ?? m.userId}</p>
+                    <p className="truncate text-sm font-semibold">{m.name ?? m.userId}</p>
                     {m.isDirector && (
-                      <Badge className="text-xs bg-primary/15 text-primary border-0 shrink-0">
-                        Director
-                      </Badge>
+                      <span className="music-tag music-tag-tone shrink-0">Director</span>
                     )}
-                    {!m.active && (
-                      <Badge variant="outline" className="text-xs shrink-0">
-                        Inactivo
-                      </Badge>
-                    )}
+                    {!m.active && <span className="music-tag shrink-0">Inactivo</span>}
                   </div>
-                  {m.email && <p className="text-xs text-muted-foreground truncate">{m.email}</p>}
-                  <div className="flex flex-wrap gap-1.5 mt-1.5">
+                  {m.email && <p className="truncate text-xs text-muted-foreground">{m.email}</p>}
+                  <div className="mt-1.5 flex flex-wrap gap-1.5">
                     {m.funciones.map(f => (
                       <FuncionChip key={f} funcion={f} />
                     ))}
@@ -380,7 +375,7 @@ export default function MusicMembers({ isDirector }: MusicMembersProps) {
                   </div>
                 </div>
                 {isDirector && (
-                  <div className="flex gap-1 shrink-0 ml-2">
+                  <div className="ml-2 flex shrink-0 gap-1">
                     <Button
                       size="icon"
                       variant="ghost"
@@ -412,12 +407,14 @@ export default function MusicMembers({ isDirector }: MusicMembersProps) {
             ))}
           </div>
         )}
-      </CardContent>
+      </div>
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="music-shell">
           <DialogHeader>
-            <DialogTitle>{editing ? 'Editar integrante' : 'Nuevo integrante'}</DialogTitle>
+            <DialogTitle className="music-heading text-2xl">
+              {editing ? 'Editar integrante' : 'Nuevo integrante'}
+            </DialogTitle>
           </DialogHeader>
           <MemberForm
             initial={editing ?? undefined}
@@ -432,6 +429,6 @@ export default function MusicMembers({ isDirector }: MusicMembersProps) {
           />
         </DialogContent>
       </Dialog>
-    </Card>
+    </section>
   );
 }

--- a/src/pages/dashboard/music/RepertoireList.tsx
+++ b/src/pages/dashboard/music/RepertoireList.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react';
 
-import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
@@ -20,8 +19,8 @@ function relativeLastPlayed(date: string | null): string {
 /**
  * Ranked repertoire list (search + rows), shared by the director's Canciones
  * tab and the servidor's read-only repertoire. One implementation = one set of
- * medal colors, no drift. The module renders on the dark music-shell, so the
- * medals use the lighter shades that read well on it.
+ * medal colors, no drift. Each medal color has a light/dark pair so it reads
+ * well against the music-shell's theme-aware canvas either way.
  */
 export function RepertoireList({
   stats,
@@ -76,30 +75,30 @@ export function RepertoireList({
             : 'Sin coincidencias.'}
         </p>
       ) : (
-        <div className="space-y-1.5">
+        <div className="music-stagger space-y-1.5">
           {filtered.map((s, i) => {
             const pct = maxPlays > 0 ? Math.round((s.timesPlayed / maxPlays) * 100) : 0;
             return (
-              <div
-                key={s.id}
-                className="relative overflow-hidden rounded-xl border border-border/60 bg-background/40"
-              >
+              <div key={s.id} className="music-row relative overflow-hidden">
+                {/* Medidor de frecuencia al pie de la fila: el ranking se lee sin
+                    mirar el número. Va abajo y no como fondo completo — un lavado
+                    a todo lo alto se confunde con el estado hover de la fila. */}
                 <div
-                  className="absolute inset-y-0 left-0 bg-primary/10"
+                  className="music-meter-fill absolute bottom-0 left-0 h-[2px] rounded-full bg-primary/70"
                   style={{ width: `${pct}%` }}
                 />
                 <div className="relative flex items-center justify-between gap-2 px-3 py-2.5">
                   <div className="flex min-w-0 items-center gap-3">
                     <span
                       className={cn(
-                        'w-5 shrink-0 text-center text-xs font-bold tabular-nums',
-                        i === 0 && 'text-amber-400',
-                        i === 1 && 'text-zinc-300',
-                        i === 2 && 'text-orange-400',
+                        'music-num w-6 shrink-0 text-center text-xs font-semibold',
+                        i === 0 && 'text-amber-700 dark:text-amber-300',
+                        i === 1 && 'text-zinc-500 dark:text-zinc-400',
+                        i === 2 && 'text-orange-700 dark:text-orange-300',
                         i > 2 && 'text-muted-foreground'
                       )}
                     >
-                      {i + 1}
+                      {String(i + 1).padStart(2, '0')}
                     </span>
                     <div className="min-w-0">
                       <p className="truncate text-sm font-medium">{s.name}</p>
@@ -109,17 +108,15 @@ export function RepertoireList({
                     </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
-                    {s.historicalKey && (
-                      <Badge variant="outline" className="text-xs">
-                        {s.historicalKey}
-                      </Badge>
-                    )}
-                    <Badge
-                      variant={s.timesPlayed === 0 ? 'outline' : 'secondary'}
-                      className="text-xs tabular-nums"
+                    {s.historicalKey && <span className="music-key">{s.historicalKey}</span>}
+                    <span
+                      className={cn(
+                        'music-num text-sm font-semibold',
+                        s.timesPlayed === 0 ? 'text-muted-foreground' : 'text-foreground'
+                      )}
                     >
                       {s.timesPlayed}×
-                    </Badge>
+                    </span>
                   </div>
                 </div>
               </div>

--- a/src/pages/dashboard/music/ServidorHero.tsx
+++ b/src/pages/dashboard/music/ServidorHero.tsx
@@ -10,13 +10,13 @@ import {
   ThumbsUp,
   Sparkles,
 } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { MusicService } from '@/services/music.service';
 import type { MusicAssignment, AssignmentState, MusicEventType } from '@/types/music.types';
-import { EVENT_TYPE_GRADIENT, EVENT_TYPE_LABEL } from './event-visual';
+import { EVENT_TYPE_LABEL, EVENT_TYPE_TONE, toneStyle } from './event-visual';
+import { MusicEmpty, StatTile } from './MusicHero';
 
 const STATE_LABEL: Record<AssignmentState, string> = {
   asignado: 'Pendiente de confirmar',
@@ -54,45 +54,38 @@ function NextCultoSongs({ eventId }: { eventId: string }) {
   if (isLoading) return <Skeleton className="h-24 w-full rounded-2xl" />;
 
   return (
-    <div className="rounded-2xl border border-border bg-card p-4 sm:p-5">
-      <div className="flex items-center gap-2 mb-3">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 text-primary">
+    <div className="music-panel p-4 sm:p-5">
+      <div className="mb-4 flex items-center gap-3">
+        <span className="music-glyph">
           <Music2 className="h-4 w-4" />
+        </span>
+        <div className="min-w-0">
+          <p className="music-eyebrow">Canciones del culto</p>
+          <p className="music-heading mt-1 text-lg leading-none">Lo que vamos a tocar</p>
         </div>
-        <div>
-          <p className="text-sm font-semibold leading-tight">Canciones del culto</p>
-          <p className="text-xs text-muted-foreground">Lo que vamos a tocar</p>
-        </div>
-        <Badge variant="secondary" className="ml-auto tabular-nums">
+        <span className="music-num ml-auto text-2xl font-semibold leading-none">
           {songs.length}
-        </Badge>
+        </span>
       </div>
       {songs.length === 0 ? (
         <p className="py-4 text-center text-sm text-muted-foreground">
           El director todavía no cargó el repertorio.
         </p>
       ) : (
-        <ol className="space-y-1.5">
+        <ol className="music-stagger space-y-1.5">
           {songs.map((s, i) => (
-            <li
-              key={s.id}
-              className="flex items-center gap-3 rounded-xl border border-border/60 bg-background/40 px-3 py-2"
-            >
-              <span className="w-5 shrink-0 text-center text-xs font-bold tabular-nums text-muted-foreground">
-                {i + 1}
+            <li key={s.id} className="music-row flex items-center gap-3 px-3 py-2.5">
+              <span className="music-num w-5 shrink-0 text-center text-xs font-semibold text-muted-foreground">
+                {String(i + 1).padStart(2, '0')}
               </span>
               <span className="min-w-0 flex-1 truncate text-sm font-medium">{s.songName}</span>
-              {s.tono && (
-                <Badge variant="outline" className="shrink-0 text-xs">
-                  {s.tono}
-                </Badge>
-              )}
+              {s.tono && <span className="music-key shrink-0">{s.tono}</span>}
               {s.link && (
                 <a
                   href={s.link}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="shrink-0 text-primary hover:opacity-70"
+                  className="shrink-0 text-primary transition-opacity hover:opacity-70"
                   aria-label={`Abrir ${s.songName}`}
                 >
                   <ExternalLink className="h-4 w-4" />
@@ -139,10 +132,10 @@ export function ServidorMusicHero() {
   if (isLoading) {
     return (
       <div className="space-y-4">
-        <Skeleton className="h-44 w-full rounded-2xl" />
+        <Skeleton className="h-48 w-full rounded-3xl" />
         <div className="grid grid-cols-3 gap-3">
           {[1, 2, 3].map(i => (
-            <Skeleton key={i} className="h-20 rounded-xl" />
+            <Skeleton key={i} className="h-20 rounded-2xl" />
           ))}
         </div>
       </div>
@@ -151,77 +144,68 @@ export function ServidorMusicHero() {
 
   if (!next) {
     return (
-      <div className="rounded-2xl border-2 border-dashed border-border p-6 text-center space-y-2">
-        <div className="w-12 h-12 mx-auto rounded-full bg-muted flex items-center justify-center">
-          <Sparkles className="h-6 w-6 text-muted-foreground" />
-        </div>
-        <div>
-          <p className="font-semibold">No tenés cultos próximos asignados</p>
-          <p className="text-sm text-muted-foreground">
-            Cuando te asignen, vas a recibir la notificación acá.
-          </p>
-        </div>
-      </div>
+      <MusicEmpty
+        icon={<Sparkles className="h-6 w-6" />}
+        title="No tenés cultos próximos asignados"
+        hint="Cuando te asignen, vas a recibir la notificación acá."
+      />
     );
   }
 
   const dCount = daysUntil(next.eventDate ?? '');
-  const dLabel =
-    dCount === 0
-      ? 'Hoy'
-      : dCount === 1
-        ? 'Mañana'
-        : dCount > 1
-          ? `En ${dCount} días`
-          : `Hace ${Math.abs(dCount)} días`;
-
+  const dLabel = dCount === 1 ? 'día' : dCount > 1 ? 'días' : 'pasado';
   const type = (next.eventType ?? 'domingo') as MusicEventType;
+  const tone = EVENT_TYPE_TONE[type] ?? EVENT_TYPE_TONE.domingo;
+  const isConfirmed = next.state === 'confirmado';
 
   return (
     <div className="space-y-4">
-      <div
-        className={cn(
-          'relative overflow-hidden rounded-2xl text-white shadow-lg',
-          'bg-gradient-to-br',
-          EVENT_TYPE_GRADIENT[type]
-        )}
-      >
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(255,255,255,0.18),transparent_60%)]" />
-        <div className="relative p-5 sm:p-6 space-y-4">
-          <div className="flex items-start justify-between gap-3">
+      <div className="music-stage music-rise" style={toneStyle(tone)}>
+        <span className="music-spine" />
+        <div className="relative space-y-5 p-5 pl-6 sm:p-7 sm:pl-8">
+          <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
-              <p className="text-xs uppercase tracking-wider opacity-80">Mi próximo culto</p>
-              <h2 className="text-2xl sm:text-3xl font-bold capitalize leading-tight mt-1">
+              <p className="music-eyebrow">Mi próximo culto</p>
+              <h2 className="music-heading mt-2 text-[1.85rem] leading-[1.05] first-letter:uppercase sm:text-[2.6rem]">
                 {formatLongDate(next.eventDate ?? '')}
               </h2>
-              <div className="flex items-center gap-2 mt-2 flex-wrap">
-                <Badge className="bg-white/20 hover:bg-white/30 text-white border-0 backdrop-blur">
-                  {EVENT_TYPE_LABEL[type] ?? type}
-                </Badge>
-                <Badge className="bg-white/20 hover:bg-white/30 text-white border-0 backdrop-blur capitalize">
-                  {next.funcion}
-                </Badge>
-                {next.instrument && (
-                  <Badge className="bg-white/20 hover:bg-white/30 text-white border-0 backdrop-blur">
-                    {next.instrument}
-                  </Badge>
-                )}
-                <span className="text-xs opacity-90">· {STATE_LABEL[next.state]}</span>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <span className="music-tag music-tag-tone">{EVENT_TYPE_LABEL[type] ?? type}</span>
+                <span className="music-tag">{next.funcion}</span>
+                {next.instrument && <span className="music-tag">{next.instrument}</span>}
               </div>
             </div>
-            <div className="text-right shrink-0">
-              <div className="text-3xl sm:text-4xl font-extrabold tabular-nums leading-none">
-                {dCount >= 0 ? dCount : '—'}
-              </div>
-              <p className="text-xs opacity-80 mt-1">{dLabel}</p>
+            <div className="shrink-0 text-right">
+              {dCount === 0 ? (
+                <span className="music-heading text-3xl leading-none text-[hsl(var(--music-tone))] sm:text-4xl">
+                  Hoy
+                </span>
+              ) : (
+                <span className="music-num block text-[2.75rem] font-semibold leading-none text-[hsl(var(--music-tone))] sm:text-[3.5rem]">
+                  {dCount > 0 ? dCount : Math.abs(dCount)}
+                </span>
+              )}
+              {dCount !== 0 && <p className="music-eyebrow mt-2">{dLabel}</p>}
             </div>
           </div>
 
-          <div className="flex flex-col sm:flex-row gap-2 pt-1">
-            {next.state !== 'confirmado' && (
+          <hr className="music-rule" />
+
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                'h-1.5 w-1.5 rounded-full',
+                isConfirmed ? 'bg-emerald-400' : 'bg-amber-400 animate-pulse-dot'
+              )}
+            />
+            <span className="music-eyebrow">{STATE_LABEL[next.state]}</span>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            {!isConfirmed && (
               <Button
                 size="lg"
-                className="flex-1 bg-white text-emerald-700 hover:bg-white/90 gap-2 font-semibold"
+                className="flex-1 gap-2 font-semibold"
                 onClick={() => updateMutation.mutate({ id: next.id, state: 'confirmado' })}
                 disabled={updateMutation.isPending}
               >
@@ -232,7 +216,7 @@ export function ServidorMusicHero() {
             <Button
               size="lg"
               variant="outline"
-              className="flex-1 bg-transparent text-white border-white/40 hover:bg-white/10 gap-2"
+              className="flex-1 gap-2 border-white/15 bg-transparent hover:bg-white/5"
               onClick={() => updateMutation.mutate({ id: next.id, state: 'no_puedo' })}
               disabled={updateMutation.isPending}
             >
@@ -245,33 +229,24 @@ export function ServidorMusicHero() {
 
       <NextCultoSongs eventId={next.eventId} />
 
-      <div className="grid grid-cols-3 gap-3">
-        <div className="rounded-xl border border-border p-3 sm:p-4">
-          <div className="flex items-center gap-2 mb-1 text-muted-foreground">
-            <CalendarDays className="h-3.5 w-3.5" />
-            <span className="text-xs font-medium">Próximos</span>
-          </div>
-          <p className="text-xl sm:text-2xl font-bold tabular-nums">{upcoming.length}</p>
-        </div>
-        <div
-          className={cn(
-            'rounded-xl border p-3 sm:p-4',
-            pending > 0 ? 'bg-amber-500/10 border-amber-500/30' : 'border-border'
-          )}
-        >
-          <div className="flex items-center gap-2 mb-1 text-muted-foreground">
-            <Music2 className="h-3.5 w-3.5" />
-            <span className="text-xs font-medium">Pendientes</span>
-          </div>
-          <p className="text-xl sm:text-2xl font-bold tabular-nums">{pending}</p>
-        </div>
-        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 sm:p-4">
-          <div className="flex items-center gap-2 mb-1 text-muted-foreground">
-            <CheckCircle2 className="h-3.5 w-3.5" />
-            <span className="text-xs font-medium">Confirmados</span>
-          </div>
-          <p className="text-xl sm:text-2xl font-bold tabular-nums">{confirmed}</p>
-        </div>
+      <div className="music-stagger grid grid-cols-3 gap-3">
+        <StatTile
+          label="Próximos"
+          value={upcoming.length}
+          icon={<CalendarDays className="h-3.5 w-3.5" />}
+        />
+        <StatTile
+          label="Pendientes"
+          value={pending}
+          icon={<Music2 className="h-3.5 w-3.5" />}
+          tone={pending > 0 ? 'warning' : 'default'}
+        />
+        <StatTile
+          label="Confirmados"
+          value={confirmed}
+          icon={<CheckCircle2 className="h-3.5 w-3.5" />}
+          tone="success"
+        />
       </div>
     </div>
   );

--- a/src/pages/dashboard/music/ServidorRepertoire.tsx
+++ b/src/pages/dashboard/music/ServidorRepertoire.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { ListMusic } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { MusicService } from '@/services/music.service';
 import { RepertoireList } from './RepertoireList';
 
@@ -16,18 +15,18 @@ export function ServidorRepertoire() {
   });
 
   return (
-    <div className="rounded-2xl border border-border bg-card p-4 sm:p-5">
-      <div className="mb-3 flex items-center gap-2">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 text-primary">
+    <div className="music-panel p-4 sm:p-5">
+      <div className="mb-4 flex items-center gap-3">
+        <span className="music-glyph">
           <ListMusic className="h-4 w-4" />
+        </span>
+        <div className="min-w-0">
+          <p className="music-eyebrow">Las canciones que más tocamos</p>
+          <p className="music-heading mt-1 text-lg leading-none">Repertorio de la banda</p>
         </div>
-        <div>
-          <p className="text-sm font-semibold leading-tight">Repertorio de la banda</p>
-          <p className="text-xs text-muted-foreground">Las canciones que más tocamos</p>
-        </div>
-        <Badge variant="secondary" className="ml-auto tabular-nums">
+        <span className="music-num ml-auto text-2xl font-semibold leading-none">
           {stats.length}
-        </Badge>
+        </span>
       </div>
 
       <RepertoireList stats={stats} isLoading={isLoading} />

--- a/src/pages/dashboard/music/event-visual.ts
+++ b/src/pages/dashboard/music/event-visual.ts
@@ -1,3 +1,5 @@
+import type { CSSProperties } from 'react';
+
 import type { MusicEventType } from '@/types/music.types';
 
 // Single source of truth for how a culto type looks across the whole module.
@@ -9,16 +11,30 @@ export const EVENT_TYPE_LABEL: Record<MusicEventType, string> = {
   especial: 'Especial',
 };
 
-// Dot / solid fill (listas, calendario).
+// Dot / solid fill (listas, calendario). Alineado a la paleta "latón sobre
+// tinta": el domingo (el culto central) se lleva el dorado de la marca, el
+// viernes el periwinkle frío y el especial el rosa de función especial.
 export const EVENT_TYPE_COLOR: Record<MusicEventType, string> = {
-  viernes: 'bg-blue-500',
-  domingo: 'bg-emerald-500',
-  especial: 'bg-amber-500',
+  viernes: 'bg-indigo-400',
+  domingo: 'bg-amber-400',
+  especial: 'bg-rose-400',
 };
 
-// Hero background gradient por tipo de culto.
-export const EVENT_TYPE_GRADIENT: Record<MusicEventType, string> = {
-  viernes: 'from-blue-500 to-indigo-600',
-  domingo: 'from-emerald-500 to-teal-600',
-  especial: 'from-amber-500 to-orange-600',
+// Referencia a la variable de tono definida en music-theme.css (`.music-shell`
+// para lienzo claro, `.dark .music-shell` para oscuro), no un triplete HSL
+// fijo: así el color del culto sigue el toggle claro/oscuro del sistema en
+// vez de quedar calibrado para un solo modo.
+export const EVENT_TYPE_TONE: Record<MusicEventType, string> = {
+  viernes: 'var(--music-tone-viernes)',
+  domingo: 'var(--music-tone-domingo)',
+  especial: 'var(--music-tone-especial)',
 };
+
+/**
+ * Inyecta el tono del culto como CSS var. Lo leen `.music-stage`, `.music-spine`
+ * y `.music-tag-tone` en music-theme.css, así el color viaja por herencia y no
+ * hay que pasarlo por props a cada hijo.
+ */
+export function toneStyle(tone: string): CSSProperties {
+  return { '--music-tone': tone } as CSSProperties;
+}

--- a/src/pages/dashboard/music/instrument-visual.tsx
+++ b/src/pages/dashboard/music/instrument-visual.tsx
@@ -9,55 +9,68 @@ export const CATEGORY_META: Record<
   InstrumentCategory,
   { label: string; Icon: LucideIcon; chip: string; text: string }
 > = {
-  voz: { label: 'Voz', Icon: Mic, chip: 'bg-pink-500/15 text-pink-300', text: 'text-pink-300' },
+  voz: {
+    label: 'Voz',
+    Icon: Mic,
+    chip: 'bg-pink-500/15 text-pink-700 dark:text-pink-300',
+    text: 'text-pink-700 dark:text-pink-300',
+  },
   cuerdas: {
     label: 'Cuerdas',
     Icon: Guitar,
-    chip: 'bg-amber-500/15 text-amber-300',
-    text: 'text-amber-300',
+    chip: 'bg-amber-500/15 text-amber-700 dark:text-amber-300',
+    text: 'text-amber-700 dark:text-amber-300',
   },
   teclas: {
     label: 'Teclas',
     Icon: Piano,
-    chip: 'bg-violet-500/15 text-violet-300',
-    text: 'text-violet-300',
+    chip: 'bg-violet-500/15 text-violet-700 dark:text-violet-300',
+    text: 'text-violet-700 dark:text-violet-300',
   },
   percusion: {
     label: 'Percusión',
     Icon: Drum,
-    chip: 'bg-orange-500/15 text-orange-300',
-    text: 'text-orange-300',
+    chip: 'bg-orange-500/15 text-orange-700 dark:text-orange-300',
+    text: 'text-orange-700 dark:text-orange-300',
   },
   viento: {
     label: 'Viento',
     Icon: Wind,
-    chip: 'bg-cyan-500/15 text-cyan-300',
-    text: 'text-cyan-300',
+    chip: 'bg-cyan-500/15 text-cyan-700 dark:text-cyan-300',
+    text: 'text-cyan-700 dark:text-cyan-300',
   },
   tecnico: {
     label: 'Técnico',
     Icon: SlidersHorizontal,
-    chip: 'bg-emerald-500/15 text-emerald-300',
-    text: 'text-emerald-300',
+    chip: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+    text: 'text-emerald-700 dark:text-emerald-300',
   },
   otro: {
     label: 'Otro',
     Icon: Music2,
-    chip: 'bg-slate-500/15 text-slate-300',
-    text: 'text-slate-300',
+    chip: 'bg-slate-500/15 text-slate-700 dark:text-slate-300',
+    text: 'text-slate-700 dark:text-slate-300',
   },
 };
 
 // Broad role identity (independent of the specific instrument).
 export const FUNCION_META: Record<Funcion, { label: string; Icon: LucideIcon; chip: string }> = {
-  corista: { label: 'Corista', Icon: Mic, chip: 'bg-pink-500/15 text-pink-300' },
-  musico: { label: 'Músico', Icon: Guitar, chip: 'bg-amber-500/15 text-amber-300' },
+  corista: { label: 'Corista', Icon: Mic, chip: 'bg-pink-500/15 text-pink-700 dark:text-pink-300' },
+  musico: {
+    label: 'Músico',
+    Icon: Guitar,
+    chip: 'bg-amber-500/15 text-amber-700 dark:text-amber-300',
+  },
   tecnico: {
     label: 'Técnico',
     Icon: SlidersHorizontal,
-    chip: 'bg-emerald-500/15 text-emerald-300',
+    chip: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
   },
-  danzarina: { label: 'Danzarina', Icon: Sparkles, chip: 'bg-fuchsia-500/15 text-fuchsia-300' },
+  danzarina: {
+    label: 'Danzarina',
+    Icon: Sparkles,
+    chip: 'bg-fuchsia-500/15 text-fuchsia-700 dark:text-fuchsia-300',
+  },
 };
 
 /** Resolve a free-text instrument name to its catalog category (case-insensitive). */

--- a/src/pages/dashboard/music/music-theme.css
+++ b/src/pages/dashboard/music/music-theme.css
@@ -1,58 +1,502 @@
 /*
- * Autonomous theme for the Music module. Scoped under `.music-shell` so it
- * re-skins every shadcn component inside (they read these HSL vars) without
- * touching a single component. Always dark — independent of the app's theme.
- * ponytail: one file re-themes the whole module; per-component styling if a
- * specific surface ever needs to break out of this palette.
+ * ─────────────────────────────────────────────────────────────
+ *  MÚSICA — tema propio del módulo ("Dirección B")
+ * ─────────────────────────────────────────────────────────────
+ * Scoped bajo `.music-shell`, así re-skinea cada componente shadcn que viva
+ * adentro (todos leen estas vars HSL) sin tocar un solo componente.
  *
- * Paleta: "escenario oscuro" atado a la marca — azul JETRO (220) de base y
- * dorado de la iglesia (45) como accent. Mantiene el efecto stage-lighting
- * inmersivo pero se siente cálido y propio, no un theme neón genérico.
+ * Dirección de diseño: LIENZO CÁLIDO + ÁMBAR.
+ *   · El lienzo (background/foreground/card/border/muted/...) NO se redefine
+ *     acá: hereda los tokens reales del sistema (:root / .dark en index.css),
+ *     así Música sigue el toggle claro/oscuro del resto del ERP en vez de
+ *     tener su propia paleta fija. Lo único propio del módulo es el color de
+ *     acción — el mismo dorado de la iglesia (--sion-gold) — y los tonos de
+ *     tipo de culto, ambos con contraste ajustado por modo más abajo.
+ *   · Una sola voz tipográfica: la grotesca del sistema, en dos pesos
+ *     (heading semibold para títulos, texto normal para cuerpo) + mono
+ *     tabular para datos (tonos, conteos, porcentajes, horas).
+ *
+ * ponytail: un solo archivo re-tematiza todo el módulo; styling por componente
+ * solo si alguna superficie necesita salirse de esta paleta.
+ *
+ * OJO: Radix portalea SelectContent / DialogContent a document.body, fuera del
+ * scope. Todo Select/Dialog nuevo necesita className="music-shell" explícito o
+ * sale con el theme de la app.
  */
 
 .music-shell {
-  --background: 220 45% 8%;
-  --foreground: 220 20% 96%;
+  /* ── Ámbar: el color de acción del módulo ───────────────────────────
+   * Mismo dorado que --sion-gold / --accent del sistema (45 93% 50%) —
+   * ese token no cambia entre :root y .dark, así que el texto sobre dorado
+   * también se queda fijo en tinta oscura en los dos modos. */
+  --primary: 45 93% 50%;
+  --primary-foreground: 222 45% 12%;
 
-  --card: 220 40% 12%;
-  --card-foreground: 220 20% 96%;
+  /* ── Tokens propios del módulo ──────────────────────────── */
+  --music-brass: 45 93% 50%; /* = primary, para usarlo con alpha */
+  --music-brass-ink: 222 45% 12%; /* texto sobre superficies doradas, fijo en los 2 modos */
+  --music-spot: 222 60% 50%; /* azul frío: acento secundario (viernes, info) */
+  --music-ok: 152 55% 42%; /* confirmado */
+  --music-ink: 222 45% 14%; /* texto fuerte / sombras */
 
-  --popover: 220 42% 10%;
-  --popover-foreground: 220 20% 96%;
+  /* Tono de tipo de culto, con contraste calibrado para lienzo claro.
+   * Overrides más abajo en .dark .music-shell para lienzo oscuro. */
+  --music-tone-viernes: 222 60% 48%;
+  --music-tone-domingo: 42 78% 44%;
+  --music-tone-especial: 345 70% 46%;
 
-  --primary: 220 85% 60%;
-  --primary-foreground: 0 0% 100%;
+  --music-mono: ui-monospace, SFMono-Regular, 'SF Mono', 'JetBrains Mono', Menlo, Consolas,
+    monospace;
 
-  --secondary: 220 30% 18%;
-  --secondary-foreground: 220 20% 96%;
+  /* Las curvas nativas de CSS son flojas: no tienen el punch que hace que una
+   * animación se sienta intencional. */
+  --music-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --music-ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
 
-  --muted: 220 28% 16%;
-  --muted-foreground: 220 14% 70%;
+  --music-hairline: inset 0 1px 0 hsl(0 0% 100% / 0.7);
+  --music-lift: 0 1px 2px hsl(30 20% 60% / 0.12), 0 20px 45px -25px hsl(30 30% 30% / 0.35);
 
-  --accent: 45 93% 55%;
-  --accent-foreground: 220 45% 8%;
-
-  --destructive: 0 75% 58%;
-  --destructive-foreground: 0 0% 100%;
-
-  --border: 220 28% 24%;
-  --input: 220 28% 24%;
-  --ring: 220 85% 60%;
-
-  --radius: 1rem;
+  --music-glyph-ink: 35 70% 38%;
+  --music-surface-sunken: hsl(var(--muted) / 0.5);
 
   color: hsl(var(--foreground));
-  background-color: hsl(220 48% 6%);
+  background-color: hsl(var(--background));
 }
 
-/* Stage-lighting aurora behind the page content. Only on the page canvas, not
- * on the dialog (which reuses the vars but stays flat for readability).
- * Azul de marca + dos toques dorado/ámbar para el calor. */
+/* Lienzo oscuro: solo lo que de verdad necesita más luminosidad para leerse
+ * sobre tinta oscura. El dorado, el ink-sobre-dorado y el lienzo base ya
+ * vienen bien de :root/.dark — no se tocan acá. */
+.dark .music-shell {
+  --music-spot: 222 75% 68%;
+  --music-ok: 152 55% 55%;
+  --music-glyph-ink: 42 90% 68%;
+
+  --music-tone-viernes: 222 75% 70%;
+  --music-tone-domingo: 42 88% 62%;
+  --music-tone-especial: 345 80% 68%;
+
+  --music-hairline: inset 0 1px 0 hsl(0 0% 100% / 0.06);
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Lienzo: papel cálido, plano — sin grano ni luz de escenario.
+ * ───────────────────────────────────────────────────────────── */
 .music-aurora {
-  background-image:
-    radial-gradient(circle at 12% -5%, hsl(220 90% 45% / 0.28), transparent 42%),
-    radial-gradient(circle at 96% 6%, hsl(45 93% 52% / 0.16), transparent 38%),
-    radial-gradient(circle at 50% 118%, hsl(35 90% 50% / 0.14), transparent 46%);
-  background-attachment: local;
+  background-color: hsl(var(--background));
   min-height: 100%;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Tipografía
+ * ───────────────────────────────────────────────────────────── */
+/* Título — masthead, hero, panel o diálogo, todos con el mismo peso. */
+.music-shell .music-heading {
+  font-weight: 650;
+  letter-spacing: -0.015em;
+}
+
+/* Micro-label en versalitas espaciadas: el registro "hoja de sala". */
+.music-shell .music-eyebrow {
+  font-size: 0.625rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.music-shell .music-eyebrow-xs {
+  font-size: 0.5rem;
+  letter-spacing: 0.18em;
+}
+
+/* Todo dato numérico va en mono tabular: las columnas no bailan al refrescar. */
+.music-shell .music-num {
+  font-family: var(--music-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.03em;
+}
+
+/* Regla de luz: hairline con degradé, separa bloques sin meter una caja más. */
+.music-shell .music-rule {
+  height: 1px;
+  border: 0;
+  background: linear-gradient(
+    90deg,
+    hsl(var(--music-brass) / 0.5),
+    hsl(var(--music-spot) / 0.25) 32%,
+    hsl(var(--border)) 70%,
+    transparent
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Superficies
+ * ───────────────────────────────────────────────────────────── */
+.music-shell .music-panel {
+  border-radius: 1.1rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  box-shadow: var(--music-hairline), 0 1px 2px hsl(30 20% 60% / 0.08);
+}
+
+/* Panel hundido: para listas dentro de un panel (no card-dentro-de-card). */
+.music-shell .music-well {
+  border-radius: 0.85rem;
+  border: 1px solid hsl(var(--border));
+  background: var(--music-surface-sunken);
+}
+
+/* Casillero de icono (los cuadraditos de 32px al lado de cada título). */
+.music-shell .music-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+  flex-shrink: 0;
+  border-radius: 0.6rem;
+  color: hsl(var(--music-glyph-ink));
+  background: hsl(var(--music-brass) / 0.15);
+  box-shadow: inset 0 0 0 1px hsl(var(--music-brass) / 0.25);
+}
+
+.music-shell .music-glyph-spot {
+  color: hsl(var(--music-spot));
+  background: hsl(var(--music-spot) / 0.12);
+  box-shadow: inset 0 0 0 1px hsl(var(--music-spot) / 0.22);
+}
+
+.music-shell .music-glyph-lg {
+  height: 3rem;
+  width: 3rem;
+  border-radius: 0.9rem;
+}
+
+/* Etiqueta en versalitas. Reemplaza al <Badge> de shadcn dentro del módulo:
+ * el badge redondeado gris es el tell más obvio de "dashboard genérico". */
+.music-shell .music-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.625rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+.music-shell .music-tag-tone {
+  background: hsl(var(--music-tone, var(--music-brass)) / 0.16);
+  color: hsl(var(--music-tone, var(--music-brass)));
+}
+
+.music-shell .music-tag-ok {
+  background: hsl(var(--music-ok) / 0.14);
+  color: hsl(var(--music-ok));
+}
+
+/* Tono musical. NO puede ir con el uppercase del .music-tag: "Am" (la menor) y
+ * "AM" no son lo mismo, y el tracking ancho lo parte en dos letras sueltas. */
+.music-shell .music-key {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.4rem;
+  padding: 0.2rem 0.45rem;
+  font-family: var(--music-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0;
+  text-transform: none;
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+}
+
+.music-shell .music-tag-warn {
+  background: hsl(var(--destructive) / 0.12);
+  color: hsl(var(--destructive));
+}
+
+/* Fila de lista. Hover solo con mouse real: en touch el :hover se dispara al
+ * tocar y queda pegado. */
+.music-shell .music-row {
+  border-radius: 0.8rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  transition:
+    background-color 170ms var(--music-ease-out),
+    border-color 170ms var(--music-ease-out),
+    transform 170ms var(--music-ease-out);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .music-shell .music-row:hover {
+    background: var(--music-surface-sunken);
+    border-color: hsl(var(--music-brass) / 0.4);
+  }
+}
+
+.music-shell .music-row:active {
+  transform: scale(0.99);
+}
+
+.music-shell .music-row-pill {
+  border-radius: 999px;
+}
+
+/* Feedback de presión para <button> crudos (el Button de shadcn ya lo trae). */
+.music-shell .music-press {
+  transition: transform 140ms var(--music-ease-out);
+}
+
+.music-shell .music-press:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+/* Lomo de color: identifica el tipo de culto sin teñir toda la tarjeta. */
+.music-shell .music-spine {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    hsl(var(--music-tone, var(--music-brass))),
+    hsl(var(--music-tone, var(--music-brass)) / 0.2)
+  );
+}
+
+/* Halo del tipo de culto sobre el hero: ahora un lienzo blanco con un cenital
+ * suave del color del culto, no una sala oscura. */
+.music-shell .music-stage {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: 1.25rem;
+  border: 1px solid hsl(var(--music-tone, var(--music-brass)) / 0.35);
+  background:
+    radial-gradient(
+      120% 100% at 88% -30%,
+      hsl(var(--music-tone, var(--music-brass)) / 0.14),
+      transparent 60%
+    ),
+    hsl(var(--card));
+  box-shadow: var(--music-hairline), var(--music-lift);
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Navegación
+ * ───────────────────────────────────────────────────────────── */
+
+/* Web: píldora ámbar sobre la pestaña activa (no el riel subrayado). */
+.music-shell .music-tabs {
+  display: flex;
+  height: auto;
+  justify-content: flex-start;
+  gap: 0.35rem;
+  border-radius: 0;
+  border-bottom: 1px solid hsl(var(--border));
+  background: transparent;
+  padding: 0 0 0.5rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.music-shell .music-tab {
+  position: relative;
+  border-radius: 0.7rem;
+  background: transparent;
+  box-shadow: none;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: hsl(var(--muted-foreground));
+  transition:
+    color 180ms var(--music-ease-out),
+    background-color 180ms var(--music-ease-out);
+}
+
+.music-shell .music-tab[data-state='active'] {
+  background: hsl(var(--music-brass) / 0.16);
+  box-shadow: none;
+  color: hsl(var(--foreground));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .music-shell .music-tab:hover {
+    color: hsl(var(--foreground));
+  }
+}
+
+/* Mobile director: píldoras scrolleables. */
+.music-shell .music-pill {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  padding: 0.5rem 0.9rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: hsl(var(--muted-foreground));
+  transition:
+    background-color 180ms var(--music-ease-out),
+    border-color 180ms var(--music-ease-out),
+    color 180ms var(--music-ease-out),
+    transform 140ms var(--music-ease-out);
+}
+
+.music-shell .music-pill:active {
+  transform: scale(0.96);
+}
+
+/* Variante liviana: toggles chicos dentro de un panel (Lista / Calendario). */
+.music-shell .music-pill-ghost {
+  border-color: transparent;
+  background: transparent;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.7rem;
+}
+
+.music-shell .music-pill[data-active='true'] {
+  background: hsl(var(--music-brass));
+  border-color: hsl(var(--music-brass));
+  color: hsl(var(--primary-foreground));
+  box-shadow: 0 6px 18px -10px hsl(var(--music-brass) / 0.9);
+}
+
+/* Mobile servidor: segmented control de 3 con indicador que se desliza.
+ * El indicador se mueve con transform (GPU) en vez de repintar fondos. */
+.music-shell .music-seg {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-radius: 1rem;
+  border: 1px solid hsl(var(--border));
+  background: var(--music-surface-sunken);
+  padding: 0.25rem;
+}
+
+.music-shell .music-seg-thumb {
+  position: absolute;
+  top: 0.25rem;
+  bottom: 0.25rem;
+  left: 0.25rem;
+  width: calc((100% - 0.5rem) / 3);
+  border-radius: 0.8rem;
+  background: hsl(var(--music-brass));
+  box-shadow: 0 6px 18px -10px hsl(var(--music-brass) / 0.9);
+  transform: translateX(calc(var(--music-seg-index, 0) * 100%));
+  transition: transform 320ms var(--music-ease-in-out);
+}
+
+.music-shell .music-seg-item {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 0.8rem;
+  padding: 0.5rem 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+  transition:
+    color 200ms var(--music-ease-out),
+    transform 140ms var(--music-ease-out);
+}
+
+.music-shell .music-seg-item:active {
+  transform: scale(0.96);
+}
+
+.music-shell .music-seg-item[data-active='true'] {
+  color: hsl(var(--primary-foreground));
+}
+
+/* Barra sticky de navegación mobile. */
+.music-shell .music-navbar {
+  background: linear-gradient(180deg, hsl(var(--background) / 0.94), hsl(var(--background) / 0.75));
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Movimiento
+ * ───────────────────────────────────────────────────────────── */
+@keyframes music-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.music-shell .music-rise {
+  animation: music-rise 260ms var(--music-ease-out) both;
+}
+
+/* Entrada escalonada: 40ms entre filas. Más lento se siente perezoso; la
+ * cascada nunca bloquea el click porque `both` deja el estado final. */
+.music-shell .music-stagger > * {
+  animation: music-rise 300ms var(--music-ease-out) both;
+}
+.music-shell .music-stagger > *:nth-child(2) {
+  animation-delay: 40ms;
+}
+.music-shell .music-stagger > *:nth-child(3) {
+  animation-delay: 80ms;
+}
+.music-shell .music-stagger > *:nth-child(4) {
+  animation-delay: 120ms;
+}
+.music-shell .music-stagger > *:nth-child(5) {
+  animation-delay: 160ms;
+}
+.music-shell .music-stagger > *:nth-child(6) {
+  animation-delay: 200ms;
+}
+.music-shell .music-stagger > *:nth-child(n + 7) {
+  animation-delay: 240ms;
+}
+
+/* Barra de progreso de confirmaciones: crece desde la izquierda. */
+.music-shell .music-meter-fill {
+  transition: width 520ms var(--music-ease-out);
+}
+
+/* El movimiento puede marear. Reducido = menos y más suave, no cero: se
+ * mantienen opacidad y color porque ayudan a comprender; se saca el
+ * desplazamiento. */
+@media (prefers-reduced-motion: reduce) {
+  .music-shell .music-rise,
+  .music-shell .music-stagger > * {
+    animation: none;
+  }
+
+  .music-shell .music-seg-thumb,
+  .music-shell .music-tab::after,
+  .music-shell .music-meter-fill {
+    transition-duration: 1ms;
+  }
+
+  .music-shell .music-row:active,
+  .music-shell .music-press:active,
+  .music-shell .music-pill:active,
+  .music-shell .music-seg-item:active {
+    transform: none;
+  }
 }

--- a/src/services/discipleship-analytics.service.ts
+++ b/src/services/discipleship-analytics.service.ts
@@ -20,6 +20,7 @@ export interface DiscipleshipAnalytics {
   activeLeaders: number;
   multiplications: number;
   spiritualHealth: number;
+  auxiliarySupervisors: number;
   dateRange: { from: string; to: string };
 }
 
@@ -192,6 +193,7 @@ export class DiscipleshipAnalyticsService {
       activeLeaders: data.active_leaders || 0,
       multiplications: data.multiplications || 0,
       spiritualHealth: data.spiritual_health || 0,
+      auxiliarySupervisors: data.auxiliary_supervisors || 0,
       dateRange: { from: '', to: '' },
     };
   }
@@ -218,8 +220,8 @@ export class DiscipleshipAnalyticsService {
       avgAttendance: zone.avg_attendance || 0,
       avg_attendance: zone.avg_attendance || 0,
       isActive: zone.is_active || false,
-      growthRate: 0,
-      healthIndex: 0,
+      growthRate: zone.growth_rate || 0,
+      healthIndex: zone.health_index || 0,
     }));
   }
 
@@ -310,8 +312,11 @@ export class DiscipleshipAnalyticsService {
       averageAttendance: analytics.averageAttendance,
       growthRate: analytics.growthRate,
       healthIndex: analytics.spiritualHealth,
-      groupsUnderSupervision: level === 2 ? Math.ceil(analytics.totalGroups / 3) : undefined,
-      auxiliarySupervisors: level >= 3 ? Math.ceil(analytics.activeLeaders / 4) : undefined,
+      // Ambos ya vienen scoped desde el backend según el nivel jerárquico de quien
+      // consulta — antes se estimaban con divisores arbitrarios (÷3, ÷4) sin
+      // relación con la data real.
+      groupsUnderSupervision: level === 2 ? analytics.totalGroups : undefined,
+      auxiliarySupervisors: level >= 3 ? analytics.auxiliarySupervisors : undefined,
       leadersSupportNeeded: alerts.filter(a => a.actionRequired && !a.resolved).length,
       territoryHealthIndex: analytics.spiritualHealth,
       totalSupervisors: analytics.activeLeaders,
@@ -386,6 +391,7 @@ export class DiscipleshipAnalyticsService {
       activeLeaders: rawAnalytics?.active_leaders || 0,
       multiplications: rawAnalytics?.multiplications || 0,
       spiritualHealth: rawAnalytics?.spiritual_health || 0,
+      auxiliarySupervisors: rawAnalytics?.auxiliary_supervisors || 0,
       dateRange: { from: '', to: '' },
     };
 

--- a/src/services/discipleship.service.ts
+++ b/src/services/discipleship.service.ts
@@ -159,17 +159,27 @@ export class DiscipleshipService {
     return ApiService.get(`/zones`);
   }
 
+  /** 24 buckets horarios (más viejo → más reciente) con reportes reales de las últimas 24h. */
+  static async getActivityTimeline(): Promise<number[]> {
+    const data = (await ApiService.get(`${this.baseUrl}/analytics/timeline`)) as {
+      buckets?: number[];
+    };
+    return data?.buckets || new Array(24).fill(0);
+  }
+
   static async getGroupPerformance(): Promise<GroupPerformance[]> {
-    const data = (await ApiService.get(`${this.baseUrl}/analytics`)) as any;
-    return ((data?.group_performance as any[]) || []).map((g: any) => ({
-      groupId: g.group_id || '',
-      groupName: g.group_name || 'Sin nombre',
-      leaderName: g.leader_name || 'Sin líder',
-      avgAttendance: g.avg_attendance || 0,
-      growthRate: g.growth_rate || 0,
-      spiritualTemp: g.spiritual_temp || 0,
-      status: g.status || 'active',
-      lastReportDate: g.last_report_date || '',
+    const data = (await ApiService.get(`${this.baseUrl}/analytics`)) as {
+      group_performance?: Array<Record<string, string | number | undefined>>;
+    };
+    return (data?.group_performance || []).map(g => ({
+      groupId: String(g.group_id ?? ''),
+      groupName: String(g.group_name ?? 'Sin nombre'),
+      leaderName: String(g.leader_name ?? 'Sin líder'),
+      avgAttendance: Number(g.avg_attendance ?? 0),
+      growthRate: Number(g.growth_rate ?? 0),
+      spiritualTemp: Number(g.spiritual_temp ?? 0),
+      status: String(g.status ?? 'active'),
+      lastReportDate: String(g.last_report_date ?? ''),
     }));
   }
 
@@ -383,10 +393,7 @@ export class DiscipleshipService {
   // CUMPLIMIENTO DE REPORTES (report_compliance)
   // =====================================================
 
-  static async getZoneRollup(
-    periodStart: string,
-    periodEnd: string
-  ): Promise<ZoneRollupResponse> {
+  static async getZoneRollup(periodStart: string, periodEnd: string): Promise<ZoneRollupResponse> {
     return ApiService.get(
       `${this.baseUrl}/zone-rollup?period_start=${periodStart}&period_end=${periodEnd}`
     );

--- a/src/types/discipleship.types.ts
+++ b/src/types/discipleship.types.ts
@@ -44,6 +44,8 @@ export interface ZoneMapGroup extends DiscipleshipGroup {
   supervisor_name?: string;
   /** Timestamp del último reporte real recibido de este grupo (MAX(submitted_at)), '' si nunca reportó. */
   last_report_date?: string;
+  /** El grupo tiene un reporte enviado sin aprobar (status='submitted'). El marcador titila hasta que lo aprueban. */
+  has_pending_report?: boolean;
 }
 
 export interface ZoneMapData {

--- a/src/types/discipleship.types.ts
+++ b/src/types/discipleship.types.ts
@@ -42,6 +42,8 @@ export interface Zone {
 export interface ZoneMapGroup extends DiscipleshipGroup {
   leader_name?: string;
   supervisor_name?: string;
+  /** Timestamp del último reporte real recibido de este grupo (MAX(submitted_at)), '' si nunca reportó. */
+  last_report_date?: string;
 }
 
 export interface ZoneMapData {

--- a/supabase/migrations/20260818000001_discipleship_reports_realtime.sql
+++ b/supabase/migrations/20260818000001_discipleship_reports_realtime.sql
@@ -1,0 +1,37 @@
+-- Realtime para el "mapa en vivo" del discipulado.
+--
+-- El mapa (DiscipleshipMap) se suscribe a los cambios de discipleship_reports
+-- para refrescar al instante (titileo de reportes pendientes, contador EN VIVO)
+-- en vez de pollear cada 30s. La data del mapa la sigue sirviendo el backend Go
+-- (getMapData, con su aislamiento por TenantTx) — Realtime solo actúa como
+-- "ping: algo cambió, refrescá".
+--
+-- Aislamiento multi-tenant: la policy existente `tenant_isolation` usa
+-- current_setting('app.current_church_id'), que SOLO setea el backend (TenantTx)
+-- y NO aplica a una conexión Realtime directa del cliente. Por eso se agrega una
+-- policy basada en el JWT (app_metadata.church_id) para que la suscripción quede
+-- scopeada por iglesia. Se limita además a roles staff+ (los únicos que ven el
+-- mapa y que legítimamente ya ven todos los reportes de su iglesia por la app),
+-- así no se amplía el acceso directo de un miembro común.
+
+-- 1) Agregar la tabla a la publicación de Realtime (idempotente).
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and tablename = 'discipleship_reports'
+  ) then
+    alter publication supabase_realtime add table discipleship_reports;
+  end if;
+end $$;
+
+-- 2) Policy SELECT scopeada por iglesia (JWT) + rol, para Realtime.
+drop policy if exists "reports_realtime_church_staff" on discipleship_reports;
+create policy "reports_realtime_church_staff"
+on discipleship_reports
+for select
+to authenticated
+using (
+  church_id = (auth.jwt() -> 'app_metadata' ->> 'church_id')::uuid
+  and (auth.jwt() -> 'app_metadata' ->> 'role') in ('admin', 'pastor', 'staff')
+);


### PR DESCRIPTION
## Resumen

Dos frentes, ambos verificados (Go `build` + tests de handlers/middleware OK, `tsc` limpio, verificación visual en browser en claro y oscuro).

### 📊 Analítica avanzada de discipulado (`afe795c`)
Cierra los indicadores que estaban muertos o divergentes en el dashboard pastoral y por nivel jerárquico:

- **`growthRate`** a nivel iglesia y por nivel (líder/supervisor/general/coordinador/pastoral) vía helper compartido `memberGrowthRate`, con tarjeta **"Crecimiento"** (verde/rojo según signo) en `PastoralDashboard`.
- **`auxiliarySupervisors`**: conteo real desde `discipleship_hierarchy` (nivel 2), con tarjeta **"Sup. Auxiliares"**.
- **Multiplicaciones** y **Salud Espiritual** unificadas en helpers Go compartidos (se eliminan las copias divergentes).
- **Zonas**: `growth_rate` y `health_index` calculados live en `GetZones`/`GetZone`.
- **Radar de salud por zona**: normalizado al dominio `[0,10]` (asistencia ya no se sale del eje). Área de crecimiento con dataKeys `asistencia`/`reportando`.
- **MinistryHealthTab**: temperatura reescalada `/13 → /10`.
- Todas las queries de stats **scopeadas por `church_id`**.

### 🎵 Música: tema claro/oscuro del sistema (`582ec0f`)
El módulo dejó de tener paleta fija y ahora hereda los tokens reales del sistema (`:root` / `.dark`), siguiendo el toggle claro/oscuro del resto del ERP.

- `music-theme.css`: quita la definición propia de background/card/border/muted; conserva solo el color de acción (mismo dorado `--sion-gold`) y agrega variantes `.dark .music-shell`.
- Tonos de tipo de culto por variable CSS según modo.
- Shades Tailwind hardcodeados con par `dark:` para contraste en ambos lienzos.
- Incluye el rediseño "Dirección B" y la unificación tipográfica a una sola voz.

## Nota
Deuda pre-existente de lint (`no-explicit-any` en `useDiscipleshipData.ts`) quedó marcada como tarea aparte — no es regresión de este PR y `tsc` pasa limpio.