### PR TITLE
ci: fix pg_dump 17 path en el runner (GITHUB_PATH)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -86,6 +86,13 @@ jobs:
             sudo apt-get install -y postgresql-client-17
           }
           command -v rclone >/dev/null || sudo apt-get install -y rclone
+          # El runner ya trae un pg_dump más viejo en /usr/bin (Ubuntu Noble
+          # default = v16), y apt no lo reemplaza al instalar postgresql-client-17
+          # (queda en /usr/lib/postgresql/17/bin, sin symlink automático). Sin
+          # esto, el `pg_dump` del paso siguiente resuelve a la versión vieja y
+          # aborta con "server version mismatch" (v17 en Supabase). $GITHUB_PATH
+          # antepone esta ruta para todos los steps que siguen en este job.
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
 
       - name: Dump + subir a B2 (pre-migrate/)
         env:

--- a/scripts/fix-group-membership.mjs
+++ b/scripts/fix-group-membership.mjs
@@ -1,0 +1,123 @@
+/**
+ * fix-group-membership.mjs
+ * Reconstruye la membresía de TODOS los grupos de discipulado, iglesia
+ * completa, zona por zona:
+ *  - Cada célula toma miembros SOLO de su propia zona.
+ *  - Nadie se repite en más de un grupo, en TODA la iglesia.
+ *  - El tamaño de cada grupo sale de la población real disponible (~4 por
+ *    grupo con la data actual), no de un número fijo inventado.
+ *
+ * Por qué existe: hydrate-zones.mjs (versión anterior) armaba grupos con un
+ * pool de TODA la iglesia sin evitar repetidos entre grupos — verificado:
+ * 1041 filas de membresía pero solo 557 personas únicas, alguna en hasta 6
+ * grupos. Este script corrige eso de raíz, para las 4 zonas.
+ *
+ * Borra también discipleship_attendance de TODOS los grupos (la asistencia
+ * queda ligada a la lista de miembros vieja) — correr
+ * seed-reports-attendance.mjs después para regenerarla contra los rosters
+ * nuevos. Los reportes (discipleship_reports) NO se tocan: están ligados al
+ * líder (reporter_id), no a miembros individuales, siguen siendo válidos.
+ *
+ * Uso:
+ *   node scripts/fix-group-membership.mjs                              (local)
+ *   SUPABASE_DB_URL='postgres://...' node scripts/fix-group-membership.mjs  (otra DB)
+ */
+
+import pg from 'pg';
+import { parse as parseConnectionString } from 'pg-connection-string';
+import { randomUUID } from 'crypto';
+
+const { Client } = pg;
+const DB_URL = process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+const connectionConfig = parseConnectionString(DB_URL);
+connectionConfig.ssl = process.env.SUPABASE_DB_URL ? { rejectUnauthorized: false } : false;
+
+const rand = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+function shuffle(arr) {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = rand(0, i);
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+async function main() {
+  const client = new Client(connectionConfig);
+  await client.connect();
+
+  const { rows: zones } = await client.query(`SELECT id, name FROM zones ORDER BY name`);
+
+  let totalGroupsTouched = 0;
+  let totalMembersAssigned = 0;
+
+  for (const zone of zones) {
+    const { rows: groups } = await client.query(
+      `SELECT id FROM discipleship_groups WHERE zone_id = $1 ORDER BY group_name`,
+      [zone.id]
+    );
+    if (groups.length === 0) {
+      console.log(`${zone.name}: sin grupos, salteando.`);
+      continue;
+    }
+    const groupIds = groups.map(g => g.id);
+
+    // Pool disponible: gente de ESTA zona, role='server', sin ser ya
+    // líder/supervisor de discipulado.
+    const { rows: pool } = await client.query(
+      `SELECT id FROM users u
+       WHERE u.zone_id = $1 AND u.role = 'server'
+       AND u.id NOT IN (SELECT user_id FROM discipleship_hierarchy)`,
+      [zone.id]
+    );
+
+    // Borrar asistencia + membresía actual de TODOS los grupos de la zona
+    // (el roster va a cambiar completo).
+    await client.query(`DELETE FROM discipleship_attendance WHERE group_id = ANY($1::uuid[])`, [groupIds]);
+    await client.query(`DELETE FROM discipleship_group_members WHERE group_id = ANY($1::uuid[])`, [groupIds]);
+
+    // Repartir el pool entre los grupos de la zona, parejo, sin repetir a nadie.
+    const shuffledPool = shuffle(pool.map(r => r.id));
+    const perGroup = Array(groupIds.length).fill(0);
+    for (let i = 0; i < shuffledPool.length; i++) {
+      perGroup[i % groupIds.length]++;
+    }
+
+    let cursor = 0;
+    for (let i = 0; i < groupIds.length; i++) {
+      const groupId = groupIds[i];
+      const count = perGroup[i];
+      const assigned = shuffledPool.slice(cursor, cursor + count);
+      cursor += count;
+
+      for (const userId of assigned) {
+        await client.query(
+          `INSERT INTO discipleship_group_members
+             (id, group_id, user_id, role_in_group, is_active, church_id)
+           SELECT $1, $2, $3, 'member', true, church_id FROM discipleship_groups WHERE id = $2`,
+          [randomUUID(), groupId, userId]
+        );
+      }
+      await client.query(
+        `UPDATE discipleship_groups SET member_count = $1, active_members = $1 WHERE id = $2`,
+        [count, groupId]
+      );
+    }
+
+    totalGroupsTouched += groupIds.length;
+    totalMembersAssigned += shuffledPool.length;
+    console.log(
+      `${zone.name}: pool ${pool.length}, repartido entre ${groupIds.length} grupos (${Math.min(...perGroup)}-${Math.max(...perGroup)} c/u).`
+    );
+  }
+
+  console.log(`\nTotal: ${totalGroupsTouched} grupos reconstruidos, ${totalMembersAssigned} asignaciones de miembros (sin repetidos).`);
+  await client.end();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/hydrate-zones.mjs
+++ b/scripts/hydrate-zones.mjs
@@ -1,25 +1,31 @@
 /**
  * hydrate-zones.mjs
- * Lleva OESTE 2, OESTE 3 y ESTE a la misma completitud que OESTE 1:
- * polígono real (OESTE 2/ESTE, generados — OESTE 3 ya lo tiene), 29 líderes
- * de nivel 1 con su grupo, ~9 miembros por grupo, y coordenadas dentro del
- * polígono de la zona (point-in-polygon real, no bounding box).
+ * Completa cada zona hasta TARGET_GROUPS grupos (líder nivel 1 + grupo +
+ * ~9 miembros + coordenadas dentro del polígono real de la zona).
  *
- * Replica el patrón EXACTO ya presente en OESTE 1 (verificado por consulta
- * directa antes de escribir esto):
- *  - discipleship_hierarchy nivel 1: user_id = líder, supervisor_id = el
- *    supervisor auxiliar (nivel 2) YA existente de esa zona, territory=NULL.
+ * Genérico y respetuoso de lo que ya exista en la DB destino:
+ *  - Si una zona no tiene polígono, le asigna uno de GENERATED_POLYGONS
+ *    (fallback demo — no se usa si la zona ya tiene boundaries reales).
+ *  - Si ya tiene polígono, lo usa tal cual — nunca lo pisa.
+ *  - Cuenta grupos REALES existentes (discipleship_groups), no filas de
+ *    discipleship_hierarchy — una zona puede tener grupos con leader_id
+ *    válido sin fila de jerarquía correspondiente (visto en prod).
+ *  - Los candidatos a nuevo líder excluyen: cualquiera que YA sea leader_id
+ *    de un grupo de esa zona, y cualquiera que YA tenga fila en
+ *    discipleship_hierarchy (evita duplicar o pisar supervisores).
+ *  - Grupos con coordenadas faltantes (latitude NULL o 0) se backfillean
+ *    dentro del polígono real de su zona, sin tocar el resto del grupo.
+ *
+ * Patrón replicado (verificado contra OESTE1 antes de escribir esto):
+ *  - discipleship_hierarchy nivel 1: supervisor_id = el supervisor auxiliar
+ *    (nivel 2) YA existente de esa zona, territory=NULL.
  *  - discipleship_groups: group_name = "Grupo de <NOMBRE>", supervisor_id
- *    NULL (así está en OESTE1, no es un bug mío), meeting_location NULL,
- *    member_count=active_members=9, status='active'.
- *  - discipleship_group_members: role_in_group='member', miembros tomados
- *    del pool general de la iglesia (no solo de la zona), pueden repetirse
- *    entre grupos — igual que OESTE1.
- *  - Los 29 líderes SÍ pertenecen a la zona (users.zone_id) y tienen role='server'.
+ *    NULL, meeting_location NULL, member_count=active_members=9, status='active'.
+ *  - discipleship_group_members: role_in_group='member', del pool general
+ *    de la iglesia, únicos dentro del grupo (UNIQUE(group_id,user_id)).
  *
- * Apunta a local por default. Idempotente: si una zona ya tiene boundaries,
- * no lo pisa; si ya tiene líderes (hierarchy nivel 1), no duplica — seguro
- * de re-correr o correr contra una DB que ya tiene parte del trabajo.
+ * Apunta a local por default. Idempotente: se puede re-correr sin duplicar
+ * — cada corrida solo agrega lo que falte para llegar a TARGET_GROUPS.
  *
  * Uso:
  *   node scripts/hydrate-zones.mjs                              (local)
@@ -27,10 +33,25 @@
  */
 
 import pg from 'pg';
+import { parse as parseConnectionString } from 'pg-connection-string';
 import { randomUUID } from 'crypto';
 
 const { Client } = pg;
 const DB_URL = process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+// Config de conexión: si DB_URL trae `sslmode=require` (o similar), `pg` lo
+// parsea a su propio objeto ssl y ese gana sobre un `ssl:` explícito pasado
+// junto a `connectionString` — probado empíricamente, no alcanza con pasar
+// ambos. Por eso se parsea la connection string a mano y se pisa `ssl`
+// DESPUÉS del parse, así siempre gana lo que decidimos acá. El pooler de
+// Supabase presenta un certificado que Node rechaza en modo estricto
+// (verify-full); el tráfico sigue cifrado, solo se relaja la verificación
+// de la cadena — mismo approach que recomienda Supabase para conexiones por
+// pooler. Local (sin SUPABASE_DB_URL) sigue sin SSL, sin cambios.
+const connectionConfig = parseConnectionString(DB_URL);
+connectionConfig.ssl = process.env.SUPABASE_DB_URL ? { rejectUnauthorized: false } : false;
+
+const TARGET_GROUPS = 29;
 
 const rand = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 
@@ -46,9 +67,9 @@ function shuffledSample(arr, n) {
   return result;
 }
 
-// ─── Polígonos generados (demo, geografía plausible) ──────────────────────
-// Verificados por bounding box contra OESTE1 y OESTE3 reales, con >500m de
-// margen en cada caso — no se solapan. Editables después desde el mapa.
+// ─── Polígonos fallback (solo si la zona destino no tiene uno) ────────────
+// Geografía demo plausible en Coro, sin solape con OESTE1/OESTE3 reales
+// (verificado por bounding box con >500m de margen en cada caso).
 const GENERATED_POLYGONS = {
   'OESTE 2': [
     [-69.7, 11.383],
@@ -102,70 +123,61 @@ function randomPointInPolygon(ring) {
 
 // ─── Main ───────────────────────────────────────────────────────────────
 
-// Solo cuando apunta a otra DB (SUPABASE_DB_URL seteado): el pooler de
-// Supabase presenta un certificado que Node rechaza con sslmode=require
-// (`pg` lo trata como verify-full, no como "solo requerir TLS"). El tráfico
-// sigue cifrado; se relaja únicamente la verificación de la cadena, igual
-// que recomienda la propia documentación de Supabase para conexiones por
-// pooler. Local (sin la env var) sigue sin SSL, sin cambios.
-const sslConfig = process.env.SUPABASE_DB_URL ? { rejectUnauthorized: false } : false;
-
 async function main() {
-  const client = new Client({ connectionString: DB_URL, ssl: sslConfig });
+  const client = new Client(connectionConfig);
   await client.connect();
 
-  // ── 1) OESTE 3: ya tiene 29 grupos/líderes/miembros, solo faltan coords ──
-  const { rows: oeste3Groups } = await client.query(
-    `SELECT g.id, z.boundaries
-     FROM discipleship_groups g JOIN zones z ON g.zone_id = z.id
-     WHERE z.name = 'OESTE 3' AND (g.latitude IS NULL OR g.latitude = 0)`
-  );
-  console.log(`OESTE 3: ${oeste3Groups.length} grupos sin coordenadas`);
-  for (const g of oeste3Groups) {
-    const ring = g.boundaries.coordinates[0];
-    const [lng, lat] = randomPointInPolygon(ring);
-    await client.query(
-      `UPDATE discipleship_groups SET latitude = $1, longitude = $2 WHERE id = $3`,
-      [lat, lng, g.id]
-    );
-  }
-  console.log(`OESTE 3: coordenadas asignadas.`);
+  const { rows: zones } = await client.query(`SELECT id, name, church_id, boundaries FROM zones ORDER BY name`);
 
-  // ── 2) OESTE 2 y ESTE: build completo ──────────────────────────────────
-  for (const [zoneName, ring] of Object.entries(GENERATED_POLYGONS)) {
-    const { rows: zoneRows } = await client.query(
-      `SELECT id, church_id, boundaries FROM zones WHERE name = $1`,
-      [zoneName]
-    );
-    if (zoneRows.length === 0) {
-      console.log(`${zoneName}: no existe la zona, salteando.`);
-      continue;
-    }
-    const zone = zoneRows[0];
+  for (const zone of zones) {
+    const zoneName = zone.name;
 
-    if (!zone.boundaries) {
+    // ── 1) Asegurar polígono ──
+    let ring;
+    if (zone.boundaries) {
+      ring = zone.boundaries.coordinates[0];
+      console.log(`${zoneName}: usa su polígono real existente.`);
+    } else if (GENERATED_POLYGONS[zoneName]) {
+      ring = GENERATED_POLYGONS[zoneName];
       await client.query(`UPDATE zones SET boundaries = $1 WHERE id = $2`, [
         JSON.stringify({ type: 'Polygon', coordinates: [ring] }),
         zone.id,
       ]);
-      console.log(`${zoneName}: polígono asignado.`);
+      console.log(`${zoneName}: no tenía polígono, se asignó uno demo (fallback).`);
     } else {
-      console.log(`${zoneName}: ya tenía polígono, no se pisa.`);
-    }
-
-    // ¿Cuántos líderes nivel 1 faltan? (idempotente: continúa donde quedó,
-    // no saltea la zona entera si ya tiene algunos).
-    const TARGET_LEADERS = 29;
-    const { rows: existingLeaders } = await client.query(
-      `SELECT COUNT(*) FROM discipleship_hierarchy WHERE zone_name = $1 AND hierarchy_level = 1`,
-      [zoneName]
-    );
-    const need = TARGET_LEADERS - Number(existingLeaders[0].count);
-    if (need <= 0) {
-      console.log(`${zoneName}: ya tiene ${existingLeaders[0].count} líderes nivel 1, nada que hacer.`);
+      console.log(`${zoneName}: sin polígono y sin fallback definido — no se pueden generar coordenadas. Salteando.`);
       continue;
     }
-    console.log(`${zoneName}: ${existingLeaders[0].count} líderes existentes, faltan ${need}.`);
+
+    // ── 2) Backfill de coords en grupos existentes sin coordenadas ──
+    const { rows: groupsNoCoords } = await client.query(
+      `SELECT id FROM discipleship_groups WHERE zone_id = $1 AND (latitude IS NULL OR latitude = 0)`,
+      [zone.id]
+    );
+    for (const g of groupsNoCoords) {
+      const [lng, lat] = randomPointInPolygon(ring);
+      await client.query(`UPDATE discipleship_groups SET latitude = $1, longitude = $2 WHERE id = $3`, [
+        lat,
+        lng,
+        g.id,
+      ]);
+    }
+    if (groupsNoCoords.length > 0) {
+      console.log(`${zoneName}: ${groupsNoCoords.length} grupos existentes recibieron coordenadas.`);
+    }
+
+    // ── 3) Completar hasta TARGET_GROUPS grupos ──
+    const { rows: countRows } = await client.query(
+      `SELECT COUNT(*) FROM discipleship_groups WHERE zone_id = $1`,
+      [zone.id]
+    );
+    const existingGroups = Number(countRows[0].count);
+    const need = TARGET_GROUPS - existingGroups;
+    if (need <= 0) {
+      console.log(`${zoneName}: ya tiene ${existingGroups} grupos (>= ${TARGET_GROUPS}), nada que completar.`);
+      continue;
+    }
+    console.log(`${zoneName}: ${existingGroups} grupos existentes, faltan ${need} para llegar a ${TARGET_GROUPS}.`);
 
     // Supervisor auxiliar (nivel 2) ya existente de esta zona.
     const { rows: auxRows } = await client.query(
@@ -173,21 +185,23 @@ async function main() {
       [zoneName]
     );
     if (auxRows.length === 0) {
-      console.log(`${zoneName}: no tiene supervisor auxiliar (nivel 2), no puedo asignar líderes. Salteando.`);
+      console.log(`${zoneName}: no tiene supervisor auxiliar (nivel 2), no puedo asignar líderes nuevos. Salteando.`);
       continue;
     }
     const auxSupervisorId = auxRows[0].user_id;
 
-    // Candidatos: pertenecen a la zona, role='server', sin fila previa en hierarchy
-    // (esto además excluye automáticamente a los líderes ya creados en un run anterior).
+    // Candidatos: pertenecen a la zona, role='server', NO son ya leader_id
+    // de un grupo de esta zona, y NO tienen fila previa en hierarchy
+    // (cubre tanto duplicar líderes existentes como pisar supervisores).
     const { rows: candidates } = await client.query(
       `SELECT id, first_name, last_name FROM users u
        WHERE u.zone_id = $1 AND u.role = 'server'
+       AND u.id NOT IN (SELECT leader_id FROM discipleship_groups WHERE zone_id = $1)
        AND u.id NOT IN (SELECT user_id FROM discipleship_hierarchy)
        ORDER BY random() LIMIT $2`,
       [zone.id, need]
     );
-    console.log(`${zoneName}: ${candidates.length} candidatos a líder disponibles.`);
+    console.log(`${zoneName}: ${candidates.length} candidatos a líder disponibles (de ${need} necesarios).`);
 
     // Pool general de miembros (igual que OESTE1: de cualquier parte de la iglesia).
     const { rows: memberPool } = await client.query(
@@ -236,7 +250,7 @@ async function main() {
         );
       }
     }
-    console.log(`${zoneName}: ${candidates.length} grupos creados con líder + 9 miembros c/u.`);
+    console.log(`${zoneName}: ${candidates.length} grupos nuevos creados con líder + 9 miembros c/u.`);
   }
 
   await client.end();

--- a/scripts/hydrate-zones.mjs
+++ b/scripts/hydrate-zones.mjs
@@ -1,0 +1,240 @@
+/**
+ * hydrate-zones.mjs
+ * Lleva OESTE 2, OESTE 3 y ESTE a la misma completitud que OESTE 1:
+ * polígono real (OESTE 2/ESTE, generados — OESTE 3 ya lo tiene), 29 líderes
+ * de nivel 1 con su grupo, ~9 miembros por grupo, y coordenadas dentro del
+ * polígono de la zona (point-in-polygon real, no bounding box).
+ *
+ * Replica el patrón EXACTO ya presente en OESTE 1 (verificado por consulta
+ * directa antes de escribir esto):
+ *  - discipleship_hierarchy nivel 1: user_id = líder, supervisor_id = el
+ *    supervisor auxiliar (nivel 2) YA existente de esa zona, territory=NULL.
+ *  - discipleship_groups: group_name = "Grupo de <NOMBRE>", supervisor_id
+ *    NULL (así está en OESTE1, no es un bug mío), meeting_location NULL,
+ *    member_count=active_members=9, status='active'.
+ *  - discipleship_group_members: role_in_group='member', miembros tomados
+ *    del pool general de la iglesia (no solo de la zona), pueden repetirse
+ *    entre grupos — igual que OESTE1.
+ *  - Los 29 líderes SÍ pertenecen a la zona (users.zone_id) y tienen role='server'.
+ *
+ * Apunta a local por default. Idempotente: si una zona ya tiene boundaries,
+ * no lo pisa; si ya tiene líderes (hierarchy nivel 1), no duplica — seguro
+ * de re-correr o correr contra una DB que ya tiene parte del trabajo.
+ *
+ * Uso:
+ *   node scripts/hydrate-zones.mjs                              (local)
+ *   SUPABASE_DB_URL='postgres://...' node scripts/hydrate-zones.mjs  (otra DB)
+ */
+
+import pg from 'pg';
+import { randomUUID } from 'crypto';
+
+const { Client } = pg;
+const DB_URL = process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+const rand = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+// Muestra `n` elementos ÚNICOS de `arr` (Fisher-Yates parcial).
+function shuffledSample(arr, n) {
+  const copy = [...arr];
+  const result = [];
+  for (let i = 0; i < n && copy.length > 0; i++) {
+    const idx = rand(0, copy.length - 1);
+    result.push(copy[idx]);
+    copy.splice(idx, 1);
+  }
+  return result;
+}
+
+// ─── Polígonos generados (demo, geografía plausible) ──────────────────────
+// Verificados por bounding box contra OESTE1 y OESTE3 reales, con >500m de
+// margen en cada caso — no se solapan. Editables después desde el mapa.
+const GENERATED_POLYGONS = {
+  'OESTE 2': [
+    [-69.7, 11.383],
+    [-69.696, 11.358],
+    [-69.668, 11.352],
+    [-69.653, 11.366],
+    [-69.661, 11.383],
+    [-69.7, 11.383],
+  ],
+  ESTE: [
+    [-69.638, 11.428],
+    [-69.601, 11.422],
+    [-69.596, 11.394],
+    [-69.624, 11.384],
+    [-69.639, 11.399],
+    [-69.638, 11.428],
+  ],
+};
+
+// ─── Point-in-polygon (ray casting) + muestreo por rechazo ────────────────
+
+function pointInPolygon([lng, lat], ring) {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    const intersects =
+      yi > lat !== yj > lat && lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+function randomPointInPolygon(ring) {
+  const lngs = ring.map(p => p[0]);
+  const lats = ring.map(p => p[1]);
+  const minLng = Math.min(...lngs),
+    maxLng = Math.max(...lngs);
+  const minLat = Math.min(...lats),
+    maxLat = Math.max(...lats);
+  for (let attempt = 0; attempt < 500; attempt++) {
+    const candidate = [
+      minLng + Math.random() * (maxLng - minLng),
+      minLat + Math.random() * (maxLat - minLat),
+    ];
+    if (pointInPolygon(candidate, ring)) return candidate;
+  }
+  // Fallback (no debería pasar con estos polígonos): centroide del bbox.
+  return [(minLng + maxLng) / 2, (minLat + maxLat) / 2];
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────
+
+async function main() {
+  const client = new Client({ connectionString: DB_URL });
+  await client.connect();
+
+  // ── 1) OESTE 3: ya tiene 29 grupos/líderes/miembros, solo faltan coords ──
+  const { rows: oeste3Groups } = await client.query(
+    `SELECT g.id, z.boundaries
+     FROM discipleship_groups g JOIN zones z ON g.zone_id = z.id
+     WHERE z.name = 'OESTE 3' AND (g.latitude IS NULL OR g.latitude = 0)`
+  );
+  console.log(`OESTE 3: ${oeste3Groups.length} grupos sin coordenadas`);
+  for (const g of oeste3Groups) {
+    const ring = g.boundaries.coordinates[0];
+    const [lng, lat] = randomPointInPolygon(ring);
+    await client.query(
+      `UPDATE discipleship_groups SET latitude = $1, longitude = $2 WHERE id = $3`,
+      [lat, lng, g.id]
+    );
+  }
+  console.log(`OESTE 3: coordenadas asignadas.`);
+
+  // ── 2) OESTE 2 y ESTE: build completo ──────────────────────────────────
+  for (const [zoneName, ring] of Object.entries(GENERATED_POLYGONS)) {
+    const { rows: zoneRows } = await client.query(
+      `SELECT id, church_id, boundaries FROM zones WHERE name = $1`,
+      [zoneName]
+    );
+    if (zoneRows.length === 0) {
+      console.log(`${zoneName}: no existe la zona, salteando.`);
+      continue;
+    }
+    const zone = zoneRows[0];
+
+    if (!zone.boundaries) {
+      await client.query(`UPDATE zones SET boundaries = $1 WHERE id = $2`, [
+        JSON.stringify({ type: 'Polygon', coordinates: [ring] }),
+        zone.id,
+      ]);
+      console.log(`${zoneName}: polígono asignado.`);
+    } else {
+      console.log(`${zoneName}: ya tenía polígono, no se pisa.`);
+    }
+
+    // ¿Cuántos líderes nivel 1 faltan? (idempotente: continúa donde quedó,
+    // no saltea la zona entera si ya tiene algunos).
+    const TARGET_LEADERS = 29;
+    const { rows: existingLeaders } = await client.query(
+      `SELECT COUNT(*) FROM discipleship_hierarchy WHERE zone_name = $1 AND hierarchy_level = 1`,
+      [zoneName]
+    );
+    const need = TARGET_LEADERS - Number(existingLeaders[0].count);
+    if (need <= 0) {
+      console.log(`${zoneName}: ya tiene ${existingLeaders[0].count} líderes nivel 1, nada que hacer.`);
+      continue;
+    }
+    console.log(`${zoneName}: ${existingLeaders[0].count} líderes existentes, faltan ${need}.`);
+
+    // Supervisor auxiliar (nivel 2) ya existente de esta zona.
+    const { rows: auxRows } = await client.query(
+      `SELECT user_id FROM discipleship_hierarchy WHERE zone_name = $1 AND hierarchy_level = 2 LIMIT 1`,
+      [zoneName]
+    );
+    if (auxRows.length === 0) {
+      console.log(`${zoneName}: no tiene supervisor auxiliar (nivel 2), no puedo asignar líderes. Salteando.`);
+      continue;
+    }
+    const auxSupervisorId = auxRows[0].user_id;
+
+    // Candidatos: pertenecen a la zona, role='server', sin fila previa en hierarchy
+    // (esto además excluye automáticamente a los líderes ya creados en un run anterior).
+    const { rows: candidates } = await client.query(
+      `SELECT id, first_name, last_name FROM users u
+       WHERE u.zone_id = $1 AND u.role = 'server'
+       AND u.id NOT IN (SELECT user_id FROM discipleship_hierarchy)
+       ORDER BY random() LIMIT $2`,
+      [zone.id, need]
+    );
+    console.log(`${zoneName}: ${candidates.length} candidatos a líder disponibles.`);
+
+    // Pool general de miembros (igual que OESTE1: de cualquier parte de la iglesia).
+    const { rows: memberPool } = await client.query(
+      `SELECT id FROM users WHERE role IN ('member', 'server')`
+    );
+
+    for (const leader of candidates) {
+      const hierarchyId = randomUUID();
+      await client.query(
+        `INSERT INTO discipleship_hierarchy
+           (id, user_id, hierarchy_level, supervisor_id, zone_name, territory,
+            active_groups_assigned, zone_id, church_id)
+         VALUES ($1, $2, 1, $3, $4, NULL, 0, $5, $6)`,
+        [hierarchyId, leader.id, auxSupervisorId, zoneName, zone.id, zone.church_id]
+      );
+
+      const [lng, lat] = randomPointInPolygon(ring);
+      const groupId = randomUUID();
+      await client.query(
+        `INSERT INTO discipleship_groups
+           (id, group_name, leader_id, supervisor_id, meeting_location, meeting_day,
+            meeting_time, member_count, active_members, status, zone_name,
+            zone_id, latitude, longitude, meeting_address, church_id)
+         VALUES ($1, $2, $3, NULL, NULL, NULL, NULL, 9, 9, 'active', $4, $5, $6, $7, NULL, $8)`,
+        [
+          groupId,
+          `Grupo de ${leader.first_name} ${leader.last_name}`,
+          leader.id,
+          zoneName,
+          zone.id,
+          lat,
+          lng,
+          zone.church_id,
+        ]
+      );
+
+      // 9 miembros ÚNICOS para este grupo (hay UNIQUE(group_id,user_id)) —
+      // pueden repetirse entre grupos distintos, no dentro del mismo.
+      const groupMembers = shuffledSample(memberPool, 9);
+      for (const member of groupMembers) {
+        await client.query(
+          `INSERT INTO discipleship_group_members
+             (id, group_id, user_id, role_in_group, is_active, church_id)
+           VALUES ($1, $2, $3, 'member', true, $4)`,
+          [randomUUID(), groupId, member.id, zone.church_id]
+        );
+      }
+    }
+    console.log(`${zoneName}: ${candidates.length} grupos creados con líder + 9 miembros c/u.`);
+  }
+
+  await client.end();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/hydrate-zones.mjs
+++ b/scripts/hydrate-zones.mjs
@@ -102,8 +102,16 @@ function randomPointInPolygon(ring) {
 
 // ─── Main ───────────────────────────────────────────────────────────────
 
+// Solo cuando apunta a otra DB (SUPABASE_DB_URL seteado): el pooler de
+// Supabase presenta un certificado que Node rechaza con sslmode=require
+// (`pg` lo trata como verify-full, no como "solo requerir TLS"). El tráfico
+// sigue cifrado; se relaja únicamente la verificación de la cadena, igual
+// que recomienda la propia documentación de Supabase para conexiones por
+// pooler. Local (sin la env var) sigue sin SSL, sin cambios.
+const sslConfig = process.env.SUPABASE_DB_URL ? { rejectUnauthorized: false } : false;
+
 async function main() {
-  const client = new Client({ connectionString: DB_URL });
+  const client = new Client({ connectionString: DB_URL, ssl: sslConfig });
   await client.connect();
 
   // ── 1) OESTE 3: ya tiene 29 grupos/líderes/miembros, solo faltan coords ──

--- a/scripts/seed-reports-attendance.mjs
+++ b/scripts/seed-reports-attendance.mjs
@@ -4,17 +4,19 @@
  * para todos los grupos activos, así las gráficas de Crecimiento, Salud del
  * Sistema e Indicadores clave del dashboard pastoral tienen data real.
  *
- * SOLO LOCAL — apunta al Postgres de `supabase start` (127.0.0.1:54322).
- * Idempotente: usa NOT EXISTS / ON CONFLICT DO NOTHING, se puede re-correr.
+ * Apunta a local por default. Idempotente: usa NOT EXISTS / ON CONFLICT DO
+ * NOTHING, se puede re-correr sin duplicar.
  *
- * Uso: node scripts/seed-reports-attendance.mjs
+ * Uso:
+ *   node scripts/seed-reports-attendance.mjs                              (local)
+ *   SUPABASE_DB_URL='postgres://...' node scripts/seed-reports-attendance.mjs  (otra DB)
  */
 
 import pg from 'pg';
 import { randomUUID } from 'crypto';
 
 const { Client } = pg;
-const DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+const DB_URL = process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
 
 const REPORT_WEEKS = 16;
 const ATTENDANCE_WEEKS = 10;

--- a/scripts/seed-reports-attendance.mjs
+++ b/scripts/seed-reports-attendance.mjs
@@ -13,10 +13,17 @@
  */
 
 import pg from 'pg';
+import { parse as parseConnectionString } from 'pg-connection-string';
 import { randomUUID } from 'crypto';
 
 const { Client } = pg;
 const DB_URL = process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+// Ver comentario equivalente en hydrate-zones.mjs: si DB_URL trae sslmode=
+// en la query string, `pg` lo prioriza sobre un `ssl:` pasado junto con
+// `connectionString` — hay que parsear y pisar `ssl` DESPUÉS del parse.
+const connectionConfig = parseConnectionString(DB_URL);
+connectionConfig.ssl = process.env.SUPABASE_DB_URL ? { rejectUnauthorized: false } : false;
 
 const REPORT_WEEKS = 16;
 const ATTENDANCE_WEEKS = 10;
@@ -58,16 +65,8 @@ function buildReportData(groupId) {
   };
 }
 
-// Solo cuando apunta a otra DB (SUPABASE_DB_URL seteado): el pooler de
-// Supabase presenta un certificado que Node rechaza con sslmode=require
-// (`pg` lo trata como verify-full, no como "solo requerir TLS"). El tráfico
-// sigue cifrado; se relaja únicamente la verificación de la cadena, igual
-// que recomienda la propia documentación de Supabase para conexiones por
-// pooler. Local (sin la env var) sigue sin SSL, sin cambios.
-const sslConfig = process.env.SUPABASE_DB_URL ? { rejectUnauthorized: false } : false;
-
 async function main() {
-  const client = new Client({ connectionString: DB_URL, ssl: sslConfig });
+  const client = new Client(connectionConfig);
   await client.connect();
 
   const { rows: groups } = await client.query(`

--- a/scripts/seed-reports-attendance.mjs
+++ b/scripts/seed-reports-attendance.mjs
@@ -58,8 +58,16 @@ function buildReportData(groupId) {
   };
 }
 
+// Solo cuando apunta a otra DB (SUPABASE_DB_URL seteado): el pooler de
+// Supabase presenta un certificado que Node rechaza con sslmode=require
+// (`pg` lo trata como verify-full, no como "solo requerir TLS"). El tráfico
+// sigue cifrado; se relaja únicamente la verificación de la cadena, igual
+// que recomienda la propia documentación de Supabase para conexiones por
+// pooler. Local (sin la env var) sigue sin SSL, sin cambios.
+const sslConfig = process.env.SUPABASE_DB_URL ? { rejectUnauthorized: false } : false;
+
 async function main() {
-  const client = new Client({ connectionString: DB_URL });
+  const client = new Client({ connectionString: DB_URL, ssl: sslConfig });
   await client.connect();
 
   const { rows: groups } = await client.query(`

--- a/scripts/sync-zone-geography.mjs
+++ b/scripts/sync-zone-geography.mjs
@@ -1,0 +1,174 @@
+/**
+ * sync-zone-geography.mjs
+ * Sincroniza los 4 polígonos de zona al valor "canónico" (el que ya está
+ * verificado y funcionando en local — geografía real de Coro para OESTE 1/3,
+ * demo plausible para OESTE 2/ESTE), y revalida/regenera coordenadas:
+ *
+ *  - discipleship_groups: si el punto actual de un grupo cae FUERA de su
+ *    zona (polígono nuevo), se le genera uno nuevo dentro. Si ya está
+ *    adentro, no se toca.
+ *  - users: mismo criterio, para cada usuario con zone_id asignado. Cubre
+ *    tanto "nunca tuvo coordenadas" (local: 0/587) como "las tenía pero
+ *    quedaron afuera al cambiar el polígono de su zona" (prod: 575 usuarios
+ *    con coords calculadas para las franjas rectangulares viejas).
+ *
+ * Point-in-polygon real (ray casting), no bounding box — mismo método ya
+ * verificado en hydrate-zones.mjs.
+ *
+ * Uso:
+ *   node scripts/sync-zone-geography.mjs                              (local)
+ *   SUPABASE_DB_URL='postgres://...' node scripts/sync-zone-geography.mjs  (otra DB)
+ */
+
+import pg from 'pg';
+import { parse as parseConnectionString } from 'pg-connection-string';
+
+const { Client } = pg;
+const DB_URL = process.env.SUPABASE_DB_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+const connectionConfig = parseConnectionString(DB_URL);
+connectionConfig.ssl = process.env.SUPABASE_DB_URL ? { rejectUnauthorized: false } : false;
+
+// Polígonos canónicos — exactamente los que ya están en local, verificados
+// en pantalla (radar, marcadores, leyenda) y por point-in-polygon.
+const CANONICAL_POLYGONS = {
+  'OESTE 1': [
+    [-69.678458311, 11.421090375],
+    [-69.666823894, 11.388460751],
+    [-69.64486884, 11.42422342],
+    [-69.648620412, 11.426071813],
+    [-69.667243324, 11.424777331],
+    [-69.678458311, 11.421090375],
+  ],
+  'OESTE 3': [
+    [-69.702115059, 11.402114234],
+    [-69.700505733, 11.390776584],
+    [-69.686193466, 11.395782875],
+    [-69.692094326, 11.403733861],
+    [-69.702115059, 11.402114234],
+  ],
+  'OESTE 2': [
+    [-69.7, 11.383],
+    [-69.696, 11.358],
+    [-69.668, 11.352],
+    [-69.653, 11.366],
+    [-69.661, 11.383],
+    [-69.7, 11.383],
+  ],
+  ESTE: [
+    [-69.638, 11.428],
+    [-69.601, 11.422],
+    [-69.596, 11.394],
+    [-69.624, 11.384],
+    [-69.639, 11.399],
+    [-69.638, 11.428],
+  ],
+};
+
+function pointInPolygon([lng, lat], ring) {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    const intersects =
+      yi > lat !== yj > lat && lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+function randomPointInPolygon(ring) {
+  const lngs = ring.map(p => p[0]);
+  const lats = ring.map(p => p[1]);
+  const minLng = Math.min(...lngs),
+    maxLng = Math.max(...lngs);
+  const minLat = Math.min(...lats),
+    maxLat = Math.max(...lats);
+  for (let attempt = 0; attempt < 500; attempt++) {
+    const candidate = [
+      minLng + Math.random() * (maxLng - minLng),
+      minLat + Math.random() * (maxLat - minLat),
+    ];
+    if (pointInPolygon(candidate, ring)) return candidate;
+  }
+  return [(minLng + maxLng) / 2, (minLat + maxLat) / 2];
+}
+
+async function main() {
+  const client = new Client(connectionConfig);
+  await client.connect();
+
+  const { rows: zones } = await client.query(`SELECT id, name, boundaries FROM zones ORDER BY name`);
+
+  for (const zone of zones) {
+    const canonical = CANONICAL_POLYGONS[zone.name];
+    if (!canonical) {
+      console.log(`${zone.name}: sin polígono canónico definido, salteando.`);
+      continue;
+    }
+    const currentJson = zone.boundaries ? JSON.stringify(zone.boundaries.coordinates[0]) : null;
+    const canonicalJson = JSON.stringify(canonical);
+    if (currentJson !== canonicalJson) {
+      await client.query(`UPDATE zones SET boundaries = $1 WHERE id = $2`, [
+        JSON.stringify({ type: 'Polygon', coordinates: [canonical] }),
+        zone.id,
+      ]);
+      console.log(`${zone.name}: polígono sincronizado al valor canónico.`);
+    } else {
+      console.log(`${zone.name}: ya tenía el polígono canónico.`);
+    }
+  }
+
+  // ── Grupos: revalidar contra el polígono (nuevo o existente) de su zona ──
+  let groupsFixed = 0;
+  for (const zone of zones) {
+    const ring = CANONICAL_POLYGONS[zone.name];
+    if (!ring) continue;
+    const { rows: groups } = await client.query(
+      `SELECT id, latitude, longitude FROM discipleship_groups WHERE zone_id = $1`,
+      [zone.id]
+    );
+    for (const g of groups) {
+      const hasCoords = g.latitude != null && g.longitude != null && Number(g.latitude) !== 0;
+      const inside = hasCoords && pointInPolygon([Number(g.longitude), Number(g.latitude)], ring);
+      if (!inside) {
+        const [lng, lat] = randomPointInPolygon(ring);
+        await client.query(`UPDATE discipleship_groups SET latitude = $1, longitude = $2 WHERE id = $3`, [
+          lat,
+          lng,
+          g.id,
+        ]);
+        groupsFixed++;
+      }
+    }
+  }
+  console.log(`Grupos: ${groupsFixed} recibieron coordenadas nuevas (fuera de su zona o sin coords).`);
+
+  // ── Personas: mismo criterio, para cada usuario con zona asignada ──
+  let usersFixed = 0;
+  for (const zone of zones) {
+    const ring = CANONICAL_POLYGONS[zone.name];
+    if (!ring) continue;
+    const { rows: usersInZone } = await client.query(
+      `SELECT id, latitude, longitude FROM users WHERE zone_id = $1`,
+      [zone.id]
+    );
+    for (const u of usersInZone) {
+      const hasCoords = u.latitude != null && u.longitude != null && Number(u.latitude) !== 0;
+      const inside = hasCoords && pointInPolygon([Number(u.longitude), Number(u.latitude)], ring);
+      if (!inside) {
+        const [lng, lat] = randomPointInPolygon(ring);
+        await client.query(`UPDATE users SET latitude = $1, longitude = $2 WHERE id = $3`, [lat, lng, u.id]);
+        usersFixed++;
+      }
+    }
+  }
+  console.log(`Personas: ${usersFixed} recibieron coordenadas nuevas (fuera de su zona, sin coords, o sin zona antes).`);
+
+  await client.end();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
El runner de GitHub ya trae un pg_dump viejo en /usr/bin sin symlink automático al instalar postgresql-client-17 vía apt — el backup abortaba con 'server version mismatch' contra Supabase (v17). Se antepone la ruta correcta a GITHUB_PATH. También trae la sincronización de geografía de zonas (polígonos + coords de personas) hecha antes en esta sesión.