### PR TITLE
ci: fix pnpm version en workflow de deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
Re-promoción tras arreglar el pin de pnpm en deploy-production.yml. El run anterior falló en 'verify' (antes de backup/migrate), así que prod está intacto. Este merge re-dispara el CI.