### PR TITLE
fix: xlsx integrity en lockfile (verify CI verde)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -54,14 +54,8 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-      # El lockfile referencia xlsx desde un CDN (cdn.sheetjs.com) sin campo
-      # integrity, y pnpm 10 aborta el install aun sin --frozen. Regeneramos el
-      # lockfile en el runner (efímero, NO se commitea) para que pnpm baje el
-      # tarball y compute la integrity al vuelo. Este job es un chequeo de build.
       - name: Install deps
-        run: |
-          rm -f pnpm-lock.yaml
-          pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Typecheck + build frontend
         run: |
           pnpm typecheck

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4688,7 +4688,7 @@ packages:
         optional: true
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true


### PR DESCRIPTION
Agrega integrity al tarball de xlsx del CDN para que --frozen-lockfile funcione sin regenerar versiones. Build verificado local. Debería dejar verify verde y avanzar a backup → migrate (con gate de aprobación).